### PR TITLE
Added a link to LDtk in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Bevy tracking](https://img.shields.io/badge/Bevy%20tracking-released%20version-lightblue)](https://github.com/bevyengine/bevy/blob/main/docs/plugins_guidelines.md#main-branch-tracking)
 [![CI](https://github.com/Trouv/bevy_ecs_ldtk/actions/workflows/ci.yml/badge.svg)](https://github.com/Trouv/bevy_ecs_ldtk/actions/workflows/ci.yml)
 
-An ECS-friendly ldtk plugin for [bevy](https://github.com/bevyengine/bevy).
+An ECS-friendly [LDtk](https://ldtk.io/) plugin for [bevy](https://github.com/bevyengine/bevy).
 Uses [bevy_ecs_tilemap](https://github.com/StarArawn/bevy_ecs_tilemap) as a
 base.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
-//! An ECS-friendly ldtk plugin for [bevy](https://github.com/bevyengine/bevy). Uses
+//! An ECS-friendly [LDtk](https://ldtk.io/) plugin for 
+//! [bevy](https://github.com/bevyengine/bevy). Uses
 //! [bevy_ecs_tilemap](https://github.com/StarArawn/bevy_ecs_tilemap) as a base.
 //!
 //! ### Getting Started

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! An ECS-friendly [LDtk](https://ldtk.io/) plugin for 
+//! An ECS-friendly [LDtk](https://ldtk.io/) plugin for
 //! [bevy](https://github.com/bevyengine/bevy). Uses
 //! [bevy_ecs_tilemap](https://github.com/StarArawn/bevy_ecs_tilemap) as a base.
 //!


### PR DESCRIPTION
Adding a link to the README for the LDtk website for people who stumble upon bevy_ecs_ldtk without knowing what LDtk is.