### PR TITLE
feat: add `Respawn` component and rework schedule using it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["assets/*", "repo/*", "scripts/*"]
 
 [dependencies]
 bevy_ecs_ldtk_macros = { version = "0.3", optional = true, path = "macros" }
-bevy_ecs_tilemap = { version = "0.7.0" }
+bevy_ecs_tilemap = "0.7"
 bevy = { version = "0.8", default-features = false, features = ["bevy_sprite"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/examples/platformer/main.rs
+++ b/examples/platformer/main.rs
@@ -36,6 +36,7 @@ fn main() {
         .add_system(systems::dbg_player_items)
         .add_system(systems::spawn_ground_sensor)
         .add_system(systems::ground_detection)
+        .add_system(systems::restart_level)
         .register_ldtk_int_cell::<components::WallBundle>(1)
         .register_ldtk_int_cell::<components::LadderBundle>(2)
         .register_ldtk_int_cell::<components::WallBundle>(3)

--- a/examples/platformer/systems.rs
+++ b/examples/platformer/systems.rs
@@ -517,3 +517,15 @@ pub fn ground_detection(
         }
     }
 }
+
+pub fn restart_level(
+    mut commands: Commands,
+    level_query: Query<Entity, With<Handle<LdtkLevel>>>,
+    input: Res<Input<KeyCode>>,
+) {
+    if input.just_pressed(KeyCode::R) {
+        for level_entity in level_query.iter() {
+            commands.entity(level_entity).insert(Respawn);
+        }
+    }
+}

--- a/src/components.rs
+++ b/src/components.rs
@@ -15,7 +15,7 @@ use bevy::prelude::CoreStage;
 #[allow(unused_imports)]
 use crate::{
     assets::LdtkLevel,
-    plugin::LdtkStage,
+    plugin::{LdtkStage, LdtkSystemLabel},
     prelude::{LdtkEntity, LdtkIntCell},
     resources::{LevelSelection, LevelSpawnBehavior},
     utils::ldtk_grid_coords_to_grid_coords,
@@ -44,6 +44,9 @@ pub struct IntGridCell {
 /// If not, [LevelSet] allows you to have more direct control over the levels you spawn.
 ///
 /// Changes to this component are idempotent, so levels won't be respawned greedily.
+///
+/// While not necessary, you can avoid frame delay by updating this component before
+/// [CoreStage::Update], or before [LdtkSystemLabel::LevelSet] within [CoreStage::Update].
 #[derive(Clone, Eq, PartialEq, Debug, Default, Component)]
 pub struct LevelSet {
     pub iids: HashSet<String>,

--- a/src/components.rs
+++ b/src/components.rs
@@ -10,8 +10,12 @@ use std::{
 };
 
 #[allow(unused_imports)]
+use bevy::prelude::CoreStage;
+
+#[allow(unused_imports)]
 use crate::{
     assets::LdtkLevel,
+    plugin::LdtkStage,
     prelude::{LdtkEntity, LdtkIntCell},
     resources::{LevelSelection, LevelSpawnBehavior},
     utils::ldtk_grid_coords_to_grid_coords,
@@ -313,6 +317,16 @@ impl From<&LayerInstance> for LayerMetadata {
     }
 }
 
+/// [Component] that indicates that an LDtk level or world should respawn.
+///
+/// Inserting this component on an entity with either `Handle<LdtkAsset>` or `Handle<LdtkLevel>`
+/// components will cause it to respawn.
+/// This can be used to implement a simple level-restart feature.
+/// Internally, this is used to support the entire level spawning process
+///
+/// **Important:** this must be inserted *before* [LdtkStage::Clean], which occurs immediately
+/// after [CoreStage::Update].
+/// Inserting it during or after this stage is, for now, undefined behavior.
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Default, Hash, Component, Reflect)]
 #[reflect(Component)]
 pub struct Respawn;

--- a/src/components.rs
+++ b/src/components.rs
@@ -15,7 +15,7 @@ use bevy::prelude::CoreStage;
 #[allow(unused_imports)]
 use crate::{
     assets::LdtkLevel,
-    plugin::{LdtkStage, LdtkSystemLabel},
+    plugin::LdtkStage,
     prelude::{LdtkEntity, LdtkIntCell},
     resources::{LevelSelection, LevelSpawnBehavior},
     utils::ldtk_grid_coords_to_grid_coords,
@@ -44,9 +44,6 @@ pub struct IntGridCell {
 /// If not, [LevelSet] allows you to have more direct control over the levels you spawn.
 ///
 /// Changes to this component are idempotent, so levels won't be respawned greedily.
-///
-/// While not necessary, you can avoid frame delay by updating this component before
-/// [CoreStage::Update], or before [LdtkSystemLabel::LevelSet] within [CoreStage::Update].
 #[derive(Clone, Eq, PartialEq, Debug, Default, Component)]
 pub struct LevelSet {
     pub iids: HashSet<String>,
@@ -326,10 +323,6 @@ impl From<&LayerInstance> for LayerMetadata {
 /// components will cause it to respawn.
 /// This can be used to implement a simple level-restart feature.
 /// Internally, this is used to support the entire level spawning process
-///
-/// **Important:** this must be inserted *before* [LdtkStage::Clean], which occurs immediately
-/// after [CoreStage::Update].
-/// Inserting it during or after this stage is, for now, undefined behavior.
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Default, Hash, Component, Reflect)]
 #[reflect(Component)]
 pub struct Respawn;

--- a/src/components.rs
+++ b/src/components.rs
@@ -313,6 +313,10 @@ impl From<&LayerInstance> for LayerMetadata {
     }
 }
 
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Default, Hash, Component, Reflect)]
+#[reflect(Component)]
+pub struct Respawn;
+
 #[derive(Copy, Clone, Debug, Default, Bundle)]
 pub(crate) struct TileGridBundle {
     #[bundle]

--- a/src/components.rs
+++ b/src/components.rs
@@ -10,12 +10,8 @@ use std::{
 };
 
 #[allow(unused_imports)]
-use bevy::prelude::CoreStage;
-
-#[allow(unused_imports)]
 use crate::{
     assets::LdtkLevel,
-    plugin::LdtkStage,
     prelude::{LdtkEntity, LdtkIntCell},
     resources::{LevelSelection, LevelSpawnBehavior},
     utils::ldtk_grid_coords_to_grid_coords,

--- a/src/level.rs
+++ b/src/level.rs
@@ -141,7 +141,7 @@ fn spatial_bundle_for_tiles(
     }
 }
 
-fn insert_tile_spatial_bundles_for_layer(
+fn insert_spatial_bundle_for_layer_tiles(
     commands: &mut Commands,
     storage: &TileStorage,
     size: &TilemapSize,
@@ -652,7 +652,7 @@ pub fn spawn_level(
                             }
                         };
 
-                        insert_tile_spatial_bundles_for_layer(
+                        insert_spatial_bundle_for_layer_tiles(
                             commands,
                             &tilemap_bundle.storage,
                             &tilemap_bundle.size,

--- a/src/level.rs
+++ b/src/level.rs
@@ -225,7 +225,7 @@ pub fn spawn_level(
         let mut layer_z = 0;
 
         // creating an image to use for the background color, and for intgrid colors
-        let mut white_image = Image::new_fill(
+        let white_image = Image::new_fill(
             Extent3d {
                 width: level.px_wid as u32,
                 height: level.px_hei as u32,
@@ -235,8 +235,6 @@ pub fn spawn_level(
             &[255, 255, 255, 255],
             TextureFormat::Rgba8UnormSrgb,
         );
-        white_image.texture_descriptor.usage =
-            TextureUsages::TEXTURE_BINDING | TextureUsages::COPY_SRC | TextureUsages::COPY_DST;
 
         let white_image_handle = images.add(white_image);
 

--- a/src/level.rs
+++ b/src/level.rs
@@ -132,7 +132,6 @@ fn spatial_bundle_for_tiles(
 ) -> SpatialBundle {
     let mut translation =
         grid_coords_to_translation_centered(grid_coords, IVec2::splat(grid_size)).extend(0.);
-
     translation /= layer_scale;
 
     SpatialBundle {
@@ -391,7 +390,10 @@ pub fn spawn_level(
                             x: layer_instance.grid_size as f32,
                             y: layer_instance.grid_size as f32,
                         },
-                        None => TilemapGridSize::default(),
+                        None => TilemapGridSize {
+                            x: tile_size.x,
+                            y: tile_size.y,
+                        },
                     };
 
                     let spacing = match tileset_definition {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,8 +133,11 @@ mod plugin {
         Other,
     }
 
+    /// [StageLabel] for stages added by the plugin.
     #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash, StageLabel)]
     pub enum LdtkStage {
+        /// Occurs immediately after [CoreStage::Update].
+        /// Used for systems relating to [components::Worldly] and [components::Respawn].
         Clean,
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,7 +187,7 @@ mod plugin {
                 )
                 .add_system_to_stage(
                     LdtkStage::Clean,
-                    systems::clean_respawn_entities.label(LdtkSystemLabel::Clean),
+                    systems::clean_respawn_entities.exclusive_system().at_end(),
                 )
                 .add_system_to_stage(
                     CoreStage::PostUpdate,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,22 +168,18 @@ mod plugin {
                     systems::process_ldtk_levels.label(LdtkSystemLabel::LevelSpawning),
                 )
                 .add_system_to_stage(
-                    CoreStage::PreUpdate,
-                    systems::apply_level_selection
-                        .label(LdtkSystemLabel::LevelSelection)
-                        .after(LdtkSystemLabel::LevelSpawning),
-                )
-                .add_system_to_stage(
-                    CoreStage::PreUpdate,
-                    systems::apply_level_set
-                        .label(LdtkSystemLabel::LevelSet)
-                        .after(LdtkSystemLabel::LevelSelection),
+                    LdtkStage::Clean,
+                    systems::worldly_adoption.label(LdtkSystemLabel::Other),
                 )
                 .add_system_to_stage(
                     LdtkStage::Clean,
-                    systems::worldly_adoption
-                        .label(LdtkSystemLabel::Other)
-                        .before(LdtkSystemLabel::Clean),
+                    systems::apply_level_selection.label(LdtkSystemLabel::LevelSelection),
+                )
+                .add_system_to_stage(
+                    LdtkStage::Clean,
+                    systems::apply_level_set
+                        .label(LdtkSystemLabel::LevelSet)
+                        .after(LdtkSystemLabel::LevelSelection),
                 )
                 .add_system_to_stage(
                     LdtkStage::Clean,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,10 +136,7 @@ mod plugin {
     /// [StageLabel] for stages added by the plugin.
     #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash, StageLabel)]
     pub enum LdtkStage {
-        /// Occurs immediately after [CoreStage::Update]
-        /// Used for systems related to [resources::LevelSelection] and [components::LevelSet]
-        LevelSelection,
-        /// Occurs immediately after [LdtkStage::LevelSelection].
+        /// Occurs immediately after [CoreStage::Update].
         /// Used for systems relating to [components::Worldly] and [components::Respawn].
         Clean,
     }
@@ -153,16 +150,7 @@ mod plugin {
     impl Plugin for LdtkPlugin {
         fn build(&self, app: &mut App) {
             app.add_plugin(bevy_ecs_tilemap::TilemapPlugin)
-                .add_stage_after(
-                    CoreStage::Update,
-                    LdtkStage::LevelSelection,
-                    SystemStage::parallel(),
-                )
-                .add_stage_after(
-                    LdtkStage::LevelSelection,
-                    LdtkStage::Clean,
-                    SystemStage::parallel(),
-                )
+                .add_stage_after(CoreStage::Update, LdtkStage::Clean, SystemStage::parallel())
                 .init_non_send_resource::<app::LdtkEntityMap>()
                 .init_non_send_resource::<app::LdtkIntCellMap>()
                 .init_resource::<resources::LdtkSettings>()
@@ -180,11 +168,11 @@ mod plugin {
                     systems::process_ldtk_levels.label(LdtkSystemLabel::LevelSpawning),
                 )
                 .add_system_to_stage(
-                    LdtkStage::LevelSelection,
+                    CoreStage::Update,
                     systems::apply_level_selection.label(LdtkSystemLabel::LevelSelection),
                 )
                 .add_system_to_stage(
-                    LdtkStage::LevelSelection,
+                    CoreStage::Update,
                     systems::apply_level_set
                         .label(LdtkSystemLabel::LevelSet)
                         .after(LdtkSystemLabel::LevelSelection),
@@ -218,7 +206,7 @@ pub mod prelude {
             Respawn, TileEnumTags, TileMetadata, Worldly,
         },
         ldtk::{self, FieldValue, LayerInstance, TilesetDefinition},
-        plugin::LdtkPlugin,
+        plugin::{LdtkPlugin, LdtkSystemLabel},
         resources::{
             IntGridRendering, LdtkSettings, LevelBackground, LevelEvent, LevelSelection,
             LevelSpawnBehavior, SetClearColor,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,7 +219,7 @@ pub mod prelude {
             Respawn, TileEnumTags, TileMetadata, Worldly,
         },
         ldtk::{self, FieldValue, LayerInstance, TilesetDefinition},
-        plugin::{LdtkPlugin, LdtkSystemLabel},
+        plugin::LdtkPlugin,
         resources::{
             IntGridRendering, LdtkSettings, LevelBackground, LevelEvent, LevelSelection,
             LevelSpawnBehavior, SetClearColor,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,22 +168,26 @@ mod plugin {
                     systems::process_ldtk_levels.label(LdtkSystemLabel::LevelSpawning),
                 )
                 .add_system_to_stage(
-                    CoreStage::Update,
-                    systems::apply_level_selection.label(LdtkSystemLabel::LevelSelection),
+                    CoreStage::PreUpdate,
+                    systems::apply_level_selection
+                        .label(LdtkSystemLabel::LevelSelection)
+                        .after(LdtkSystemLabel::LevelSpawning),
                 )
                 .add_system_to_stage(
-                    CoreStage::Update,
+                    CoreStage::PreUpdate,
                     systems::apply_level_set
                         .label(LdtkSystemLabel::LevelSet)
                         .after(LdtkSystemLabel::LevelSelection),
                 )
                 .add_system_to_stage(
                     LdtkStage::Clean,
-                    systems::clean_respawn_entities.label(LdtkSystemLabel::Clean),
+                    systems::worldly_adoption
+                        .label(LdtkSystemLabel::Other)
+                        .before(LdtkSystemLabel::Clean),
                 )
                 .add_system_to_stage(
                     LdtkStage::Clean,
-                    systems::worldly_adoption.label(LdtkSystemLabel::Other),
+                    systems::clean_respawn_entities.label(LdtkSystemLabel::Clean),
                 )
                 .add_system_to_stage(
                     CoreStage::PostUpdate,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,8 +136,10 @@ mod plugin {
     /// [StageLabel] for stages added by the plugin.
     #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash, StageLabel)]
     pub enum LdtkStage {
+        /// Occurs immediately after [CoreStage::Update]
+        /// Used for systems related to [resources::LevelSelection] and [components::LevelSet]
         LevelSelection,
-        /// Occurs immediately after [CoreStage::Update].
+        /// Occurs immediately after [LdtkStage::LevelSelection].
         /// Used for systems relating to [components::Worldly] and [components::Respawn].
         Clean,
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,11 +126,10 @@ mod plugin {
     #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash, SystemLabel)]
     pub enum LdtkSystemLabel {
         ProcessAssets,
-        Clean,
         LevelSelection,
-        PreSpawn,
+        LevelSet,
         LevelSpawning,
-        FrameDelay,
+        Clean,
         Other,
     }
 
@@ -164,7 +163,7 @@ mod plugin {
                 .add_system_to_stage(
                     CoreStage::First,
                     systems::apply_level_set
-                        .label(LdtkSystemLabel::PreSpawn)
+                        .label(LdtkSystemLabel::LevelSet)
                         .after(LdtkSystemLabel::LevelSelection),
                 )
                 .add_system_to_stage(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,7 +129,6 @@ mod plugin {
         LevelSelection,
         LevelSet,
         LevelSpawning,
-        Clean,
         Other,
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,10 +165,6 @@ mod plugin {
                 )
                 .add_system_to_stage(
                     CoreStage::PreUpdate,
-                    systems::set_ldtk_texture_filters_to_nearest.label(LdtkSystemLabel::Other),
-                )
-                .add_system_to_stage(
-                    CoreStage::PreUpdate,
                     systems::worldly_adoption.label(LdtkSystemLabel::Other),
                 )
                 .add_system_to_stage(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,7 +160,7 @@ mod plugin {
                 .add_event::<resources::LevelEvent>()
                 .add_system_to_stage(
                     CoreStage::First,
-                    systems::choose_levels.label(LdtkSystemLabel::LevelSelection),
+                    systems::apply_level_selection.label(LdtkSystemLabel::LevelSelection),
                 )
                 .add_system_to_stage(
                     CoreStage::First,
@@ -202,7 +202,7 @@ pub mod prelude {
         assets::{LdtkAsset, LdtkLevel},
         components::{
             EntityInstance, GridCoords, IntGridCell, LayerMetadata, LdtkWorldBundle, LevelSet,
-            TileEnumTags, TileMetadata, Worldly,
+            Respawn, TileEnumTags, TileMetadata, Worldly,
         },
         ldtk::{self, FieldValue, LayerInstance, TilesetDefinition},
         plugin::LdtkPlugin,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,6 @@ mod plugin {
     //! Provides [LdtkPlugin] and its scheduling-related dependencies.
 
     use super::*;
-    use bevy::asset::AssetStage;
 
     /// [SystemLabel] used by the plugin for scheduling its systems.
     #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash, SystemLabel)]

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -3,7 +3,7 @@
 use crate::ldtk::Level;
 
 #[allow(unused_imports)]
-use bevy::prelude::GlobalTransform;
+use bevy::prelude::{CoreStage, GlobalTransform};
 
 #[allow(unused_imports)]
 use crate::components::{LdtkWorldBundle, LevelSet};
@@ -133,8 +133,6 @@ pub struct LdtkSettings {
 #[derive(Clone, Eq, PartialEq, Debug, Hash)]
 pub enum LevelEvent {
     /// Indicates that a level has been triggered to spawn, but hasn't been spawned yet.
-    ///
-    /// Occurs one update before the level is spawned.
     SpawnTriggered(String),
     /// The level, with all of its layers, entities, etc., has spawned.
     ///
@@ -142,8 +140,8 @@ pub enum LevelEvent {
     /// you want to listen for.
     /// If your systems are [GlobalTransform]-dependent, see [LevelEvent::Transformed].
     Spawned(String),
-    /// Occurs one update after the level has spawned, so all [GlobalTransform]s of the level
-    /// should be updated.
+    /// Occurs during the [CoreStage::PostUpdate] after the level has spawned, so all
+    /// [GlobalTransform]s of the level should be updated.
     Transformed(String),
     /// Indicates that a level has despawned.
     Despawned(String),

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -6,7 +6,10 @@ use crate::ldtk::Level;
 use bevy::prelude::{CoreStage, GlobalTransform};
 
 #[allow(unused_imports)]
-use crate::components::{LdtkWorldBundle, LevelSet};
+use crate::{
+    components::{LdtkWorldBundle, LevelSet},
+    plugin::LdtkSystemLabel,
+};
 
 /// Resource for choosing which level(s) to spawn.
 ///
@@ -16,6 +19,9 @@ use crate::components::{LdtkWorldBundle, LevelSet};
 /// This resource works by updating the [LdtkWorldBundle]'s [LevelSet] component.
 /// If you need more control over the spawned levels than this resource provides,
 /// you can choose not to insert this resource and interface with [LevelSet] directly instead.
+///
+/// While not necessary, you can avoid frame delay by updating this component before
+/// [CoreStage::Update], or before [LdtkSystemLabel::LevelSelection] within [CoreStage::Update].
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub enum LevelSelection {
     /// Spawn level with the given identifier.

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -6,10 +6,7 @@ use crate::ldtk::Level;
 use bevy::prelude::{CoreStage, GlobalTransform};
 
 #[allow(unused_imports)]
-use crate::{
-    components::{LdtkWorldBundle, LevelSet},
-    plugin::LdtkSystemLabel,
-};
+use crate::components::{LdtkWorldBundle, LevelSet};
 
 /// Resource for choosing which level(s) to spawn.
 ///
@@ -19,9 +16,6 @@ use crate::{
 /// This resource works by updating the [LdtkWorldBundle]'s [LevelSet] component.
 /// If you need more control over the spawned levels than this resource provides,
 /// you can choose not to insert this resource and interface with [LevelSet] directly instead.
-///
-/// While not necessary, you can avoid frame delay by updating this component before
-/// [CoreStage::Update], or before [LdtkSystemLabel::LevelSelection] within [CoreStage::Update].
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub enum LevelSelection {
     /// Spawn level with the given identifier.

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -216,14 +216,14 @@ pub fn process_ldtk_levels(
     ldtk_int_cell_map: NonSend<LdtkIntCellMap>,
     ldtk_query: Query<&Handle<LdtkAsset>>,
     level_query: Query<
-        (Entity, &Handle<LdtkLevel>, &Parent),
+        (Entity, &Handle<LdtkLevel>, &Parent, Option<&Respawn>),
         Or<(Added<Handle<LdtkLevel>>, With<Respawn>)>,
     >,
     worldly_query: Query<&Worldly>,
     mut level_events: EventWriter<LevelEvent>,
     ldtk_settings: Res<LdtkSettings>,
 ) {
-    for (ldtk_entity, level_handle, parent) in level_query.iter() {
+    for (ldtk_entity, level_handle, parent, respawn) in level_query.iter() {
         if let Ok(ldtk_handle) = ldtk_query.get(parent.get()) {
             if let Some(ldtk_asset) = ldtk_assets.get(ldtk_handle) {
                 let tileset_definition_map: HashMap<i32, &TilesetDefinition> = ldtk_asset
@@ -261,10 +261,12 @@ pub fn process_ldtk_levels(
                     );
                     level_events.send(LevelEvent::Spawned(level.level.iid.clone()));
                 }
+
+                if respawn.is_some() {
+                    commands.entity(ldtk_entity).remove::<Respawn>();
+                }
             }
         }
-
-        commands.entity(ldtk_entity).remove::<Respawn>();
     }
 }
 

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -64,6 +64,7 @@ pub fn process_ldtk_assets(
     }
 }
 
+/// Updates all LevelSet components according to the LevelSelection
 pub fn apply_level_selection(
     level_selection: Option<Res<LevelSelection>>,
     ldtk_settings: Res<LdtkSettings>,
@@ -104,6 +105,7 @@ pub fn apply_level_selection(
     }
 }
 
+/// Triggers the spawning/despawning of levels according to `LevelSet` values.
 #[allow(clippy::too_many_arguments)]
 pub fn apply_level_set(
     mut commands: Commands,
@@ -251,6 +253,7 @@ pub fn process_ldtk_levels(
     }
 }
 
+/// Performs the "despawning" portion of the respawn process for `Respawn` entities.
 pub fn clean_respawn_entities(
     mut commands: Commands,
     ldtk_worlds_to_clean: Query<&Children, (With<Handle<LdtkAsset>>, With<Respawn>)>,
@@ -271,6 +274,7 @@ pub fn clean_respawn_entities(
     }
 }
 
+/// Implements the functionality for `Worldly` components.
 pub fn worldly_adoption(
     mut commands: Commands,
     mut worldly_query: Query<(&mut Transform, &Parent, Entity), Added<Worldly>>,

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -281,7 +281,7 @@ pub fn clean_respawn_entities(
             commands.entity(*child).despawn_recursive();
 
             if let Ok(level_handle) = other_ldtk_levels.get(*child) {
-                if let Some(level_asset) = level_assets.get(&*level_handle) {
+                if let Some(level_asset) = level_assets.get(level_handle) {
                     level_events.send(LevelEvent::Despawned(level_asset.level.iid.clone()));
                 }
             }

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -64,27 +64,7 @@ pub fn process_ldtk_assets(
     }
 }
 
-pub fn clean_respawn_entities(
-    mut commands: Commands,
-    ldtk_worlds_to_clean: Query<&Children, (With<Handle<LdtkAsset>>, With<Respawn>)>,
-    ldtk_levels_to_clean: Query<Entity, (With<Handle<LdtkLevel>>, With<Respawn>)>,
-    other_ldtk_levels: Query<Entity, (With<Handle<LdtkLevel>>, Without<Respawn>)>,
-) {
-    for world_children in ldtk_worlds_to_clean.iter() {
-        for child in world_children
-            .iter()
-            .filter(|l| other_ldtk_levels.contains(**l))
-        {
-            commands.entity(*child).despawn_recursive();
-        }
-    }
-
-    for level_entity in ldtk_levels_to_clean.iter() {
-        commands.entity(level_entity).despawn_descendants();
-    }
-}
-
-pub fn choose_levels(
+pub fn apply_level_selection(
     level_selection: Option<Res<LevelSelection>>,
     ldtk_settings: Res<LdtkSettings>,
     ldtk_assets: Res<Assets<LdtkAsset>>,
@@ -268,6 +248,26 @@ pub fn process_ldtk_levels(
         }
 
         commands.entity(ldtk_entity).remove::<Respawn>();
+    }
+}
+
+pub fn clean_respawn_entities(
+    mut commands: Commands,
+    ldtk_worlds_to_clean: Query<&Children, (With<Handle<LdtkAsset>>, With<Respawn>)>,
+    ldtk_levels_to_clean: Query<Entity, (With<Handle<LdtkLevel>>, With<Respawn>)>,
+    other_ldtk_levels: Query<Entity, (With<Handle<LdtkLevel>>, Without<Respawn>)>,
+) {
+    for world_children in ldtk_worlds_to_clean.iter() {
+        for child in world_children
+            .iter()
+            .filter(|l| other_ldtk_levels.contains(**l))
+        {
+            commands.entity(*child).despawn_recursive();
+        }
+    }
+
+    for level_entity in ldtk_levels_to_clean.iter() {
+        commands.entity(level_entity).despawn_descendants();
     }
 }
 

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -269,11 +269,12 @@ pub fn clean_respawn_entities(
     ldtk_worlds_to_clean: Query<&Children, (With<Handle<LdtkAsset>>, With<Respawn>)>,
     ldtk_levels_to_clean: Query<Entity, (With<Handle<LdtkLevel>>, With<Respawn>)>,
     other_ldtk_levels: Query<Entity, (With<Handle<LdtkLevel>>, Without<Respawn>)>,
+    worldly_entities: Query<Entity, With<Worldly>>,
 ) {
     for world_children in ldtk_worlds_to_clean.iter() {
         for child in world_children
             .iter()
-            .filter(|l| other_ldtk_levels.contains(**l))
+            .filter(|l| other_ldtk_levels.contains(**l) || worldly_entities.contains(**l))
         {
             commands.entity(*child).despawn_recursive();
         }

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -10,7 +10,7 @@ use crate::{
     utils::*,
 };
 
-use bevy::{prelude::*, render::render_resource::*};
+use bevy::prelude::*;
 use std::collections::{HashMap, HashSet};
 
 pub fn choose_levels(
@@ -298,36 +298,6 @@ pub fn worldly_adoption(
             *transform = level_transform.mul_transform(*transform);
             // Make it a child of the world
             commands.entity(level_parent.get()).add_child(entity);
-        }
-    }
-}
-
-pub fn set_ldtk_texture_filters_to_nearest(
-    mut texture_events: EventReader<AssetEvent<Image>>,
-    mut textures: ResMut<Assets<Image>>,
-    ldtk_assets: Res<Assets<LdtkAsset>>,
-) {
-    // Based on
-    // https://github.com/StarArawn/bevy_ecs_tilemap/blob/main/examples/helpers/texture.rs,
-    // except it only applies to the ldtk tilesets.
-    for event in texture_events.iter() {
-        if let AssetEvent::Created { handle } = event {
-            let mut set_texture_filters_to_nearest = false;
-
-            for (_, ldtk_asset) in ldtk_assets.iter() {
-                if ldtk_asset.tileset_map.iter().any(|(_, v)| v == handle) {
-                    set_texture_filters_to_nearest = true;
-                    break;
-                }
-            }
-
-            if set_texture_filters_to_nearest {
-                if let Some(mut texture) = textures.get_mut(handle) {
-                    texture.texture_descriptor.usage = TextureUsages::TEXTURE_BINDING
-                        | TextureUsages::COPY_SRC
-                        | TextureUsages::COPY_DST;
-                }
-            }
         }
     }
 }

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -20,12 +20,13 @@ pub fn process_ldtk_assets(
     mut ldtk_events: EventReader<AssetEvent<LdtkAsset>>,
     new_ldtks: Query<(Entity, &Handle<LdtkAsset>), Added<Handle<LdtkAsset>>>,
     ldtk_world_query: Query<(Entity, &Handle<LdtkAsset>)>,
+    ldtk_settings: Res<LdtkSettings>,
+    mut clear_color: ResMut<ClearColor>,
+    ldtk_assets: Res<Assets<LdtkAsset>>,
     mut created_assets: Local<HashSet<Handle<LdtkAsset>>>,
 ) {
     let mut ldtk_handles_to_respawn = HashSet::new();
 
-    // This function uses code from the bevy_ecs_tilemap ldtk example
-    // https://github.com/StarArawn/bevy_ecs_tilemap/blob/main/examples/ldtk/ldtk.rs
     for event in ldtk_events.iter() {
         match event {
             AssetEvent::Created { handle } => {
@@ -45,6 +46,15 @@ pub fn process_ldtk_assets(
                     .into_iter()
                     .filter(|changed_handle| *changed_handle != handle)
                     .collect();
+            }
+        }
+    }
+
+    if ldtk_settings.set_clear_color == SetClearColor::FromEditorBackground {
+        for handle in ldtk_handles_to_respawn.iter() {
+            if let Some(ldtk_asset) = ldtk_assets.get(handle) {
+                println!("setting clear color");
+                clear_color.0 = ldtk_asset.project.bg_color;
             }
         }
     }
@@ -93,11 +103,11 @@ pub fn apply_level_selection(
                     };
 
                     if *level_set != new_level_set {
-                        *level_set = new_level_set
-                    }
+                        *level_set = new_level_set;
 
-                    if ldtk_settings.set_clear_color == SetClearColor::FromLevelBackground {
-                        clear_color.0 = level.bg_color;
+                        if ldtk_settings.set_clear_color == SetClearColor::FromLevelBackground {
+                            clear_color.0 = level.bg_color;
+                        }
                     }
                 }
             }

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -291,6 +291,10 @@ pub fn process_ldtk_levels(
 }
 
 /// Performs the "despawning" portion of the respawn process for `Respawn` entities.
+///
+/// This is currently an exclusive system for scheduling purposes.
+/// If we need to revert it to its non-exclusive form, copy it from
+/// 90155a75acb6dea4c97bb92a724b741e693b100d
 pub fn clean_respawn_entities(world: &mut World) {
     let mut system_state: SystemState<(
         Query<&Children, (With<Handle<LdtkAsset>>, With<Respawn>)>,

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -293,9 +293,10 @@ pub fn process_ldtk_levels(
 /// Performs the "despawning" portion of the respawn process for `Respawn` entities.
 ///
 /// This is currently an exclusive system for scheduling purposes.
-/// If we need to revert it to its non-exclusive form, copy it from
+/// If we need to revert it to its non-exclusive form, copy it from commit
 /// 90155a75acb6dea4c97bb92a724b741e693b100d
 pub fn clean_respawn_entities(world: &mut World) {
+    #[allow(clippy::type_complexity)]
     let mut system_state: SystemState<(
         Query<&Children, (With<Handle<LdtkAsset>>, With<Respawn>)>,
         Query<(Entity, &Handle<LdtkLevel>), With<Respawn>>,

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -116,7 +116,7 @@ pub fn apply_level_selection(
 }
 
 /// Triggers the spawning/despawning of levels according to `LevelSet` values.
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::type_complexity)]
 pub fn apply_level_set(
     mut commands: Commands,
     ldtk_world_query: Query<

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -104,17 +104,14 @@ pub fn choose_levels(
                         } = ldtk_settings.level_spawn_behavior
                         {
                             if load_level_neighbors {
-                                level_set
-                                    .iids
-                                    .extend(level.neighbours.iter().map(|n| n.level_iid.clone()));
+                                iids.extend(level.neighbours.iter().map(|n| n.level_iid.clone()));
                             }
                         }
 
                         LevelSet { iids }
                     };
 
-                    if *level_set.as_ref() != new_level_set {
-                        println!("level set updated");
+                    if *level_set != new_level_set {
                         *level_set = new_level_set
                     }
 
@@ -141,7 +138,6 @@ pub fn apply_level_set(
     mut level_events: EventWriter<LevelEvent>,
 ) {
     for (world_entity, level_set, children, ldtk_asset_handle) in ldtk_world_query.iter() {
-        println!("level set applied");
         let mut previous_level_maps = HashMap::new();
         if let Some(children) = children {
             for child in children.iter() {


### PR DESCRIPTION
Closes #96
Closes #108

This is a pretty major change internally. If you're reading this and want to help me out, **please** update your games to this branch and let me know here whether or not there are any issues. I would like this to be the final PR before releasing 0.4, and I would like to release 0.4 very soon.

```toml
bevy_ecs_ldtk = { git = "https://github.com/Trouv/bevy_ecs_ldtk", branch = "feat/respawn" }
```

The scheduling has been completely reworked, and some systems have been significantly changed as a result. However, this is definitely an improvement. Many frame-delay issues are addressed by this rework, and hot reloading works again. This change was assisted by a new `Respawn` component, which can work on world entities and level entities. As a bonus, users can use the `Respawn` component in their games. I imagine this will mostly be used to restart levels.

The main point of this rework is to be more careful about having stage separation between commands-sensitive, order-sensitive systems. If one adds a particular component to entities, and another filters for those additions, there needs to be a stage barrier between them. Most importantly, if one despawns entities, and another spawns similar entities, there needs to be stage barrier between them. This last point was the main cause for a lot of bugs since updating to 0.8 and the `bevy_ecs_tilemap` rewrite.

One drawback here is that there's a new stage between update and post-update: `LdtkStage::Clean`. It's important that this goes before `PostUpdate`, since it despawns `bevy_ecs_tilemap` entities, which need to be further cleaned up in `PostUpdate`. It's also important that this goes after `Update` so that users can use `Respawn` and `Worldly` components without experiencing frame-delay or undefined behavior, and without having to worry about doing anything special with their scheduling. This isn't ideal, but I think it's a small price to pay. Besides, stageless is just around the corner.

## Use cases targeted
- Spawning LdtkWorldBundle in startup system
  - Selecting levels with LevelSelection
  - Selecting levels with LevelSet
- Spawning LdtkWorldBundle in non-startup system (State::on_enter)
  - Selecting levels with LevelSelection
  - Selecting levels with LevelSet
- Spawning LdtkWorldBundle with an **already-loaded** LdtkAsset handle
- Hot reloading levels
- Respawning world with `Respawn` component
- Respawning level with `Respawn` component

## New schedule (updated c5984fded3e875a42d9daa1e238b3ad964ac8a7a)
- Stage PreUpdate
  - LdtkAsset processor system
    - Reads AssetEvent::Modified and adds `Respawn` components to entities with those handles
  - level spawn system
    - For any new placeholder level entities, or any that have `Respawn` components, spawn their contents normally
- Stage LdtkStage::ProcessApi (between update and post update)
  - worldly adoption system
    - Have the grandparents of worldly entities adopt them (no change)
    - Needs to be after Update for frame delay reasons
  - LevelSelection system
    - Updates LevelSet components according to LevelSelection values
    - Needs to be after Update *and* before the LevelSet system for frame delay reasons
  - LevelSet system
    - For any world entities whose LevelSets have changed, or that have `Respawn` components, spawn/despawn placeholder level entities as children accordingly
  - `Respawn` cleanup system
    - Exclusive system at the end of the stage
    - For `Handle<LdtkAsset>` entities with `Respawn` components, despawns all of their children with `Worldly` or `Handle<LdtkLevel>` components
    - For `Handle<LdtkLevel>` entities with `Respawn`components, despawns their descendants.
    - Needs to be after the LevelSet system for frame delay reasons, but before PostUpdate to appease bevy_ecs_tilemap cleanup

## Known issues (to be fixed or promoted)
- When using `Respawn` on a world where a `Worldly` entity has the *only* handle to a particular asset via `#[sprite_bundle(...)]`, that asset unloads.