### PR TITLE
Implement Ground detection in platformer example

### DIFF
--- a/examples/platformer/components.rs
+++ b/examples/platformer/components.rs
@@ -244,4 +244,7 @@ pub struct GroundDetection {
 }
 
 #[derive(Component)]
-pub struct GroundSensor(pub Entity);
+pub struct GroundSensor {
+    pub ground_detection_entity: Entity,
+    pub intersecting_ground_entities: HashSet<Entity>,
+}

--- a/examples/platformer/components.rs
+++ b/examples/platformer/components.rs
@@ -124,6 +124,7 @@ pub struct PlayerBundle {
     #[worldly]
     pub worldly: Worldly,
     pub climber: Climber,
+    pub ground_detection: GroundDetection,
 
     // Build Items Component manually by using `impl From<EntityInstance>
     #[from_entity_instance]
@@ -237,6 +238,10 @@ pub struct ChestBundle {
     pub collider_bundle: ColliderBundle,
 }
 
+#[derive(Clone, Default, Component)]
 pub struct GroundDetection {
     pub on_ground: bool,
 }
+
+#[derive(Component)]
+pub struct GroundSensor(pub Entity);

--- a/examples/platformer/components.rs
+++ b/examples/platformer/components.rs
@@ -236,3 +236,7 @@ pub struct ChestBundle {
     #[bundle]
     pub collider_bundle: ColliderBundle,
 }
+
+pub struct GroundDetection {
+    pub on_ground: bool,
+}

--- a/examples/platformer/main.rs
+++ b/examples/platformer/main.rs
@@ -4,6 +4,7 @@
 use bevy::prelude::*;
 use bevy_ecs_ldtk::prelude::*;
 
+use components::GroundDetection;
 use heron::prelude::*;
 
 mod components;
@@ -23,6 +24,7 @@ fn main() {
             set_clear_color: SetClearColor::FromLevelBackground,
             ..Default::default()
         })
+        .insert_resource(GroundDetection { on_ground: false })
         .add_startup_system(systems::setup)
         .add_system(systems::pause_physics_during_load)
         .add_system(systems::spawn_wall_collision)
@@ -33,6 +35,7 @@ fn main() {
         .add_system(systems::camera_fit_inside_current_level)
         .add_system(systems::update_level_selection)
         .add_system(systems::dbg_player_items)
+        .add_system(systems::ground_detection)
         .register_ldtk_int_cell::<components::WallBundle>(1)
         .register_ldtk_int_cell::<components::LadderBundle>(2)
         .register_ldtk_int_cell::<components::WallBundle>(3)

--- a/examples/platformer/main.rs
+++ b/examples/platformer/main.rs
@@ -4,7 +4,6 @@
 use bevy::prelude::*;
 use bevy_ecs_ldtk::prelude::*;
 
-use components::GroundDetection;
 use heron::prelude::*;
 
 mod components;
@@ -24,7 +23,6 @@ fn main() {
             set_clear_color: SetClearColor::FromLevelBackground,
             ..Default::default()
         })
-        .insert_resource(GroundDetection { on_ground: false })
         .add_startup_system(systems::setup)
         .add_system(systems::pause_physics_during_load)
         .add_system(systems::spawn_wall_collision)
@@ -35,6 +33,7 @@ fn main() {
         .add_system(systems::camera_fit_inside_current_level)
         .add_system(systems::update_level_selection)
         .add_system(systems::dbg_player_items)
+        .add_system(systems::spawn_ground_sensor)
         .add_system(systems::ground_detection)
         .register_ldtk_int_cell::<components::WallBundle>(1)
         .register_ldtk_int_cell::<components::LadderBundle>(2)

--- a/examples/platformer/systems.rs
+++ b/examples/platformer/systems.rs
@@ -436,14 +436,6 @@ pub fn spawn_ground_sensor(
         commands.entity(entity).with_children(|builder| {
             builder
                 .spawn()
-                .insert_bundle(SpriteBundle {
-                    sprite: Sprite {
-                        color: Color::BLACK,
-                        custom_size: Some(Vec2::new(10.0, 10.0)),
-                        ..Default::default()
-                    },
-                    ..Default::default()
-                })
                 .insert(RigidBody::Sensor)
                 .insert(shape.clone())
                 .insert(Transform::from_xyz(0.0, -10.0, 5.0))

--- a/examples/platformer/systems.rs
+++ b/examples/platformer/systems.rs
@@ -4,10 +4,7 @@ use bevy_ecs_ldtk::prelude::*;
 
 use std::collections::{HashMap, HashSet};
 
-use heron::{
-    prelude::*,
-    rapier_plugin::{PhysicsWorld, ShapeCastCollisionType},
-};
+use heron::prelude::*;
 
 pub fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let camera = OrthographicCameraBundle::new_2d();
@@ -433,36 +430,25 @@ pub fn update_level_selection(
 }
 
 pub fn ground_detection(
-    player_query: Query<&Transform, With<Player>>,
-    physics_world: PhysicsWorld,
-    climbables: Query<&Climbable>,
+    player_query: Query<Entity, With<Player>>,
+    mut events: EventReader<CollisionEvent>,
     mut ground_detection: ResMut<GroundDetection>,
 ) {
-    if let Ok(transform) = player_query.get_single() {
-        let shape_size = Vec2::new(10., 1.);
-
-        let shape = CollisionShape::Cuboid {
-            half_extends: shape_size.extend(0.) / 2.,
-            border_radius: None,
-        };
-
-        let mut floor = transform.clone();
-        floor.translation.y = floor.translation.y - 20.0;
-
-        let result = physics_world.shape_cast_with_filter(
-            &shape,
-            floor.translation,
-            Quat::IDENTITY,
-            transform.translation,
-            CollisionLayers::default(),
-            |entity| climbables.get(entity).is_err(),
-        );
-
-        if let Some(collision) = result {
-            if let ShapeCastCollisionType::Collided(_) = collision.collision_type {
-                ground_detection.on_ground = false;
-            } else {
-                ground_detection.on_ground = true;
+    if let Ok(entity) = player_query.get_single() {
+        for event in events.iter() {
+            match event {
+                CollisionEvent::Started(d1, d2) => {
+                    if d1.rigid_body_entity() == entity
+                        && d2.normals().get(0) == Some(&Vec3::new(0.0, -1.0, 0.0))
+                    {
+                        ground_detection.on_ground = true;
+                    }
+                }
+                CollisionEvent::Stopped(d1, _) => {
+                    if d1.rigid_body_entity() == entity {
+                        ground_detection.on_ground = false;
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Restrict jumping to only happening when ground detection through shape casting with a filter says the player is on the ground.

This works for normal platforms. It ignores climbables by filtering them out of the shape cast.

You can still multi-jump up walls with this solution and I'm not sure how to fix that. The multi-jump up walls is caused by the wider shape cast than the character, which results in a nice coyote jump when leaving ledges. Shortening the shape does remove the "multi-wall-jump" effect (and also the coyote effect), so I assume it's because the shape cast is actually *in* the wall.

related to #44 