### PR TITLE
Insert `Name` component into entities spawned by crate

### DIFF
--- a/src/app/ldtk_entity.rs
+++ b/src/app/ldtk_entity.rs
@@ -252,7 +252,8 @@ pub trait LdtkEntity {
     /// registered to the app.
     ///
     /// Note: whether or not the entity is registered to the app, the plugin will insert [Transform],
-    /// [GlobalTransform], and [Parent] components to the entity **after** this bundle is inserted.
+    /// [GlobalTransform], [Name], and [Parent] components to the entity **after** this bundle is
+    /// inserted.
     /// So, any custom implementations of these components within this trait will be overwritten.
     fn bundle_entity(
         entity_instance: &EntityInstance,

--- a/src/level.rs
+++ b/src/level.rs
@@ -350,10 +350,12 @@ pub fn spawn_level(
                                     texture_atlases,
                                 );
 
-                                entity_commands.insert_bundle(SpatialBundle {
-                                    transform,
-                                    ..default()
-                                });
+                                entity_commands
+                                    .insert_bundle(SpatialBundle {
+                                        transform,
+                                        ..default()
+                                    })
+                                    .insert(Name::new(entity_instance.identifier.to_owned()));
                             }
                         }
                     });
@@ -675,7 +677,8 @@ pub fn spawn_level(
                             .insert_bundle(SpatialBundle::from_transform(
                                 Transform::from_translation(layer_offset).with_scale(layer_scale),
                             ))
-                            .insert(LayerMetadata::from(layer_instance));
+                            .insert(LayerMetadata::from(layer_instance))
+                            .insert(Name::new(layer_instance.identifier.to_owned()));
 
                         commands.entity(ldtk_entity).add_child(layer_entity);
 

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -198,7 +198,14 @@ fn pre_spawn_level(
             .insert_bundle(SpatialBundle {
                 transform: Transform::from_translation(translation),
                 ..default()
-            });
+            })
+            .insert(Name::new(
+                ldtk_asset
+                    .get_level(&LevelSelection::Iid(level_iid.to_string()))
+                    .unwrap()
+                    .identifier
+                    .to_owned(),
+            ));
     }
 }
 


### PR DESCRIPTION
This pull request adds the identifier of levels and of layers to the entities spawned by `bevy_ecs_ldtk`.

## Motivation

This makes it a lot easier to see quickly what's going on in the hierarchy, for example with [bevy-inspector-egui](https://github.com/jakobhellermann/bevy-inspector-egui).

## Before

![image](https://user-images.githubusercontent.com/20472367/188124213-115025b3-95e8-4745-a702-e3891e7334be.png)


## After

![image](https://user-images.githubusercontent.com/20472367/188124140-bed134a0-f5fa-4889-84bc-7ff31159b624.png)

