### PR TITLE
Support multiline string type, make LdtkAsset clonable, print the field name in unknown field error

### DIFF
--- a/src/assets.rs
+++ b/src/assets.rs
@@ -26,7 +26,7 @@ pub type LevelMap = HashMap<String, Handle<LdtkLevel>>;
 ///
 /// Load your ldtk project with the asset server, then insert the handle into the
 /// [LdtkWorldBundle].
-#[derive(TypeUuid)]
+#[derive(Clone, TypeUuid)]
 #[uuid = "ecfb87b7-9cd9-4970-8482-f2f68b770d31"]
 pub struct LdtkAsset {
     pub project: ldtk::LdtkJson,

--- a/src/ldtk/field_instance.rs
+++ b/src/ldtk/field_instance.rs
@@ -109,7 +109,10 @@ impl<'de> Deserialize<'de> for FieldInstance {
                     .map_err(de::Error::custom)?;
 
                 FieldValue::Point(point_helper.map(|p| IVec2::new(p.cx, p.cy)))
-            }
+            },
+            "Multilines" => FieldValue::String(
+                Option::<String>::deserialize(helper.value).map_err(de::Error::custom)?,
+            ),
             "Array<Int>" => FieldValue::Ints(
                 Vec::<Option<i32>>::deserialize(helper.value).map_err(de::Error::custom)?,
             ),

--- a/src/ldtk/field_instance.rs
+++ b/src/ldtk/field_instance.rs
@@ -167,7 +167,7 @@ impl<'de> Deserialize<'de> for FieldInstance {
                             .map_err(de::Error::custom)?,
                     )
                 } else {
-                    return Err(de::Error::custom("Encountered unknown field type"));
+                    return Err(de::Error::custom(format!("Encountered unknown field type: {}", t)));
                 }
             }
         };


### PR DESCRIPTION
## Make LdtkAsset clonable

This improves the ergonomics when used with bevy_asset_loader

## Improve error messages for unknown fields

Add the name of unsupported field into the error message

## Multilines

Support Multilines -type, it's identical to the string, but it can contain Markdown formatting in the LDtk editor:

```
{ "__identifier": "label", "__value": "Strange crate", "__type": "String", "__tile": null, "defUid": 65, "realEditorValues": [{
    "id": "V_String",
    "params": ["Strange crate"]
}] },
{ "__identifier": "description", "__value": "The crate has some military logo on it.", "__type": "Multilines", "__tile": null, "defUid": 64, "realEditorValues": [{
    "id": "V_String",
    "params": ["The crate has some military logo on it."]
}] },
```