### PR TITLE
refactor: move from bevy_heron to bevy_rapier2d

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,7 +351,7 @@ dependencies = [
  "bevy",
  "bevy_ecs_ldtk_macros",
  "bevy_ecs_tilemap",
- "heron",
+ "bevy_rapier2d",
  "hex",
  "rand",
  "regex",
@@ -577,6 +577,19 @@ name = "bevy_ptr"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d92d5679e89602a18682a37846573dcd1979410179e14204280460ba9fb8713a"
+
+[[package]]
+name = "bevy_rapier2d"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75900b1242f0c590fe102645ba3bde98e6330b623e6fba5ed0c399991dfcdc0"
+dependencies = [
+ "bevy",
+ "bitflags",
+ "log",
+ "nalgebra",
+ "rapier2d",
+]
 
 [[package]]
 name = "bevy_reflect"
@@ -1364,16 +1377,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
-name = "duplicate"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0a4be4cd710e92098de6ad258e6e7c24af11c29c5142f3c6f2a545652480ff8"
-dependencies = [
- "heck",
- "proc-macro-error",
-]
-
-[[package]]
 name = "either"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1748,67 +1751,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "heck"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
-
-[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "heron"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b278c3197344aeb6a7350f548f2b65fee4a582632e5e0766e8c13383744a9ac"
-dependencies = [
- "bevy",
- "cfg_aliases",
- "heron_core",
- "heron_macros",
- "heron_rapier",
-]
-
-[[package]]
-name = "heron_core"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84f8839b0fd32eec6002d629d1606dd644a302b836aa107b0879eba3e7048845"
-dependencies = [
- "bevy",
- "cfg_aliases",
- "duplicate",
- "smallvec",
-]
-
-[[package]]
-name = "heron_macros"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04df4225ffd3fb5db46839127ae818f6b26a308a9c2435197b228a9585fe10da"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
-name = "heron_rapier"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e68bf8d0835cbced961b45d34aa1f4f7857ef4778df8aa4b5ead19ba0f231d"
-dependencies = [
- "bevy",
- "cfg_aliases",
- "crossbeam",
- "fnv",
- "heron_core",
- "rapier2d",
 ]
 
 [[package]]
@@ -2199,6 +2147,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9e0a04ce089f9401aac565c740ed30c46291260f27d4911fdbaa6ca65fa3044"
 dependencies = [
  "approx",
+ "glam",
  "matrixmultiply",
  "nalgebra-macros",
  "num-complex",
@@ -2581,9 +2530,9 @@ dependencies = [
 
 [[package]]
 name = "parry2d"
-version = "0.9.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2841cebc29aaf7c69058b242742853d9b106c5245ed946090a75d941d23a6f5e"
+checksum = "f2451e4bf2c6ba705bf584f94bb51772e22977e37c82575ce2445dd797eb35a9"
 dependencies = [
  "approx",
  "arrayvec",
@@ -2678,30 +2627,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2769,9 +2694,9 @@ checksum = "63e935c45e09cc6dcf00d2f0b2d630a58f4095320223d47fc68918722f0538b6"
 
 [[package]]
 name = "rapier2d"
-version = "0.13.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f7f18a9281f4c4176754437a768e1b7124ce5729060c8743db670f7ebb3c43"
+checksum = "32b1c1ed75065adaf01adb8c46a1dad3922fb28de8225dc981481e3584f3af07"
 dependencies = [
  "approx",
  "arrayvec",
@@ -2977,9 +2902,9 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "simba"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c48e45e5961033db030b56ad67aef22e9c908c493a6e8348c0a0f6b93433cd77"
+checksum = "2f3fd720c48c53cace224ae62bef1bbff363a70c68c4802a78b5cc6159618176"
 dependencies = [
  "approx",
  "num-complex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ thiserror = "1.0"
 
 [dev-dependencies]
 bevy = "0.8"
-heron = { version = "4", features = ["2d"] }
+bevy_rapier2d = { version = "0.18" }
 rand = "0.8"
 
 [features]

--- a/examples/platformer/components.rs
+++ b/examples/platformer/components.rs
@@ -3,52 +3,55 @@ use bevy_ecs_ldtk::{prelude::*, utils::ldtk_pixel_coords_to_translation_pivoted}
 
 use std::collections::HashSet;
 
-use heron::prelude::*;
+use bevy_rapier2d::prelude::*;
 
 #[derive(Clone, Debug, Default, Bundle, LdtkIntCell)]
 pub struct ColliderBundle {
-    pub collider: CollisionShape,
+    pub collider: Collider,
     pub rigid_body: RigidBody,
     pub velocity: Velocity,
-    pub rotation_constraints: RotationConstraints,
-    pub physic_material: PhysicMaterial,
+    pub rotation_constraints: LockedAxes,
+    pub gravity_scale: GravityScale,
+    pub friction: Friction,
+    pub density: ColliderMassProperties,
+}
+
+#[derive(Clone, Debug, Default, Bundle, LdtkIntCell)]
+pub struct SensorBundle {
+    pub collider: Collider,
+    pub sensor: Sensor,
+    pub active_events: ActiveEvents,
+    pub rotation_constraints: LockedAxes,
 }
 
 impl From<EntityInstance> for ColliderBundle {
     fn from(entity_instance: EntityInstance) -> ColliderBundle {
-        let rotation_constraints = RotationConstraints::lock();
+        let rotation_constraints = LockedAxes::ROTATION_LOCKED;
 
         match entity_instance.identifier.as_ref() {
             "Player" => ColliderBundle {
-                collider: CollisionShape::Cuboid {
-                    half_extends: Vec3::new(6., 14., 0.),
-                    border_radius: None,
-                },
+                collider: Collider::cuboid(6., 14.),
                 rigid_body: RigidBody::Dynamic,
+                friction: Friction {
+                    coefficient: 0.0,
+                    combine_rule: CoefficientCombineRule::Min,
+                },
                 rotation_constraints,
                 ..Default::default()
             },
             "Mob" => ColliderBundle {
-                collider: CollisionShape::Cuboid {
-                    half_extends: Vec3::new(5., 5., 0.),
-                    border_radius: None,
-                },
+                collider: Collider::cuboid(5., 5.),
                 rigid_body: RigidBody::KinematicVelocityBased,
                 rotation_constraints,
                 ..Default::default()
             },
             "Chest" => ColliderBundle {
-                collider: CollisionShape::Cuboid {
-                    half_extends: Vec3::new(8., 8., 0.),
-                    border_radius: None,
-                },
+                collider: Collider::cuboid(8., 8.),
                 rigid_body: RigidBody::Dynamic,
                 rotation_constraints,
-                physic_material: PhysicMaterial {
-                    friction: 0.5,
-                    density: 15.0,
-                    ..Default::default()
-                },
+                gravity_scale: GravityScale(1.0),
+                friction: Friction::new(0.5),
+                density: ColliderMassProperties::Density(15.0),
                 ..Default::default()
             },
             _ => ColliderBundle::default(),
@@ -56,22 +59,21 @@ impl From<EntityInstance> for ColliderBundle {
     }
 }
 
-impl From<IntGridCell> for ColliderBundle {
-    fn from(int_grid_cell: IntGridCell) -> ColliderBundle {
-        let rotation_constraints = RotationConstraints::lock();
+impl From<IntGridCell> for SensorBundle {
+    fn from(int_grid_cell: IntGridCell) -> SensorBundle {
+        let rotation_constraints = LockedAxes::ROTATION_LOCKED;
 
+        // ladder
         if int_grid_cell.value == 2 {
-            ColliderBundle {
-                collider: CollisionShape::Cuboid {
-                    half_extends: Vec3::new(8., 8., 0.),
-                    border_radius: None,
-                },
-                rigid_body: RigidBody::Sensor,
+            SensorBundle {
+                collider: Collider::cuboid(8., 8.),
+                sensor: Sensor,
                 rotation_constraints,
+                active_events: ActiveEvents::COLLISION_EVENTS,
                 ..Default::default()
             }
         } else {
-            ColliderBundle::default()
+            SensorBundle::default()
         }
     }
 }
@@ -150,7 +152,7 @@ pub struct Climbable;
 pub struct LadderBundle {
     #[from_int_grid_cell]
     #[bundle]
-    pub collider_bundle: ColliderBundle,
+    pub sensor_bundle: SensorBundle,
     pub climbable: Climbable,
 }
 

--- a/examples/platformer/main.rs
+++ b/examples/platformer/main.rs
@@ -4,7 +4,7 @@
 use bevy::{prelude::*, render::texture::ImageSettings};
 use bevy_ecs_ldtk::prelude::*;
 
-use heron::prelude::*;
+use bevy_rapier2d::prelude::*;
 
 mod components;
 mod systems;
@@ -14,8 +14,11 @@ fn main() {
         .insert_resource(ImageSettings::default_nearest()) // prevents blurry sprites
         .add_plugins(DefaultPlugins)
         .add_plugin(LdtkPlugin)
-        .add_plugin(PhysicsPlugin::default())
-        .insert_resource(Gravity::from(Vec3::new(0.0, -2000., 0.0)))
+        .add_plugin(RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(100.0))
+        .insert_resource(RapierConfiguration {
+            gravity: Vec2::new(0.0, -2000.0),
+            ..Default::default()
+        })
         .insert_resource(LevelSelection::Uid(0))
         .insert_resource(LdtkSettings {
             level_spawn_behavior: LevelSpawnBehavior::UseWorldTranslation {
@@ -25,7 +28,6 @@ fn main() {
             ..Default::default()
         })
         .add_startup_system(systems::setup)
-        .add_system(systems::pause_physics_during_load)
         .add_system(systems::spawn_wall_collision)
         .add_system(systems::movement)
         .add_system(systems::detect_climb_range)


### PR DESCRIPTION
## Summary
The refactor consists of basically two things:
- show use of `bevy_rapier2d` in platformer example
- add `bevy_rapier2d` in cargo file and remove `heron`

For the most part I tried to not change too much of the platformer example. 
There we're some minor things though that came up whith which I had to struggle a bit.

## Notable Details
- rename `CollisionShape` -> `Collider`
- rename `Velocity.linear` -> `Velocity.linvel`
- create `SensorBundle` since there is no `RigidBody::Sensor` in `rapier2d`
- set player friction to `0.0` because the collider kept sticking to the wall when moving against it in air
- add `RapierDebugRenderPlugin` to showcase colliders with gizmos
- `pause_physics_during_load` uses RapierConfiguration now
- add `ExternalForce` to `ColliderBundle` for jumps

## Issues
I noticed that my fix for `pause_physics_during_load` might not work as excepted. Sometimes when building I have to press `R` to reload the level when I want to have the `GroundSensor` working. This might be a loading issue but I didn't find the correct solution yet.