### PR TITLE
A little bit of help on the refactor/tilemap-rewrite branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13739d7177fbd22bb0ed28badfff9f372f8bef46c863db4e1c6248f6b223b6e"
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "adler32"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,7 +59,7 @@ dependencies = [
  "alsa-sys",
  "bitflags",
  "libc",
- "nix",
+ "nix 0.23.1",
 ]
 
 [[package]]
@@ -82,6 +88,15 @@ dependencies = [
  "env_logger",
  "lazy_static",
  "log",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7ed72e1635e121ca3e79420540282af22da58be50de153d36f81ddc6b83aa9e"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -116,9 +131,9 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "ash"
-version = "0.34.0+1.2.203"
+version = "0.37.0+1.3.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0f780da53d0063880d45554306489f09dd8d1bda47688b4a57bc579119356df"
+checksum = "006ca68e0f2b03f22d6fa9f2860f85aed430d257fec20f8879b2145e7c7ae1a6"
 dependencies = [
  "libloading",
 ]
@@ -161,12 +176,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "base-x"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc19a4937b4fbd3fe3379793130e42060d10627a360f2127802b10b87e7baf74"
-
-[[package]]
 name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,30 +183,18 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bevy"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fce306d40a111309ee61d4626efbafccdd46bb80657122c38061fa7264c08e4"
+checksum = "55f08528a4e59d607460513a823b40f602d013c1a00f57b824f1075d5d48c3cd"
 dependencies = [
  "bevy_internal",
 ]
 
 [[package]]
-name = "bevy-crevice-derive"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "191a752a01c3402deb24320acf42288bf822e5d22f19ae1d903797f02e9b0c33"
-dependencies = [
- "bevy_macro_utils",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "bevy_animation"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c087569c34b168dd988e8b3409ce273661b4a58c3c534d0e381950589f59f68e"
+checksum = "e243169af495ad616ff701247c0d3e40078a26ed8de231cf9e54bde6b3c4bb45"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -206,19 +203,21 @@ dependencies = [
  "bevy_hierarchy",
  "bevy_math",
  "bevy_reflect",
+ "bevy_time",
  "bevy_transform",
  "bevy_utils",
 ]
 
 [[package]]
 name = "bevy_app"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32660ae99fa3498ca379de28b7e2f447e6531b0e432bf200901efeec075553c1"
+checksum = "53d26d6ffdf493609d2fedc1018a2ef0cb4d8e48f6d3bcea56fa2df81867e464"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
  "bevy_reflect",
+ "bevy_tasks",
  "bevy_utils",
  "wasm-bindgen",
  "web-sys",
@@ -226,9 +225,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_asset"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2afd395240087924ba49c8cae2b00d007aeb1db53ee726a543b1e90dce2d3ab"
+checksum = "3d8fb95306d5f18fa70df40632cd984993aeb71e91ce059ae99699098a4f9ce9"
 dependencies = [
  "anyhow",
  "bevy_app",
@@ -240,11 +239,11 @@ dependencies = [
  "bevy_utils",
  "crossbeam-channel",
  "downcast-rs",
+ "fastrand",
  "js-sys",
  "ndk-glue 0.5.2",
  "notify",
- "parking_lot",
- "rand",
+ "parking_lot 0.12.1",
  "serde",
  "thiserror",
  "wasm-bindgen",
@@ -254,9 +253,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_audio"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73a1c827ae837b62868539040176fb6d4daecf24983b98a0284d158e52cd21d5"
+checksum = "eee08ac575397ce17477dd291862bafa15226334bdfb82c02bbc3d10bad7bdb8"
 dependencies = [
  "anyhow",
  "bevy_app",
@@ -264,18 +263,17 @@ dependencies = [
  "bevy_ecs",
  "bevy_reflect",
  "bevy_utils",
- "parking_lot",
+ "parking_lot 0.12.1",
  "rodio",
 ]
 
 [[package]]
 name = "bevy_core"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12c0f8614b6014671ab60bacb8bf681373d08b0bb15633b8ef72b895cf966d29"
+checksum = "c6712146d54fff9e1865362e9f39a7b63c7b037ddb72a3d7bb05b959213fb61e"
 dependencies = [
  "bevy_app",
- "bevy_derive",
  "bevy_ecs",
  "bevy_math",
  "bevy_reflect",
@@ -286,35 +284,27 @@ dependencies = [
 
 [[package]]
 name = "bevy_core_pipeline"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d570bc9310196190910a5b1ffd8c8c35bd6b73f918d0651ae3c3d4e57be9a7"
+checksum = "080bb00399b6d7697e505f871d67c6de8b52eb06b47b0cda2be80c2396805983"
 dependencies = [
  "bevy_app",
  "bevy_asset",
- "bevy_core",
+ "bevy_derive",
  "bevy_ecs",
+ "bevy_reflect",
  "bevy_render",
+ "bevy_transform",
  "bevy_utils",
-]
-
-[[package]]
-name = "bevy_crevice"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da0a284fb26c02cb96ef4d5bbf4de5fad7e1a901730035a61813bf64e28482e"
-dependencies = [
- "bevy-crevice-derive",
- "bytemuck",
- "glam",
- "mint",
+ "radsort",
+ "serde",
 ]
 
 [[package]]
 name = "bevy_derive"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6abddf2ed415f31d28a9bf9ab3c0bc857e98a722858d38dba65bdda481f8d714"
+checksum = "a4b8f0786d1fc7e0d35297917be463db3d0886f7bd8d4221ca3d565502579ffb"
 dependencies = [
  "bevy_macro_utils",
  "quote",
@@ -323,25 +313,26 @@ dependencies = [
 
 [[package]]
 name = "bevy_diagnostic"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ebf72ea058cfc379756e9da7de6861174e1860504f41e3e5a46d5b1c35d6644"
+checksum = "adab74ee5375fbf5d2b1d3da41de8d1491a8a706d17441b5e31214b65349d692"
 dependencies = [
  "bevy_app",
- "bevy_core",
  "bevy_ecs",
  "bevy_log",
+ "bevy_time",
  "bevy_utils",
 ]
 
 [[package]]
 name = "bevy_ecs"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79e67dd06b14e787d2026fe6e2b63f67482afcc62284f20ea2784d8b0662e95f"
+checksum = "a5643dc27b7d6778e3a66c8e0f6ad1fd33309aa2fa61d935f360ccc85b7be6a2"
 dependencies = [
  "async-channel",
  "bevy_ecs_macros",
+ "bevy_ptr",
  "bevy_reflect",
  "bevy_tasks",
  "bevy_utils",
@@ -349,7 +340,7 @@ dependencies = [
  "fixedbitset",
  "fxhash",
  "serde",
- "thiserror",
+ "thread_local",
 ]
 
 [[package]]
@@ -360,7 +351,6 @@ dependencies = [
  "bevy",
  "bevy_ecs_ldtk_macros",
  "bevy_ecs_tilemap",
- "heron",
  "hex",
  "rand",
  "regex",
@@ -380,9 +370,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_ecs_macros"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718923a491490bd81074492d61fc08134f9c62a29ba8666818cd7a6630421246"
+checksum = "a5f2f12677f8725d40930d0a19652f007fe0ef5ac38e23817cfc4930c61f5680"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -392,20 +382,30 @@ dependencies = [
 
 [[package]]
 name = "bevy_ecs_tilemap"
-version = "0.5.0"
-source = "git+https://github.com/StarArawn/bevy_ecs_tilemap?branch=rewrite#97133fdbae7e51f51ecdb1ed9321384a47792c34"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef56c77808aa1fc7379ce538bd9a1e4048794203b4f591f2d06131fc613a1cc"
 dependencies = [
  "bevy",
- "bytemuck",
  "log",
  "regex",
 ]
 
 [[package]]
-name = "bevy_gilrs"
-version = "0.7.0"
+name = "bevy_encase_derive"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b164983e8057a1a730412a7c26ccc540d9ce76d2c6ab68edd258a0baeb1762"
+checksum = "76a767adc36ce1fc917a736843b026d4de7069d90ed5e669c852481ef69fd5aa"
+dependencies = [
+ "bevy_macro_utils",
+ "encase_derive_impl",
+]
+
+[[package]]
+name = "bevy_gilrs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "963940426127533164af2a556971a03c493143c0afb95afadb4a070b6ab8c3df"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -416,9 +416,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_gltf"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e07bda7721091c1a683343d466132dc69dec65aa83d8c9e328a2fb3431f03be"
+checksum = "150cc6782c4472600c2ade5d78c6ce481c992690f0499e63765aba752d7e0f04"
 dependencies = [
  "anyhow",
  "base64",
@@ -426,6 +426,7 @@ dependencies = [
  "bevy_app",
  "bevy_asset",
  "bevy_core",
+ "bevy_core_pipeline",
  "bevy_ecs",
  "bevy_hierarchy",
  "bevy_log",
@@ -434,6 +435,7 @@ dependencies = [
  "bevy_reflect",
  "bevy_render",
  "bevy_scene",
+ "bevy_tasks",
  "bevy_transform",
  "bevy_utils",
  "gltf",
@@ -443,9 +445,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_hierarchy"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f407f152f35541a099484200afe3b0ca09ce625469e8233dcdc264d6f88e01a"
+checksum = "8e2e4c20d7c843cd26ef3c5d7b4c20e3e32c275943e2437ecaca1cfd6cfe3b30"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -456,9 +458,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_input"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff4ec4f6e38ef1b41ff68ec7badd6afc5c9699191e61e511c4abee91a5888afc"
+checksum = "a11c70573fb4d4c056ba32cfa553daa7e6e1245cb876ccfbe322640928b7ee1c"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -468,9 +470,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_internal"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d518a8e5f526a9537fc8408a284caec7af22b23c3b23c0dee08bacc0930e2f1a"
+checksum = "0d603b597772130782eab6e604706cbb764fb037f9cf0a1904b6f342845b6f44"
 dependencies = [
  "bevy_animation",
  "bevy_app",
@@ -488,12 +490,14 @@ dependencies = [
  "bevy_log",
  "bevy_math",
  "bevy_pbr",
+ "bevy_ptr",
  "bevy_reflect",
  "bevy_render",
  "bevy_scene",
  "bevy_sprite",
  "bevy_tasks",
  "bevy_text",
+ "bevy_time",
  "bevy_transform",
  "bevy_ui",
  "bevy_utils",
@@ -504,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_log"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943ec496720ded2ff62b292d8e5fc845817a504915f41b7c5fd12b1380300f75"
+checksum = "8cafb12fc84734236e36f407ab62c72d5d4279fa4777e40a95d7cc973cbabcd1"
 dependencies = [
  "android_log-sys",
  "bevy_app",
@@ -519,34 +523,41 @@ dependencies = [
 
 [[package]]
 name = "bevy_macro_utils"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7ddfc33a99547e36718e56e414541e461c74ec318ff987a1e9f4ff46d0dacbb"
+checksum = "4d081af83b701e16cad209255ba6b383744dfa49efa99eb6505989f293305ab3"
 dependencies = [
- "cargo-manifest",
  "quote",
  "syn",
+ "toml",
 ]
 
 [[package]]
 name = "bevy_math"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20288df0f70ff258bbaffaf55209f1271a7436438591bbffc3d81e4d84b423f2"
+checksum = "db5394e86c5708d3aa506c6e98ec4ed2a4083a7a018c6693d9ac0e77ebfabfc2"
 dependencies = [
- "bevy_reflect",
+ "glam",
+]
+
+[[package]]
+name = "bevy_mikktspace"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b299a61175a6f7e7398f83cd5b50920fd8bad4df674e614ad94f25f8426509"
+dependencies = [
  "glam",
 ]
 
 [[package]]
 name = "bevy_pbr"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06adee54840f18cfeda7af4cdc57608644fa840be076a562353f896bfdb9c694"
+checksum = "ed9a81bbd02f5e0a57899a41aec37d9cb14965e1e4d510547f3f680323d05c0f"
 dependencies = [
  "bevy_app",
  "bevy_asset",
- "bevy_core",
  "bevy_core_pipeline",
  "bevy_ecs",
  "bevy_math",
@@ -557,20 +568,29 @@ dependencies = [
  "bevy_window",
  "bitflags",
  "bytemuck",
+ "radsort",
 ]
 
 [[package]]
-name = "bevy_reflect"
-version = "0.7.0"
+name = "bevy_ptr"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d0793107bc4b7c6bd04232d739fc8d70aa5fb313bfad6e850f91f79b2557eed"
+checksum = "d92d5679e89602a18682a37846573dcd1979410179e14204280460ba9fb8713a"
+
+[[package]]
+name = "bevy_reflect"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08798e67f2d4e6898ef117d8c99cf3b50a8eebc8da4159e6dad2657a0fbe9a4e"
 dependencies = [
+ "bevy_ptr",
  "bevy_reflect_derive",
  "bevy_utils",
  "downcast-rs",
  "erased-serde",
  "glam",
- "parking_lot",
+ "once_cell",
+ "parking_lot 0.12.1",
  "serde",
  "smallvec",
  "thiserror",
@@ -578,9 +598,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_reflect_derive"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81c88de8067d19dfde31662ee78e3ee6971e2df27715799f91b515b37a636677"
+checksum = "19209a7f0238053802b7de04e6724bd90d4ed7d90e87101dbd1b64cca64ff694"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -591,19 +611,24 @@ dependencies = [
 
 [[package]]
 name = "bevy_render"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a358da8255b704153913c3499b3693fa5cfe13a48725ac6e76b043fa5633bc8"
+checksum = "bb49530388ef17cff3fb8bd5e47372fb3cfeb4befc73e3036f6462ac20f049ef"
 dependencies = [
  "anyhow",
  "bevy_app",
  "bevy_asset",
  "bevy_core",
- "bevy_crevice",
  "bevy_derive",
  "bevy_ecs",
+ "bevy_encase_derive",
+ "bevy_hierarchy",
+ "bevy_log",
  "bevy_math",
+ "bevy_mikktspace",
  "bevy_reflect",
+ "bevy_render_macros",
+ "bevy_time",
  "bevy_transform",
  "bevy_utils",
  "bevy_window",
@@ -611,32 +636,49 @@ dependencies = [
  "codespan-reporting",
  "copyless",
  "downcast-rs",
+ "encase",
  "futures-lite",
  "hex",
  "hexasphere",
  "image",
  "naga",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.1",
  "regex",
  "serde",
  "smallvec",
  "thiserror",
+ "thread_local",
  "wgpu",
 ]
 
 [[package]]
-name = "bevy_scene"
-version = "0.7.0"
+name = "bevy_render_macros"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ea240f2ffce9f58a5601cc5ead24111f577dc4c656452839eb1fdf4b7a28529"
+checksum = "e7d0b7a51fa819c20c64f43856c5aaea40f853050bbb09b9ba3672e5ff2688a5"
+dependencies = [
+ "bevy_macro_utils",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "bevy_scene"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0064d73ebb0de39901478b493604a1a6d448fd337b66803004c60f41f1fa6c37"
 dependencies = [
  "anyhow",
  "bevy_app",
  "bevy_asset",
+ "bevy_derive",
  "bevy_ecs",
  "bevy_hierarchy",
  "bevy_reflect",
+ "bevy_render",
+ "bevy_transform",
  "bevy_utils",
  "ron",
  "serde",
@@ -646,13 +688,12 @@ dependencies = [
 
 [[package]]
 name = "bevy_sprite"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fcecfbc623410137d85a71a295ff7c16604b7be24529c9ea4b9a9881d7a142b"
+checksum = "1f83dfe8897d6c0d9d5ce3818d49a13e58ae2b9b9ecf4f4bb85aa31bb0678f68"
 dependencies = [
  "bevy_app",
  "bevy_asset",
- "bevy_core",
  "bevy_core_pipeline",
  "bevy_ecs",
  "bevy_log",
@@ -664,6 +705,7 @@ dependencies = [
  "bitflags",
  "bytemuck",
  "copyless",
+ "fixedbitset",
  "guillotiere",
  "rectangle-pack",
  "serde",
@@ -672,29 +714,29 @@ dependencies = [
 
 [[package]]
 name = "bevy_tasks"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2b0f0b86c8f78c53a2d4c669522f45e725ed9d9c3d734f54ec30876494e04e"
+checksum = "ff874c91a36eaac3ef957c6f3b590fb71332d9d136671cc858847d56fe9f80a3"
 dependencies = [
  "async-channel",
  "async-executor",
  "event-listener",
  "futures-lite",
  "num_cpus",
+ "once_cell",
  "wasm-bindgen-futures",
 ]
 
 [[package]]
 name = "bevy_text"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a206112de011fd6baebaf476af69d87f4e38a1314b65e3c872060830d7c0b9fa"
+checksum = "ef05a788c2c04aaa5db95b22a8f0fff0d3a0b08a7bcd1a71f050a628b38eec6e"
 dependencies = [
  "ab_glyph",
  "anyhow",
  "bevy_app",
  "bevy_asset",
- "bevy_core",
  "bevy_ecs",
  "bevy_math",
  "bevy_reflect",
@@ -709,10 +751,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "bevy_transform"
-version = "0.7.0"
+name = "bevy_time"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2f7a77900fb23f24ca312c1f8df3eb47a45161326f41e9b4ef05b039793503"
+checksum = "74ec681d641371df81d7bfbcb0eea725ed873f38a094f34b5f7b436f0889e77c"
+dependencies = [
+ "bevy_app",
+ "bevy_ecs",
+ "bevy_reflect",
+ "bevy_utils",
+ "crossbeam-channel",
+]
+
+[[package]]
+name = "bevy_transform"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e1528e35f30bede46a50ee4134f150efc01f5c1002c340b3b2e6a0bfcb8aa5"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -723,13 +778,12 @@ dependencies = [
 
 [[package]]
 name = "bevy_ui"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c65e79658d8a3d4da087a6fb8b229cfe1455cda2c4e8e6305b3b44fb46fb1d30"
+checksum = "ac181a7b637da61fad72981ff9d2e5b899283ca7d54b2b7ea49c431121331c53"
 dependencies = [
  "bevy_app",
  "bevy_asset",
- "bevy_core",
  "bevy_core_pipeline",
  "bevy_derive",
  "bevy_ecs",
@@ -747,19 +801,18 @@ dependencies = [
  "bytemuck",
  "serde",
  "smallvec",
- "stretch",
+ "taffy",
 ]
 
 [[package]]
 name = "bevy_utils"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f354c584812996febd48cc885f36b23004b49d6680e73fc95a69a2bb17a48e5"
+checksum = "8bda6dada53e546845887ae7357eec57b8d547ef71627b716b33839b4a98b687"
 dependencies = [
  "ahash",
- "bevy_derive",
  "getrandom",
- "hashbrown",
+ "hashbrown 0.12.3",
  "instant",
  "tracing",
  "uuid",
@@ -767,12 +820,13 @@ dependencies = [
 
 [[package]]
 name = "bevy_window"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04fe33d177e10b2984fa90c1d19496fc6f6e7b36d4442699d359e2b4b507873d"
+checksum = "a3bdc3a220a9bb2fad9bd30d5f44c6645725398fe1bc588fc87abf09f092696e"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
+ "bevy_input",
  "bevy_math",
  "bevy_utils",
  "raw-window-handle",
@@ -781,9 +835,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_winit"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c0e3b94cc73907f8a9f82945ca006a39ed2ab401aca0974b47a007a468509f"
+checksum = "57537a56ac4f4e1ffcad95227bcab37cd17b51770dacff82374a2d88be376322"
 dependencies = [
  "approx",
  "bevy_app",
@@ -792,6 +846,7 @@ dependencies = [
  "bevy_math",
  "bevy_utils",
  "bevy_window",
+ "crossbeam-channel",
  "raw-window-handle",
  "wasm-bindgen",
  "web-sys",
@@ -887,17 +942,6 @@ name = "cache-padded"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
-
-[[package]]
-name = "cargo-manifest"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af6d65c7592744998c67947ec771c62687c76f00179a83ffd563c0482046bb98"
-dependencies = [
- "serde",
- "serde_derive",
- "toml",
-]
 
 [[package]]
 name = "cc"
@@ -1029,20 +1073,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_panic"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c0358e41e90e443c69b2b2811f6ec9892c228b93620634cf4344fe89967fa9f"
+
+[[package]]
 name = "copyless"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2df960f5d869b2dd8532793fde43eb5427cceb126c929747a26823ab0eeb536"
-
-[[package]]
-name = "core-foundation"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d"
-dependencies = [
- "core-foundation-sys 0.6.2",
- "libc",
-]
 
 [[package]]
 name = "core-foundation"
@@ -1063,12 +1103,6 @@ dependencies = [
  "core-foundation-sys 0.8.3",
  "libc",
 ]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
 
 [[package]]
 name = "core-foundation-sys"
@@ -1164,13 +1198,13 @@ dependencies = [
  "js-sys",
  "lazy_static",
  "libc",
- "mach 0.3.2",
+ "mach",
  "ndk 0.6.0",
  "ndk-glue 0.6.2",
- "nix",
+ "nix 0.23.1",
  "oboe",
- "parking_lot",
- "stdweb 0.1.3",
+ "parking_lot 0.11.2",
+ "stdweb",
  "thiserror",
  "wasm-bindgen",
  "web-sys",
@@ -1187,59 +1221,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae5588f6b3c3cb05239e90bd110f257254aecd01e4635400391aeae07497845"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
-dependencies = [
- "autocfg",
- "cfg-if 1.0.0",
- "crossbeam-utils",
- "lazy_static",
- "memoffset",
- "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f25d8400f4a7a5778f0e4e52384a48cbd9b5c495d110786187fc750075277a2"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -1263,9 +1248,9 @@ checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
 
 [[package]]
 name = "d3d12"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2daefd788d1e96e0a9d66dee4b828b883509bc3ea9ce30665f04c3246372690c"
+checksum = "827914e1f53b1e0e025ecd3d967a7836b7bcb54520f90e21ef8df7b4d88a2759"
 dependencies = [
  "bitflags",
  "libloading",
@@ -1309,19 +1294,12 @@ dependencies = [
 
 [[package]]
 name = "deflate"
-version = "0.8.6"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73770f8e1fe7d64df17ca66ad28994a0a623ea497fa69486e14984e715c5d174"
+checksum = "c86f7e25f518f4b81808a2cf1c50996a61f5c2eb394b2393bd87f2a4780a432f"
 dependencies = [
  "adler32",
- "byteorder",
 ]
-
-[[package]]
-name = "discard"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "dispatch"
@@ -1336,20 +1314,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
-name = "duplicate"
-version = "0.4.0"
+name = "encase"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a2535fcf1437c9de0d91a3921351c474258abdb6440cd03bb5a7cf0547e7214"
+checksum = "0a516181e9a36e8982cb37933c5e7dba638c42938cacde46ee4e5b4156f881b9"
 dependencies = [
- "heck",
- "proc-macro-error",
+ "const_panic",
+ "encase_derive",
+ "glam",
+ "thiserror",
 ]
 
 [[package]]
-name = "either"
-version = "1.6.1"
+name = "encase_derive"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+checksum = "f5b802412eea315f29f2bb2da3a5963cd6121f56eaa06aebcdc0c54eea578f22"
+dependencies = [
+ "encase_derive_impl",
+]
+
+[[package]]
+name = "encase_derive_impl"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f2f4de457d974f548d2c2a16f709ebd81013579e543bd1a9b19ced88132c2cf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "env_logger"
@@ -1493,9 +1487,9 @@ dependencies = [
 
 [[package]]
 name = "gilrs"
-version = "0.8.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1550c8bdebc993576e343d600a954654708a9a1182396ee1e805d6fe60c72909"
+checksum = "1d6ba7c37bf8ea7ba0c3e3795dfa1a7771b1e47c4bb417c4d27c7b338d79685f"
 dependencies = [
  "fnv",
  "gilrs-core",
@@ -1506,33 +1500,32 @@ dependencies = [
 
 [[package]]
 name = "gilrs-core"
-version = "0.3.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c7262ce1e88429c9b1d847820c9d2ba00adafc955218393d9c0861d5aaab88"
+checksum = "96a8d94a7fc5afd27e894e08a4cfe5a49237f85bcc7140e90721bad3399c7d02"
 dependencies = [
- "core-foundation 0.6.4",
+ "core-foundation 0.9.3",
  "io-kit-sys",
  "js-sys",
  "libc",
  "libudev-sys",
  "log",
- "nix",
+ "nix 0.24.2",
  "rusty-xinput",
- "stdweb 0.4.20",
  "uuid",
  "vec_map",
+ "wasm-bindgen",
  "web-sys",
  "winapi",
 ]
 
 [[package]]
 name = "glam"
-version = "0.20.5"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43e957e744be03f5801a55472f593d43fabdebf25a4585db250f04d86b1675f"
+checksum = "518faa5064866338b013ff9b2350dc318e14cc4fcd6cb8206d7e7c9886c98815"
 dependencies = [
  "bytemuck",
- "mint",
  "serde",
 ]
 
@@ -1627,7 +1620,7 @@ checksum = "a538f217be4d405ff4719a283ca68323cc2384003eca5baaa87501e821c81dda"
 dependencies = [
  "bitflags",
  "gpu-descriptor-types",
- "hashbrown",
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -1650,20 +1643,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "hash32-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59d2aba832b60be25c1b169146b27c64115470981b128ed84c8db18c1b03c6ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
  "ahash",
- "serde",
 ]
 
 [[package]]
-name = "heck"
-version = "0.4.0"
+name = "hashbrown"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+ "serde",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -1675,55 +1691,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "heron"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45f23a4c500926d8dc9ec59cc6ae3c17f006bc4f7d2cc13f8d6ef993a8ba7867"
-dependencies = [
- "bevy",
- "cfg_aliases",
- "heron_core",
- "heron_macros",
- "heron_rapier",
-]
-
-[[package]]
-name = "heron_core"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5159c19d52d452251e2377294f3a34534fe9293eadc3bb2b4ba18fe3ff9d10d"
-dependencies = [
- "bevy",
- "cfg_aliases",
- "duplicate",
- "smallvec",
-]
-
-[[package]]
-name = "heron_macros"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146314054f01fc7c1a345dcc4dfedc7e3a792e845ce1c6d21c7c26f5383bd98b"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
-name = "heron_rapier"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdba166504110706edc3a1c614f4e6cba9ba001cd4569afc9afb44ea557b472d"
-dependencies = [
- "bevy",
- "cfg_aliases",
- "crossbeam",
- "fnv",
- "heron_core",
- "rapier2d",
-]
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1731,12 +1698,12 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hexasphere"
-version = "7.0.0"
+version = "7.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04ab9d20ba513ff1582a7d885e91839f62cf28bef7c56b1b0428ca787315979b"
+checksum = "9652f2ed7ee9c6374a061039f60fc6e25d7adac7fa10f83365669af3b24b0bf0"
 dependencies = [
  "glam",
- "lazy_static",
+ "once_cell",
 ]
 
 [[package]]
@@ -1753,15 +1720,14 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "image"
-version = "0.23.14"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ffcb7e7244a9bf19d35bf2883b9c080c4ced3c07a9895572178cdb8f13f6a1"
+checksum = "7e30ca2ecf7666107ff827a8e481de6a132a9b687ed3bb20bb1c144a36c00964"
 dependencies = [
  "bytemuck",
  "byteorder",
  "color_quant",
- "num-iter",
- "num-rational 0.3.2",
+ "num-rational",
  "num-traits",
  "png",
  "scoped_threadpool",
@@ -1774,7 +1740,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -1823,12 +1789,12 @@ dependencies = [
 
 [[package]]
 name = "io-kit-sys"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f21dcc74995dd4cd090b147e79789f8d65959cbfb5f0b118002db869ea3bd0a0"
+checksum = "7789f7f3c9686f96164f5109d69152de759e76e284f736bd57661c6df5091919"
 dependencies = [
- "core-foundation-sys 0.6.2",
- "mach 0.2.3",
+ "core-foundation-sys 0.8.3",
+ "mach",
 ]
 
 [[package]]
@@ -1868,9 +1834,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.57"
+version = "0.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671a26f820db17c2a2750743f1dd03bafd15b98c9f30c7c2628c024c05d73397"
+checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1883,6 +1849,7 @@ checksum = "8c2352bd1d0bceb871cb9d40f24360c8133c11d7486b68b5381c1dd1a32015e3"
 dependencies = [
  "libc",
  "libloading",
+ "pkg-config",
 ]
 
 [[package]]
@@ -1930,9 +1897,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.124"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a41fed9d98f27ab1c6d161da622a4fa35e8a54a8adc24bbf3ddd0ef70b0e50"
+checksum = "505e71a4706fa491e9b1b55f51b95d4037d0821ee40131190475f692b35b009b"
 
 [[package]]
 name = "libloading"
@@ -1943,12 +1910,6 @@ dependencies = [
  "cfg-if 1.0.0",
  "winapi",
 ]
-
-[[package]]
-name = "libm"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
 
 [[package]]
 name = "libudev-sys"
@@ -1981,15 +1942,6 @@ dependencies = [
 
 [[package]]
 name = "mach"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86dd2487cdfea56def77b88438a2c915fb45113c5319bfe7e14306ca4cd0b0e1"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "mach"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
@@ -2016,15 +1968,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matrixmultiply"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add85d4dd35074e6fedc608f8c8f513a3548619a9024b751949ef0e8e45a4d84"
-dependencies = [
- "rawpointer",
-]
-
-[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2041,9 +1984,9 @@ dependencies = [
 
 [[package]]
 name = "metal"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0514f491f4cc03632ab399ee01e2c1c1b12d3e1cf2d667c1ff5f87d6dcd2084"
+checksum = "de11355d1f6781482d027a3b4d4de7825dcedb197bf573e0596d00008402d060"
 dependencies = [
  "bitflags",
  "block",
@@ -2061,30 +2004,11 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.3.7"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435"
+checksum = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc"
 dependencies = [
- "adler32",
-]
-
-[[package]]
-name = "mint"
-version = "0.5.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e53debba6bda7a793e5f99b8dacf19e626084f525f7829104ba9898f367d85ff"
-
-[[package]]
-name = "mio"
-version = "0.7.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
-dependencies = [
- "libc",
- "log",
- "miow",
- "ntapi",
- "winapi",
+ "adler",
 ]
 
 [[package]]
@@ -2112,9 +2036,9 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "0.8.5"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3012f2dbcc79e8e0b5825a4836a7106a75dd9b2fe42c528163be0f572538c705"
+checksum = "5f50357e1167a3ab92d6b3c7f4bf5f7fd13fde3f4b28bf0d5ea07b5100fdb6c0"
 dependencies = [
  "bit-set",
  "bitflags",
@@ -2127,34 +2051,9 @@ dependencies = [
  "pp-rs",
  "rustc-hash",
  "spirv",
+ "termcolor",
  "thiserror",
-]
-
-[[package]]
-name = "nalgebra"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d506eb7e08d6329505faa8a3a00a5dcc6de9f76e0c77e4b75763ae3c770831ff"
-dependencies = [
- "approx",
- "matrixmultiply",
- "nalgebra-macros",
- "num-complex",
- "num-rational 0.4.0",
- "num-traits",
- "simba",
- "typenum",
-]
-
-[[package]]
-name = "nalgebra-macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01fcc0b8149b4632adc89ac3b7b31a12fb6099a0317a4eb2ebff574ef7de7218"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -2262,6 +2161,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "195cdbc1741b8134346d515b3a56a1c94b0912758009cfd53f99ea0f57b065fc"
+dependencies = [
+ "bitflags",
+ "cfg-if 1.0.0",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2273,9 +2183,9 @@ dependencies = [
 
 [[package]]
 name = "notify"
-version = "5.0.0-pre.11"
+version = "5.0.0-pre.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c614e7ed2b1cf82ec99aeffd8cf6225ef5021b9951148eb161393c394855032c"
+checksum = "553f9844ad0b0824605c20fb55a661679782680410abfb1a8144c2e7e437e7a7"
 dependencies = [
  "bitflags",
  "crossbeam-channel",
@@ -2284,7 +2194,7 @@ dependencies = [
  "inotify",
  "kqueue",
  "libc",
- "mio 0.7.14",
+ "mio",
  "walkdir",
  "winapi",
 ]
@@ -2296,15 +2206,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
 dependencies = [
  "winapi",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26873667bbbb7c5182d4a37c1add32cdf09f841af72da53318fdb81543c15085"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -2325,28 +2226,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg",
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
-dependencies = [
- "autocfg",
- "num-integer",
  "num-traits",
 ]
 
@@ -2454,9 +2333,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.10.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "owned_ttf_parser"
@@ -2481,7 +2360,17 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.8.5",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core 0.9.3",
 ]
 
 [[package]]
@@ -2499,30 +2388,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "parry2d"
-version = "0.7.1"
+name = "parking_lot_core"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e03714e76fd6708c1fa3fc4f58a66dabd723bb87865548657a037beaf9a8eea"
+checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
 dependencies = [
- "approx",
- "arrayvec",
- "bitflags",
- "downcast-rs",
- "either",
- "nalgebra",
- "num-derive",
- "num-traits",
- "rustc-hash",
- "simba",
- "slab",
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall",
  "smallvec",
+ "windows-sys",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c520e05135d6e763148b6426a837e239041653ba7becd2e538c076c738025fc"
 
 [[package]]
 name = "peeking_take_while"
@@ -2560,9 +2436,9 @@ checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "png"
-version = "0.16.8"
+version = "0.17.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3287920cb847dee3de33d301c463fba14dda99db24214ddf93f83d3021f4c6"
+checksum = "dc38c0ad57efb786dd57b9864e5b18bae478c00c824dc55a38bbc9da95dde3ba"
 dependencies = [
  "bitflags",
  "crc32fast",
@@ -2596,30 +2472,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2642,6 +2494,12 @@ checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radsort"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17fd96390ed3feda12e1dfe2645ed587e0bea749e319333f104a33ff62f77a0b"
 
 [[package]]
 name = "rand"
@@ -2680,27 +2538,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e935c45e09cc6dcf00d2f0b2d630a58f4095320223d47fc68918722f0538b6"
 
 [[package]]
-name = "rapier2d"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c45d2910dbd279941b71ef9d20da877a0eada21f8117fcac70941e458100ea86"
-dependencies = [
- "approx",
- "arrayvec",
- "bit-vec",
- "bitflags",
- "crossbeam",
- "downcast-rs",
- "instant",
- "nalgebra",
- "num-derive",
- "num-traits",
- "parry2d",
- "rustc-hash",
- "simba",
-]
-
-[[package]]
 name = "raw-window-handle"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2708,12 +2545,6 @@ checksum = "b800beb9b6e7d2df1fe337c9e3d04e3af22a124460fb4c30fcc22c9117cefb41"
 dependencies = [
  "cty",
 ]
-
-[[package]]
-name = "rawpointer"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rectangle-pack"
@@ -2790,15 +2621,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rusty-xinput"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2814,15 +2636,6 @@ name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
-
-[[package]]
-name = "safe_arch"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "794821e4ccb0d9f979512f9c1973480123f9bd62a90d74ab0f9426fcf8f4a529"
-dependencies = [
- "bytemuck",
-]
 
 [[package]]
 name = "same-file"
@@ -2844,21 +2657,6 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
@@ -2892,21 +2690,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1da05c97445caa12d05e848c4a4fcbbea29e748ac28f7e80e9b010392063770"
-dependencies = [
- "sha1_smol",
-]
-
-[[package]]
-name = "sha1_smol"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
-
-[[package]]
 name = "sharded-slab"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2920,19 +2703,6 @@ name = "shlex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
-
-[[package]]
-name = "simba"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0b7840f121a46d63066ee7a99fc81dcabbc6105e437cae43528cea199b5a05f"
-dependencies = [
- "approx",
- "num-complex",
- "num-traits",
- "paste",
- "wide",
-]
 
 [[package]]
 name = "slab"
@@ -2975,67 +2745,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef5430c8e36b713e13b48a9f709cc21e046723fe44ce34587b73a830203b533e"
 
 [[package]]
-name = "stdweb"
-version = "0.4.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
-dependencies = [
- "discard",
- "rustc_version",
- "serde",
- "serde_json",
- "stdweb-derive",
- "stdweb-internal-macros",
- "stdweb-internal-runtime",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "stdweb-derive"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde",
- "serde_derive",
- "syn",
-]
-
-[[package]]
-name = "stdweb-internal-macros"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
-dependencies = [
- "base-x",
- "proc-macro2",
- "quote",
- "serde",
- "serde_derive",
- "serde_json",
- "sha1",
- "syn",
-]
-
-[[package]]
-name = "stdweb-internal-runtime"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
-
-[[package]]
-name = "stretch"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0dc6d20ce137f302edf90f9cd3d278866fd7fb139efca6f246161222ad6d87"
-dependencies = [
- "lazy_static",
- "libm",
-]
-
-[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3056,6 +2765,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "taffy"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec27dea659b100d489dffa57cf0efc6d7bfefb119af817b92cc14006c0b214e3"
+dependencies = [
+ "arrayvec",
+ "hash32",
+ "hash32-derive",
+ "num-traits",
+ "typenum",
 ]
 
 [[package]]
@@ -3117,7 +2839,6 @@ version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
 dependencies = [
- "indexmap",
  "serde",
 ]
 
@@ -3214,15 +2935,15 @@ checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 
 [[package]]
 name = "uuid"
-version = "0.8.2"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
 dependencies = [
  "getrandom",
  "serde",
@@ -3277,9 +2998,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.80"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27370197c907c55e3f1a9fbe26f44e937fe6451368324e009cba39e139dc08ad"
+checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -3287,13 +3008,13 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.80"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e04185bfa3a779273da532f5025e33398409573f348985af9a1cbf3774d3f4"
+checksum = "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
 dependencies = [
  "bumpalo",
- "lazy_static",
  "log",
+ "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -3302,9 +3023,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.30"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f741de44b75e14c35df886aff5f1eb73aa114fa5d4d00dcd37b5e01259bf3b2"
+checksum = "fa76fb221a1f8acddf5b54ace85912606980ad661ac7a503b4570ffd3a624dad"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -3314,9 +3035,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.80"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17cae7ff784d7e83a2fe7611cfe766ecf034111b49deb850a3dc7699c08251f5"
+checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3324,9 +3045,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.80"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99ec0dc7a4756fffc231aab1b9f2f578d23cd391390ab27f952ae0c9b3ece20b"
+checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3337,15 +3058,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.80"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
+checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
 
 [[package]]
 name = "web-sys"
-version = "0.3.57"
+version = "0.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b17e741662c70c8bd24ac5c5b18de314a2c26c32bf8346ee1e6f53de919c283"
+checksum = "ed055ab27f941423197eb86b2035720b1a3ce40504df082cac2ecc6ed73335a1"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3353,15 +3074,15 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97cd781ff044d6d697b632a2e212032c2e957d1afaa21dbf58069cbb8f78567"
+checksum = "277e967bf8b7820a76852645a6bce8bbd31c32fda2042e82d8e3ea75fda8892d"
 dependencies = [
  "arrayvec",
  "js-sys",
  "log",
  "naga",
- "parking_lot",
+ "parking_lot 0.11.2",
  "raw-window-handle",
  "smallvec",
  "wasm-bindgen",
@@ -3374,11 +3095,12 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.12.2"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4688c000eb841ca55f7b35db659b78d6e1cd77d7caf8fb929f4e181f754047d"
+checksum = "89b92788dec9d0c1bed849a1b83f01b2ee12819bf04a79c90f68e4173f7b5ba2"
 dependencies = [
  "arrayvec",
+ "bit-vec",
  "bitflags",
  "cfg_aliases",
  "codespan-reporting",
@@ -3386,21 +3108,23 @@ dependencies = [
  "fxhash",
  "log",
  "naga",
- "parking_lot",
+ "parking_lot 0.11.2",
  "profiling",
  "raw-window-handle",
  "smallvec",
  "thiserror",
+ "web-sys",
  "wgpu-hal",
  "wgpu-types",
 ]
 
 [[package]]
 name = "wgpu-hal"
-version = "0.12.5"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d684ea6a34974a2fc19f1dfd183d11a62e22d75c4f187a574bb1224df8e056c2"
+checksum = "20cbdfc3d0637dba3d5536b93adef3d26023a0b96f0e1ee5ee9560a401d9f646"
 dependencies = [
+ "android_system_properties",
  "arrayvec",
  "ash",
  "bit-set",
@@ -3421,7 +3145,7 @@ dependencies = [
  "metal",
  "naga",
  "objc",
- "parking_lot",
+ "parking_lot 0.11.2",
  "profiling",
  "range-alloc",
  "raw-window-handle",
@@ -3435,21 +3159,11 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "0.12.0"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "549533d9e1cdd4b4cda7718d33ff500fc4c34b5467b71d76b547ae0324f3b2a2"
+checksum = "1f762cbc08e1a51389859cf9c199c7aef544789cf3510889aab12c607f701604"
 dependencies = [
  "bitflags",
-]
-
-[[package]]
-name = "wide"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3aba2d1dac31ac7cae82847ac5b8be822aee8f99a4e100f279605016b185c5f"
-dependencies = [
- "bytemuck",
- "safe_arch",
 ]
 
 [[package]]
@@ -3484,6 +3198,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
 name = "winit"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3499,12 +3256,12 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "mio 0.8.2",
+ "mio",
  "ndk 0.5.0",
  "ndk-glue 0.5.2",
  "ndk-sys 0.2.2",
  "objc",
- "parking_lot",
+ "parking_lot 0.11.2",
  "percent-encoding",
  "raw-window-handle",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["assets/*", "repo/*", "scripts/*"]
 [dependencies]
 bevy_ecs_ldtk_macros = { version = "0.3", optional = true, path = "macros" }
 bevy_ecs_tilemap = { version = "0.7.0" }
-bevy = { version = "0.8", default-features = false }
+bevy = { version = "0.8", default-features = false, features = ["bevy_sprite"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 regex = "1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ exclude = ["assets/*", "repo/*", "scripts/*"]
 
 [dependencies]
 bevy_ecs_ldtk_macros = { version = "0.3", optional = true, path = "macros" }
-bevy_ecs_tilemap = { git = "https://github.com/StarArawn/bevy_ecs_tilemap", branch = "rewrite" }
-bevy = { version = "0.7", default-features = false }
+bevy_ecs_tilemap = { version = "0.7.0" }
+bevy = { version = "0.8", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 regex = "1.5"
@@ -22,8 +22,8 @@ anyhow = "1.0"
 thiserror = "1.0"
 
 [dev-dependencies]
-bevy = "0.7"
-heron = { version = "3.0", features = ["2d"] }
+bevy = "0.8"
+# heron = { version = "3.0", features = ["2d"] }
 rand = "0.8"
 
 [features]

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,8 +1,9 @@
-use bevy::prelude::*;
+use bevy::{prelude::*, render::texture::ImageSettings};
 use bevy_ecs_ldtk::prelude::*;
 
 fn main() {
     App::new()
+        .insert_resource(ImageSettings::default_nearest()) // prevents blurry sprites
         .add_plugins(DefaultPlugins)
         .add_plugin(LdtkPlugin)
         .add_startup_system(setup)
@@ -12,7 +13,7 @@ fn main() {
 }
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    commands.spawn_bundle(OrthographicCameraBundle::new_2d());
+    commands.spawn_bundle(Camera2dBundle::default());
 
     commands.spawn_bundle(LdtkWorldBundle {
         ldtk_handle: asset_server.load("my_project.ldtk"),

--- a/macros/src/ldtk_entity.rs
+++ b/macros/src/ldtk_entity.rs
@@ -222,6 +222,7 @@ fn expand_sprite_sheet_bundle_attribute(
                             asset_server.load(#asset_path).into(),
                             bevy::prelude::Vec2::new(#tile_width, #tile_height),
                             #columns, #rows, bevy::prelude::Vec2::splat(#padding),
+                            Vec2::ZERO,
                         )
                     ),
                     sprite: bevy::prelude::TextureAtlasSprite {

--- a/src/components.rs
+++ b/src/components.rs
@@ -16,7 +16,7 @@ use crate::{
     utils::ldtk_grid_coords_to_grid_coords,
 };
 
-use bevy_ecs_tilemap::tiles::{TileBundle, TilePos2d};
+use bevy_ecs_tilemap::tiles::{TileBundle, TilePos};
 
 /// [Component] added to any `IntGrid` tile by default.
 ///
@@ -112,8 +112,8 @@ impl From<GridCoords> for IVec2 {
     }
 }
 
-impl From<TilePos2d> for GridCoords {
-    fn from(tile_pos: TilePos2d) -> Self {
+impl From<TilePos> for GridCoords {
+    fn from(tile_pos: TilePos) -> Self {
         GridCoords {
             x: tile_pos.x as i32,
             y: tile_pos.y as i32,
@@ -121,9 +121,9 @@ impl From<TilePos2d> for GridCoords {
     }
 }
 
-impl From<GridCoords> for TilePos2d {
+impl From<GridCoords> for TilePos {
     fn from(grid_coords: GridCoords) -> Self {
-        TilePos2d::new(grid_coords.x as u32, grid_coords.y as u32)
+        TilePos::new(grid_coords.x as u32, grid_coords.y as u32)
     }
 }
 

--- a/src/components.rs
+++ b/src/components.rs
@@ -343,4 +343,6 @@ pub struct LdtkWorldBundle {
     pub level_set: LevelSet,
     pub transform: Transform,
     pub global_transform: GlobalTransform,
+    pub visibility: Visibility,
+    pub computed_visibility: ComputedVisibility,
 }

--- a/src/level.rs
+++ b/src/level.rs
@@ -19,7 +19,7 @@ use crate::{
 use bevy::{prelude::*, render::render_resource::*, sprite};
 use bevy_ecs_tilemap::{
     map::{
-        TilemapGridSize, TilemapSize, TilemapSpacing, TilemapTextureSize,
+        TilemapGridSize, TilemapSize, TilemapSpacing,
         TilemapTileSize, TilemapId, TilemapTexture,
     },
     tiles::{TileStorage, TileBundle, TileColor, TilePos},
@@ -250,17 +250,12 @@ pub fn spawn_level(
                 x: level.px_wid as f32,
                 y: level.px_hei as f32,
             };
-            let texture_size = Tilemap2dTextureSize {
-                x: level.px_wid as f32,
-                y: level.px_hei as f32,
-            };
             let texture = TilemapTexture(white_image_handle.clone());
 
             commands
                 .entity(background_entity)
                 .insert_bundle(TilemapBundle {
                     tile_size,
-                    texture_size,
                     storage,
                     texture,
                     ..default()
@@ -377,17 +372,6 @@ pub fn spawn_level(
                             y: tileset_definition.tile_grid_size as f32,
                         },
                         None => TilemapTileSize {
-                            x: layer_instance.grid_size as f32,
-                            y: layer_instance.grid_size as f32,
-                        },
-                    };
-
-                    let texture_size = match tileset_definition {
-                        Some(tileset_definition) => Tilemap2dTextureSize {
-                            x: tileset_definition.px_wid as f32,
-                            y: tileset_definition.px_hei as f32,
-                        },
-                        None => Tilemap2dTextureSize {
                             x: layer_instance.grid_size as f32,
                             y: layer_instance.grid_size as f32,
                         },
@@ -611,7 +595,6 @@ pub fn spawn_level(
                                 size,
                                 spacing,
                                 storage,
-                                texture_size,
                                 texture: texture.clone(),
                                 tile_size,
                                 ..default()
@@ -661,7 +644,6 @@ pub fn spawn_level(
                                 size,
                                 spacing,
                                 storage,
-                                texture_size,
                                 texture: texture.clone(),
                                 tile_size,
                                 ..default()

--- a/src/level.rs
+++ b/src/level.rs
@@ -126,20 +126,20 @@ fn insert_metadata_to_tile(
     metadata_inserted
 }
 
-fn transform_bundle_for_tiles(
+fn spatial_bundle_for_tiles(
     grid_coords: GridCoords,
     grid_size: i32,
     layer_scale: Vec3,
-) -> (Transform, GlobalTransform) {
+) -> SpatialBundle {
     let mut translation =
         grid_coords_to_translation_centered(grid_coords, IVec2::splat(grid_size)).extend(0.);
 
     translation /= layer_scale;
 
-    (
-        Transform::from_translation(translation),
-        GlobalTransform::default(),
-    )
+    SpatialBundle {
+        transform: Transform::from_translation(translation),
+        ..default()
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -161,7 +161,7 @@ fn insert_metadata_for_layer(
         if insert_metadata_to_tile(commands, tile, tile_entity, metadata_map, enum_tags_map) {
             commands
                 .entity(tile_entity)
-                .insert_bundle(transform_bundle_for_tiles(
+                .insert_bundle(spatial_bundle_for_tiles(
                     grid_coords,
                     layer_instance.grid_size,
                     layer_scale,
@@ -340,8 +340,10 @@ pub fn spawn_level(
                                 );
 
                                 entity_commands
-                                    .insert(transform)
-                                    .insert(GlobalTransform::default());
+                                    .insert_bundle(SpatialBundle {
+                                        transform,
+                                        ..default()
+                                    });
                             }
                         }
                     });
@@ -564,13 +566,13 @@ pub fn spawn_level(
                                         layer_instance,
                                     );
 
-                                    let transform_bundle = transform_bundle_for_tiles(
+                                    let spatial_bundle = spatial_bundle_for_tiles(
                                         grid_coords,
                                         layer_instance.grid_size,
                                         layer_scale,
                                     );
 
-                                    entity_commands.insert_bundle(transform_bundle);
+                                    entity_commands.insert_bundle(spatial_bundle);
                                     commands.entity(layer_entity).add_child(tile_entity);
                                 }
                             }

--- a/src/level.rs
+++ b/src/level.rs
@@ -130,8 +130,7 @@ fn transform_bundle_for_tiles(
     grid_coords: GridCoords,
     grid_size: i32,
     layer_scale: Vec3,
-    parent: Entity,
-) -> (Transform, GlobalTransform, Parent) {
+) -> (Transform, GlobalTransform) {
     let mut translation =
         grid_coords_to_translation_centered(grid_coords, IVec2::splat(grid_size)).extend(0.);
 
@@ -140,7 +139,6 @@ fn transform_bundle_for_tiles(
     (
         Transform::from_translation(translation),
         GlobalTransform::default(),
-        Parent(parent),
     )
 }
 
@@ -167,8 +165,8 @@ fn insert_metadata_for_layer(
                     grid_coords,
                     layer_instance.grid_size,
                     layer_scale,
-                    layer_entity,
                 ));
+            commands.entity(layer_entity).add_child(tile_entity);
         }
     }
 }
@@ -259,8 +257,8 @@ pub fn spawn_level(
                     storage,
                     texture,
                     ..default()
-                })
-                .insert(Parent(ldtk_entity));
+                });
+            commands.entity(ldtk_entity).add_child(background_entity);
 
             layer_z += 1;
 
@@ -277,9 +275,9 @@ pub fn spawn_level(
                     layer_z as f32,
                 ) {
                     Ok(sprite_sheet_bundle) => {
-                        commands
-                            .spawn_bundle(sprite_sheet_bundle)
-                            .insert(Parent(ldtk_entity));
+                        commands.entity(ldtk_entity).with_children(|parent| {
+                            parent.spawn_bundle(sprite_sheet_bundle);
+                        });
 
                         layer_z += 1;
                     }
@@ -570,10 +568,10 @@ pub fn spawn_level(
                                         grid_coords,
                                         layer_instance.grid_size,
                                         layer_scale,
-                                        layer_entity,
                                     );
 
                                     entity_commands.insert_bundle(transform_bundle);
+                                    commands.entity(layer_entity).add_child(tile_entity);
                                 }
                             }
 
@@ -662,8 +660,8 @@ pub fn spawn_level(
                             .insert(
                                 Transform::from_translation(layer_offset).with_scale(layer_scale),
                             )
-                            .insert(LayerMetadata::from(layer_instance))
-                            .insert(Parent(ldtk_entity));
+                            .insert(LayerMetadata::from(layer_instance));
+                        commands.entity(ldtk_entity).add_child(layer_entity);
 
                         layer_z += 1;
                     }

--- a/src/level.rs
+++ b/src/level.rs
@@ -19,10 +19,10 @@ use crate::{
 use bevy::{prelude::*, render::render_resource::*, sprite};
 use bevy_ecs_tilemap::{
     map::{
-        Tilemap2dGridSize, Tilemap2dSize, Tilemap2dSpacing, Tilemap2dTextureSize,
-        Tilemap2dTileSize, TilemapId, TilemapTexture,
+        TilemapGridSize, TilemapSize, TilemapSpacing, TilemapTextureSize,
+        TilemapTileSize, TilemapId, TilemapTexture,
     },
-    tiles::{Tile2dStorage, TileBundle, TileColor, TilePos2d},
+    tiles::{TileStorage, TileBundle, TileColor, TilePos},
     TilemapBundle,
 };
 use std::collections::{HashMap, HashSet};
@@ -147,7 +147,7 @@ fn transform_bundle_for_tiles(
 #[allow(clippy::too_many_arguments)]
 fn insert_metadata_for_layer(
     commands: &mut Commands,
-    tile_storage: &Tile2dStorage,
+    tile_storage: &TileStorage,
     grid_tiles: &[TileInstance],
     layer_instance: &LayerInstance,
     metadata_map: &HashMap<i32, TileMetadata>,
@@ -234,7 +234,7 @@ pub fn spawn_level(
         if ldtk_settings.level_background == LevelBackground::Rendered {
             let background_entity = commands.spawn().id();
 
-            let mut storage = Tile2dStorage::empty(Tilemap2dSize { x: 1, y: 1 });
+            let mut storage = TileStorage::empty(TilemapSize { x: 1, y: 1 });
 
             let tile_entity = commands
                 .spawn_bundle(TileBundle {
@@ -244,9 +244,9 @@ pub fn spawn_level(
                 })
                 .id();
 
-            storage.set(&TilePos2d::default(), Some(tile_entity));
+            storage.set(&TilePos::default(), Some(tile_entity));
 
-            let tile_size = Tilemap2dTileSize {
+            let tile_size = TilemapTileSize {
                 x: level.px_wid as f32,
                 y: level.px_hei as f32,
             };
@@ -362,7 +362,7 @@ pub fn spawn_level(
 
                     let layer_entity = commands.spawn().id();
 
-                    let size = Tilemap2dSize {
+                    let size = TilemapSize {
                         x: layer_instance.c_wid as u32,
                         y: layer_instance.c_hei as u32,
                     };
@@ -372,11 +372,11 @@ pub fn spawn_level(
                         .map(|u| tileset_definition_map.get(&u).unwrap());
 
                     let tile_size = match tileset_definition {
-                        Some(tileset_definition) => Tilemap2dTileSize {
+                        Some(tileset_definition) => TilemapTileSize {
                             x: tileset_definition.tile_grid_size as f32,
                             y: tileset_definition.tile_grid_size as f32,
                         },
-                        None => Tilemap2dTileSize {
+                        None => TilemapTileSize {
                             x: layer_instance.grid_size as f32,
                             y: layer_instance.grid_size as f32,
                         },
@@ -393,12 +393,12 @@ pub fn spawn_level(
                         },
                     };
 
-                    let mut grid_size = Tilemap2dGridSize::default();
+                    let mut grid_size = TilemapGridSize::default();
 
-                    let mut spacing = Tilemap2dSpacing::default();
+                    let mut spacing = TilemapSpacing::default();
 
                     if let Some(tileset_definition) = tileset_definition {
-                        grid_size = Tilemap2dGridSize {
+                        grid_size = TilemapGridSize {
                             x: layer_instance.grid_size as f32,
                             y: layer_instance.grid_size as f32,
                         };
@@ -478,7 +478,7 @@ pub fn spawn_level(
                             // The current spawning of IntGrid layers doesn't allow using
                             // LayerBuilder::new_batch().
                             // So, the actual LayerBuilder usage diverges greatly here
-                            let mut storage = Tile2dStorage::empty(size);
+                            let mut storage = TileStorage::empty(size);
 
                             match tileset_definition {
                                 Some(_) => {
@@ -633,7 +633,7 @@ pub fn spawn_level(
                             // This can't be accomplished using LayerBuilder::new_batch,
                             // so the logic for building layers with metadata is slower.
 
-                            let mut storage = Tile2dStorage::empty(size);
+                            let mut storage = TileStorage::empty(size);
 
                             set_all_tiles_with_func(
                                 commands,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,7 @@ mod plugin {
 
     impl Plugin for LdtkPlugin {
         fn build(&self, app: &mut App) {
-            app.add_plugin(bevy_ecs_tilemap::Tilemap2dPlugin)
+            app.add_plugin(bevy_ecs_tilemap::TilemapPlugin)
                 .init_non_send_resource::<app::LdtkEntityMap>()
                 .init_non_send_resource::<app::LdtkIntCellMap>()
                 .init_resource::<resources::LdtkSettings>()

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -219,10 +219,10 @@ fn pre_spawn_level(
         child_builder
             .spawn()
             .insert(level_handle.clone())
-            .insert_bundle((
-                Transform::from_translation(translation),
-                GlobalTransform::default(),
-            ));
+            .insert_bundle(SpatialBundle {
+                transform: Transform::from_translation(translation),
+                ..default()
+            });
     }
 }
 

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -246,7 +246,7 @@ pub fn process_ldtk_levels(
     ldtk_settings: Res<LdtkSettings>,
 ) {
     for (ldtk_entity, level_handle, parent) in level_query.iter() {
-        if let Ok(ldtk_handle) = ldtk_query.get(parent.0) {
+        if let Ok(ldtk_handle) = ldtk_query.get(parent.get()) {
             if let Some(ldtk_asset) = ldtk_assets.get(ldtk_handle) {
                 let tileset_definition_map: HashMap<i32, &TilesetDefinition> = ldtk_asset
                     .project
@@ -290,13 +290,18 @@ pub fn process_ldtk_levels(
 }
 
 pub fn worldly_adoption(
-    mut worldly_query: Query<(&mut Transform, &mut Parent), Added<Worldly>>,
+    mut commands: Commands,
+    mut worldly_query: Query<(&mut Transform, &Parent, Entity), Added<Worldly>>,
     transform_query: Query<(&Transform, &Parent), Without<Worldly>>,
 ) {
-    for (mut transform, mut parent) in worldly_query.iter_mut() {
-        if let Ok((level_transform, level_parent)) = transform_query.get(parent.0) {
+    for (mut transform, parent, entity) in worldly_query.iter_mut() {
+        if let Ok((level_transform, level_parent)) = transform_query.get(parent.get()) {
+            // Find the entity's world-relative transform, so it doesn't move when its parent changes
             *transform = level_transform.mul_transform(*transform);
-            parent.0 = level_parent.0
+            // Make it a child of the world
+            commands
+                .entity(level_parent.get())
+                .add_child(entity);
         }
     }
 }

--- a/src/tile_makers.rs
+++ b/src/tile_makers.rs
@@ -2,7 +2,7 @@
 //!
 //! A tile maker is a function loosely defined with the following signature:
 //! ```ignore
-//! impl FnMut(TilePos2d) -> Option<TileBundle>
+//! impl FnMut(TilePos) -> Option<TileBundle>
 //! ```
 //!
 //! Tile makers can be used with [set_all_tiles_with_func] to spawn many tiles at once.
@@ -15,29 +15,29 @@ use crate::{
 };
 use bevy::prelude::*;
 use bevy_ecs_tilemap::tiles::{
-    TileBundle, TileColor, TileFlip, TilePos2d, TileTexture, TileVisible,
+    TileBundle, TileColor, TileFlip, TilePos, TileTexture, TileVisible,
 };
 
 use std::collections::HashMap;
 
 #[derive(Clone, Eq, PartialEq, Debug, Default, Hash)]
-pub(crate) struct TilePos2dMap<T> {
+pub(crate) struct TilePosMap<T> {
     data: Vec<Vec<Option<T>>>,
 }
 
-impl<T> TilePos2dMap<T> {
+impl<T> TilePosMap<T> {
     fn new() -> Self {
-        TilePos2dMap::<T> { data: Vec::new() }
+        TilePosMap::<T> { data: Vec::new() }
     }
 
-    fn get(&self, tile_pos: &TilePos2d) -> Option<&T> {
+    fn get(&self, tile_pos: &TilePos) -> Option<&T> {
         self.data
             .get(tile_pos.y as usize)?
             .get(tile_pos.x as usize)?
             .as_ref()
     }
 
-    fn set(&mut self, tile_pos: TilePos2d, value: T) {
+    fn set(&mut self, tile_pos: TilePos, value: T) {
         while self.data.get(tile_pos.y as usize).is_none() {
             self.data.push(Vec::new());
         }
@@ -53,9 +53,9 @@ impl<T> TilePos2dMap<T> {
     }
 }
 
-impl<T> FromIterator<(TilePos2d, T)> for TilePos2dMap<T> {
-    fn from_iter<I: IntoIterator<Item = (TilePos2d, T)>>(iter: I) -> Self {
-        let mut tile_pos_map = TilePos2dMap::new();
+impl<T> FromIterator<(TilePos, T)> for TilePosMap<T> {
+    fn from_iter<I: IntoIterator<Item = (TilePos, T)>>(iter: I) -> Self {
+        let mut tile_pos_map = TilePosMap::new();
 
         iter.into_iter().for_each(|(t, v)| tile_pos_map.set(t, v));
 
@@ -67,19 +67,19 @@ impl<T> FromIterator<(TilePos2d, T)> for TilePos2dMap<T> {
 ///
 /// This function doesn't return a tile maker, it IS one,
 /// contrasting many of the other functions in this module.
-pub(crate) fn tile_pos_to_invisible_tile(_: TilePos2d) -> Option<TileBundle> {
+pub(crate) fn tile_pos_to_invisible_tile(_: TilePos) -> Option<TileBundle> {
     Some(TileBundle {
         visible: TileVisible(false),
         ..Default::default()
     })
 }
 
-/// Makes a Hashmap from TilePos2d to intgrid values. Doesn't insert 0s.
+/// Makes a Hashmap from TilePos to intgrid values. Doesn't insert 0s.
 pub(crate) fn tile_pos_to_int_grid_map(
     int_grid_csv: &[i32],
     layer_width_in_tiles: i32,
     layer_height_in_tiles: i32,
-) -> TilePos2dMap<i32> {
+) -> TilePosMap<i32> {
     int_grid_csv.iter().enumerate().filter(|(_, v)| **v != 0).map(|(i, v)| {
         (
             int_grid_index_to_grid_coords(i, layer_width_in_tiles as u32, layer_height_in_tiles as u32).expect("int_grid_csv indices should be within the bounds of 0..(layer_width * layer_height)",).into(),
@@ -95,8 +95,8 @@ pub(crate) fn tile_pos_to_tile_maker(
     grid_tiles: &[TileInstance],
     layer_height_in_tiles: i32,
     layer_grid_size: i32,
-) -> impl FnMut(TilePos2d) -> Option<TileBundle> {
-    let grid_tile_map: TilePos2dMap<TileInstance> = grid_tiles
+) -> impl FnMut(TilePos) -> Option<TileBundle> {
+    let grid_tile_map: TilePosMap<TileInstance> = grid_tiles
         .iter()
         .map(|t| {
             (
@@ -106,7 +106,7 @@ pub(crate) fn tile_pos_to_tile_maker(
         })
         .collect();
 
-    move |tile_pos: TilePos2d| -> Option<TileBundle> {
+    move |tile_pos: TilePos| -> Option<TileBundle> {
         match grid_tile_map.get(&tile_pos) {
             Some(tile_instance) => {
                 let (flip_x, flip_y) = match tile_instance.f {
@@ -137,15 +137,15 @@ pub(crate) fn tile_pos_to_tile_maker(
 ///
 /// Used for spawning IntGrid layers with AutoTile functionality.
 pub(crate) fn tile_pos_to_tile_if_int_grid_nonzero_maker(
-    mut tile_maker: impl FnMut(TilePos2d) -> Option<TileBundle>,
+    mut tile_maker: impl FnMut(TilePos) -> Option<TileBundle>,
     int_grid_csv: &[i32],
     layer_width_in_tiles: i32,
     layer_height_in_tiles: i32,
-) -> impl FnMut(TilePos2d) -> Option<TileBundle> {
+) -> impl FnMut(TilePos) -> Option<TileBundle> {
     let int_grid_map =
         tile_pos_to_int_grid_map(int_grid_csv, layer_width_in_tiles, layer_height_in_tiles);
 
-    move |tile_pos: TilePos2d| -> Option<TileBundle> {
+    move |tile_pos: TilePos| -> Option<TileBundle> {
         int_grid_map
             .get(&tile_pos)
             .and_then(|_| tile_maker(tile_pos))
@@ -164,7 +164,7 @@ pub(crate) fn tile_pos_to_int_grid_with_grid_tiles_tile_maker(
     layer_width_in_tiles: i32,
     layer_height_in_tiles: i32,
     layer_grid_size: i32,
-) -> impl FnMut(TilePos2d) -> Option<TileBundle> {
+) -> impl FnMut(TilePos) -> Option<TileBundle> {
     // Creating the tile makers outside of the returned tile maker so we only do it once.
     let mut auto_tile_maker =
         tile_pos_to_tile_maker(grid_tiles, layer_height_in_tiles, layer_grid_size);
@@ -175,7 +175,7 @@ pub(crate) fn tile_pos_to_int_grid_with_grid_tiles_tile_maker(
         layer_height_in_tiles,
     );
 
-    move |tile_pos: TilePos2d| -> Option<TileBundle> {
+    move |tile_pos: TilePos| -> Option<TileBundle> {
         auto_tile_maker(tile_pos).or_else(|| invisible_tile_maker(tile_pos))
     }
 }
@@ -188,7 +188,7 @@ pub(crate) fn tile_pos_to_int_grid_colored_tile_maker(
     int_grid_value_defs: &[IntGridValueDefinition],
     layer_width_in_tiles: i32,
     layer_height_in_tiles: i32,
-) -> impl FnMut(TilePos2d) -> Option<TileBundle> {
+) -> impl FnMut(TilePos) -> Option<TileBundle> {
     let color_map: HashMap<i32, Color> = int_grid_value_defs
         .iter()
         .map(|IntGridValueDefinition { value, color, .. }| (*value, *color))
@@ -196,7 +196,7 @@ pub(crate) fn tile_pos_to_int_grid_colored_tile_maker(
     let tile_pos_map =
         tile_pos_to_int_grid_map(int_grid_csv, layer_width_in_tiles, layer_height_in_tiles);
 
-    move |tile_pos: TilePos2d| -> Option<TileBundle> {
+    move |tile_pos: TilePos| -> Option<TileBundle> {
         tile_pos_map.get(&tile_pos).map(|&value| TileBundle {
             color: TileColor(
                 *color_map
@@ -213,10 +213,10 @@ pub(crate) fn tile_pos_to_int_grid_colored_tile_maker(
 ///
 /// Used for spawning Tile, AutoTile, and IntGrid layers.
 pub(crate) fn tile_pos_to_transparent_tile_maker(
-    mut tile_maker: impl FnMut(TilePos2d) -> Option<TileBundle>,
+    mut tile_maker: impl FnMut(TilePos) -> Option<TileBundle>,
     alpha: f32,
-) -> impl FnMut(TilePos2d) -> Option<TileBundle> {
-    move |tile_pos: TilePos2d| -> Option<TileBundle> {
+) -> impl FnMut(TilePos) -> Option<TileBundle> {
+    move |tile_pos: TilePos| -> Option<TileBundle> {
         if alpha < 1. {
             tile_maker(tile_pos).map(|mut tile| {
                 tile.color.0.set_a(alpha);
@@ -232,9 +232,9 @@ pub(crate) fn tile_pos_to_transparent_tile_maker(
 ///
 /// Used for spawning Tile, AutoTile, and IntGrid layers.
 pub(crate) fn tile_pos_to_tile_grid_bundle_maker(
-    mut tile_maker: impl FnMut(TilePos2d) -> Option<TileBundle>,
-) -> impl FnMut(TilePos2d) -> Option<TileGridBundle> {
-    move |tile_pos: TilePos2d| -> Option<TileGridBundle> {
+    mut tile_maker: impl FnMut(TilePos) -> Option<TileBundle>,
+) -> impl FnMut(TilePos) -> Option<TileGridBundle> {
+    move |tile_pos: TilePos| -> Option<TileGridBundle> {
         tile_maker(tile_pos).map(|mut tile_bundle| {
             tile_bundle.position = tile_pos;
             TileGridBundle {
@@ -280,10 +280,10 @@ mod tests {
 
         let mut tile_maker = tile_pos_to_tile_maker(&grid_tiles, 2, 32);
 
-        assert_eq!(tile_maker(TilePos2d { x: 0, y: 0 }).unwrap().texture.0, 2);
-        assert_eq!(tile_maker(TilePos2d { x: 1, y: 0 }).unwrap().texture.0, 1);
-        assert_eq!(tile_maker(TilePos2d { x: 0, y: 1 }).unwrap().texture.0, 1);
-        assert_eq!(tile_maker(TilePos2d { x: 1, y: 1 }).unwrap().texture.0, 4);
+        assert_eq!(tile_maker(TilePos { x: 0, y: 0 }).unwrap().texture.0, 2);
+        assert_eq!(tile_maker(TilePos { x: 1, y: 0 }).unwrap().texture.0, 1);
+        assert_eq!(tile_maker(TilePos { x: 0, y: 1 }).unwrap().texture.0, 1);
+        assert_eq!(tile_maker(TilePos { x: 1, y: 1 }).unwrap().texture.0, 4);
     }
 
     #[test]
@@ -321,17 +321,17 @@ mod tests {
 
         let mut tile_maker = tile_pos_to_tile_maker(&grid_tiles, 2, 32);
 
-        assert!(!tile_maker(TilePos2d { x: 0, y: 0 }).unwrap().flip.x);
-        assert!(tile_maker(TilePos2d { x: 0, y: 0 }).unwrap().flip.y);
+        assert!(!tile_maker(TilePos { x: 0, y: 0 }).unwrap().flip.x);
+        assert!(tile_maker(TilePos { x: 0, y: 0 }).unwrap().flip.y);
 
-        assert!(!tile_maker(TilePos2d { x: 0, y: 1 }).unwrap().flip.x);
-        assert!(!tile_maker(TilePos2d { x: 0, y: 1 }).unwrap().flip.y);
+        assert!(!tile_maker(TilePos { x: 0, y: 1 }).unwrap().flip.x);
+        assert!(!tile_maker(TilePos { x: 0, y: 1 }).unwrap().flip.y);
 
-        assert!(tile_maker(TilePos2d { x: 1, y: 1 }).unwrap().flip.x);
-        assert!(!tile_maker(TilePos2d { x: 1, y: 1 }).unwrap().flip.y);
+        assert!(tile_maker(TilePos { x: 1, y: 1 }).unwrap().flip.x);
+        assert!(!tile_maker(TilePos { x: 1, y: 1 }).unwrap().flip.y);
 
-        assert!(tile_maker(TilePos2d { x: 2, y: 1 }).unwrap().flip.x);
-        assert!(tile_maker(TilePos2d { x: 2, y: 1 }).unwrap().flip.y);
+        assert!(tile_maker(TilePos { x: 2, y: 1 }).unwrap().flip.x);
+        assert!(tile_maker(TilePos { x: 2, y: 1 }).unwrap().flip.y);
     }
 
     #[test]
@@ -362,23 +362,23 @@ mod tests {
         let mut tile_maker =
             tile_pos_to_int_grid_with_grid_tiles_tile_maker(&grid_tiles, &int_grid_csv, 2, 2, 32);
 
-        assert_eq!(tile_maker(TilePos2d { x: 0, y: 0 }).unwrap().texture.0, 0);
+        assert_eq!(tile_maker(TilePos { x: 0, y: 0 }).unwrap().texture.0, 0);
         assert_eq!(
-            tile_maker(TilePos2d { x: 0, y: 0 }).unwrap().visible.0,
+            tile_maker(TilePos { x: 0, y: 0 }).unwrap().visible.0,
             false
         );
 
-        assert!(tile_maker(TilePos2d { x: 1, y: 0 }).is_none());
+        assert!(tile_maker(TilePos { x: 1, y: 0 }).is_none());
 
-        assert_eq!(tile_maker(TilePos2d { x: 0, y: 1 }).unwrap().texture.0, 1);
+        assert_eq!(tile_maker(TilePos { x: 0, y: 1 }).unwrap().texture.0, 1);
         assert_eq!(
-            tile_maker(TilePos2d { x: 0, y: 1 }).unwrap().visible.0,
+            tile_maker(TilePos { x: 0, y: 1 }).unwrap().visible.0,
             true
         );
 
-        assert_eq!(tile_maker(TilePos2d { x: 1, y: 1 }).unwrap().texture.0, 2);
+        assert_eq!(tile_maker(TilePos { x: 1, y: 1 }).unwrap().texture.0, 2);
         assert_eq!(
-            tile_maker(TilePos2d { x: 1, y: 1 }).unwrap().visible.0,
+            tile_maker(TilePos { x: 1, y: 1 }).unwrap().visible.0,
             true
         );
     }
@@ -404,13 +404,13 @@ mod tests {
             tile_pos_to_int_grid_colored_tile_maker(&int_grid_csv, &int_grid_defs, 2, 2);
 
         assert_eq!(
-            tile_maker(TilePos2d { x: 0, y: 0 }).unwrap().color.0,
+            tile_maker(TilePos { x: 0, y: 0 }).unwrap().color.0,
             Color::BLUE
         );
-        assert!(tile_maker(TilePos2d { x: 1, y: 0 }).is_none());
-        assert!(tile_maker(TilePos2d { x: 0, y: 1 }).is_none());
+        assert!(tile_maker(TilePos { x: 1, y: 0 }).is_none());
+        assert!(tile_maker(TilePos { x: 0, y: 1 }).is_none());
         assert_eq!(
-            tile_maker(TilePos2d { x: 1, y: 1 }).unwrap().color.0,
+            tile_maker(TilePos { x: 1, y: 1 }).unwrap().color.0,
             Color::RED
         );
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -9,8 +9,8 @@ use crate::{
 use crate::{components::TileGridBundle, ldtk::*};
 use bevy::prelude::*;
 use bevy_ecs_tilemap::{
-    map::{Tilemap2dSize, TilemapId},
-    tiles::{Tile2dStorage, TilePos2d},
+    map::{TilemapSize, TilemapId},
+    tiles::{TileStorage, TilePos},
 };
 
 use std::{collections::HashMap, hash::Hash};
@@ -204,14 +204,14 @@ pub fn ldtk_pixel_coords_to_translation_pivoted(
 /// However, the performance cons of using non-batch methods still apply here.
 pub fn set_all_tiles_with_func(
     commands: &mut Commands,
-    storage: &mut Tile2dStorage,
-    size: Tilemap2dSize,
+    storage: &mut TileStorage,
+    size: TilemapSize,
     tilemap_id: TilemapId,
-    mut func: impl FnMut(TilePos2d) -> Option<TileGridBundle>,
+    mut func: impl FnMut(TilePos) -> Option<TileGridBundle>,
 ) {
     for x in 0..size.x {
         for y in 0..size.y {
-            let tile_pos = TilePos2d { x, y };
+            let tile_pos = TilePos { x, y };
             let tile_entity = func(tile_pos)
                 .map(|tile_bundle| commands.spawn_bundle(tile_bundle).insert(tilemap_id).id());
             storage.set(&tile_pos, tile_entity);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -283,6 +283,7 @@ pub fn sprite_sheet_bundle_from_entity_info(
                 tileset_definition.c_wid as usize,
                 tileset_definition.c_hei as usize,
                 Vec2::splat(tileset_definition.spacing as f32),
+                Vec2::ZERO,
             )),
             sprite: TextureAtlasSprite {
                 index: (tile.y / (tile.h + tileset_definition.spacing)) as usize


### PR DESCRIPTION
I moved the Bevy dependency to 0.8 and the bevy_ecs_tilemap one to 0.7, then started looking for whatever broke. 

~This isn't a complete upgrade and it isn't in proper working condition (the examples still need a Heron bump that isn't out yet, and also I'm still trying to untangle whatever's going on with inherited visibility), but it IS building. And all these changes seem to be things you'd have needed to do anyway, so maybe it'll save you a couple steps.~

This _seems_ to be mostly in proper working order at this point, but the examples (except `basic`) still need updates, including a Heron upgrade that I think isn't out yet. There's also some outstanding cleanup that needs done and warnings that need dealt w/, which you probably already knew about.