### PR TITLE
With attribute

### DIFF
--- a/macros/src/ldtk_entity.rs
+++ b/macros/src/ldtk_entity.rs
@@ -91,11 +91,11 @@ pub fn expand_ldtk_entity_derive(ast: &syn::DeriveInput) -> proc_macro::TokenStr
             continue;
         }
 
-        let from_path = field
+        let with = field
             .attrs
             .iter()
             .find(|a| *a.path.get_ident().as_ref().unwrap() == WITH_ATTRIBUTE_NAME);
-        if let Some(attribute) = from_path {
+        if let Some(attribute) = with {
             field_constructions.push(expand_with_attribute(attribute, field_name, field_type));
             continue;
         }

--- a/macros/src/ldtk_entity.rs
+++ b/macros/src/ldtk_entity.rs
@@ -228,14 +228,6 @@ fn expand_sprite_sheet_bundle_attribute(
                 Some(syn::NestedMeta::Lit(syn::Lit::Int(asset))) => asset.base10_parse::<usize>().unwrap(),
                 _ => panic!("Eighth argument of #[sprite_sheet_bundle(...)] should be an int")
             };
-            let tx = match nested_iter.next() {
-                Some(syn::NestedMeta::Lit(syn::Lit::Float(asset))) => asset.base10_parse::<f32>().unwrap(),
-                _ => panic!("Ninth argument of #[sprite_sheet_bundle(...)] should be an float")
-            };
-            let ty = match nested_iter.next() {
-                Some(syn::NestedMeta::Lit(syn::Lit::Float(asset))) => asset.base10_parse::<f32>().unwrap(),
-                _ => panic!("Tenth argument of #[sprite_sheet_bundle(...)] should be an float")
-            };
 
             quote! {
                 #field_name: bevy::prelude::SpriteSheetBundle {
@@ -251,7 +243,6 @@ fn expand_sprite_sheet_bundle_attribute(
                         index: #index,
                         ..Default::default()
                     },
-                    transform: Transform::from_xyz(#tx, #ty, 0.0),
                     ..Default::default()
                 },
             }

--- a/macros/src/ldtk_entity.rs
+++ b/macros/src/ldtk_entity.rs
@@ -193,7 +193,7 @@ fn expand_sprite_sheet_bundle_attribute(
         .parse_meta()
         .expect("Cannot parse #[sprite_sheet_bundle...] attribute")
     {
-        syn::Meta::List(syn::MetaList { nested, .. }) if nested.len() == 10 => {
+        syn::Meta::List(syn::MetaList { nested, .. }) if nested.len() == 8 => {
             let mut nested_iter = nested.iter();
 
             let asset_path = &match nested_iter.next() {

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -12,7 +12,8 @@ mod ldtk_int_cell;
         worldly,
         grid_coords,
         ldtk_entity,
-        from_entity_instance
+        from_entity_instance,
+        with
     )
 )]
 pub fn ldtk_entity_derive(input: TokenStream) -> TokenStream {

--- a/src/app/ldtk_entity.rs
+++ b/src/app/ldtk_entity.rs
@@ -242,6 +242,35 @@ use crate::app::register_ldtk_objects::RegisterLdtkObjects;
 ///     entity_instance: EntityInstance,
 /// }
 /// ```
+///
+/// ### `#[with(...)]`
+///
+/// Indicates that this component or bundle should be initialized with the given
+/// function.
+///
+/// Note: The given function should have signature `fn (entity: EntityInstance) -> T`
+/// where `T` is the field type. The function should also be accessible in the scope.
+///
+/// ```no_run
+/// #[derive(Clone, Default, Bundle)]
+/// pub struct InventoryBundle {
+///     pub money: f32,
+/// }
+///
+/// #[derive(Bundle, Default, LdtkEntity)]
+/// pub struct PlayerBundle {
+///     player: Player,
+///     #[with(player_initial_inventory)]
+///     #[bundle]
+///     collider: InventoryBundle,
+/// }
+///
+/// fn player_initial_inventory(_: EntityInstance) -> InventoryBundle {
+///     InventoryBundle {
+///         money: 4.0f
+///     }
+/// }
+/// ```
 pub trait LdtkEntity {
     /// The constructor used by the plugin when spawning entities from an LDtk file.
     /// Has access to resources/assets most commonly used for spawning 2d objects.

--- a/src/app/ldtk_entity.rs
+++ b/src/app/ldtk_entity.rs
@@ -252,14 +252,12 @@ use crate::app::register_ldtk_objects::RegisterLdtkObjects;
 /// where `T` is the field type. The function should also be accessible in the scope.
 ///
 /// ```
-/// use bevy::prelude::*;
-/// use bevy_ecs_ldtk::prelude::*;
-///
-/// #[derive(Component, Default)]
-/// pub struct Player;
-/// #[derive(Component, Default, Clone)]
-/// pub struct Money(f32);
-///
+/// # use bevy::prelude::*;
+/// # use bevy_ecs_ldtk::prelude::*;
+/// # #[derive(Component, Default)]
+/// # pub struct Player;
+/// # #[derive(Component, Default, Clone)]
+/// # pub struct Money(f32);
 /// #[derive(Clone, Default, Bundle)]
 /// pub struct InventoryBundle {
 ///     pub money: Money,

--- a/src/app/ldtk_entity.rs
+++ b/src/app/ldtk_entity.rs
@@ -251,10 +251,18 @@ use crate::app::register_ldtk_objects::RegisterLdtkObjects;
 /// Note: The given function should have signature `fn (entity: EntityInstance) -> T`
 /// where `T` is the field type. The function should also be accessible in the scope.
 ///
-/// ```no_run
+/// ```
+/// use bevy::prelude::*;
+/// use bevy_ecs_ldtk::prelude::*;
+///
+/// #[derive(Component, Default)]
+/// pub struct Player;
+/// #[derive(Component, Default, Clone)]
+/// pub struct Money(f32);
+///
 /// #[derive(Clone, Default, Bundle)]
 /// pub struct InventoryBundle {
-///     pub money: f32,
+///     pub money: Money,
 /// }
 ///
 /// #[derive(Bundle, Default, LdtkEntity)]
@@ -267,7 +275,7 @@ use crate::app::register_ldtk_objects::RegisterLdtkObjects;
 ///
 /// fn player_initial_inventory(_: EntityInstance) -> InventoryBundle {
 ///     InventoryBundle {
-///         money: 4.0f
+///         money: Money(4.0)
 ///     }
 /// }
 /// ```


### PR DESCRIPTION
# Summary

Adds a new attribute to the `LdtkEntity` derive macro named `with`. It allows for bundles to implement custom initializers using a method. This macro takes in a scoped function with signature `(e: EntityInstance) -> T` where T is the field type.

# Example

```rs
pub struct Bundle {
   #[with(foo_initializer)]
    foo: i32;
}

fn foo_initializer(_e: EntityInstance) -> i32 {
    4
}
```

<details>
  <summary>Longer Example</summary>
  
```rs
#[derive(Clone, Default, Bundle)]
pub struct ColliderBundle {
    pub collider: Collider,
    pub rigid_body: RigidBody,
    pub damping: Damping,
    ...
}

#[derive(Bundle, Default, LdtkEntity)]
pub struct PlayerBundle {
    player: Player,
    #[with(player_collider)]
    #[bundle]
    collider: ColliderBundle,
}

fn player_collider(_: EntityInstance) -> ColliderBundle {
    ColliderBundle {
        collider: Collider::capsule(Vec2::new(0., -4.), Vec2::new(0., -12.), 5.),
        rigid_body: RigidBody::Dynamic,
        rotation_constraints: LockedAxes::ROTATION_LOCKED,
        damping: Damping {
            linear_damping: 10.0,
            ..Default::default()
        },
        ..Default::default()
    }
}
```
</details>

# Issue

The same functionality can be done using `from_entity_instance` by filtering the `identifier` to the correct type. However, this could cause function bloat when many entities with different identifiers implement the same bundle. You can have cleaner and safer code separation with this `with(function)` attribute.

# ToDo

- [ ] Ensure type safety of function return; the error messages aren't very good if the function doesn't return the correct type
