### PR TITLE
Upgrade `bevy_ecs_tilemap` to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = ["macros"]
 
 [dependencies]
 bevy_ecs_ldtk_macros = { version = "0.4", optional = true, path = "macros" }
-bevy_ecs_tilemap = "0.7"
+bevy_ecs_tilemap = "0.8"
 bevy = { version = "0.8", default-features = false, features = ["bevy_sprite"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/level.rs
+++ b/src/level.rs
@@ -258,13 +258,13 @@ pub fn spawn_level(
                 .insert_bundle(SpatialBundle::default())
                 .id();
 
-            storage.set(&TilePos::default(), Some(tile_entity));
+            storage.set(&TilePos::default(), tile_entity);
 
             let tile_size = TilemapTileSize {
                 x: level.px_wid as f32,
                 y: level.px_hei as f32,
             };
-            let texture = TilemapTexture(white_image_handle.clone());
+            let texture = TilemapTexture::Single(white_image_handle.clone());
 
             commands
                 .entity(background_entity)
@@ -437,10 +437,10 @@ pub fn spawn_level(
                     .extend(1.);
 
                     let texture = match tileset_definition {
-                        Some(tileset_definition) => TilemapTexture(
+                        Some(tileset_definition) => TilemapTexture::Single(
                             tileset_map.get(&tileset_definition.uid).unwrap().clone(),
                         ),
-                        None => TilemapTexture(white_image_handle.clone()),
+                        None => TilemapTexture::Single(white_image_handle.clone()),
                     };
 
                     let metadata_map: HashMap<i32, TileMetadata> = tileset_definition

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -214,7 +214,10 @@ pub(crate) fn set_all_tiles_with_func(
             let tile_pos = TilePos { x, y };
             let tile_entity = func(tile_pos)
                 .map(|tile_bundle| commands.spawn_bundle(tile_bundle).insert(tilemap_id).id());
-            storage.set(&tile_pos, tile_entity);
+            match tile_entity {
+                Some(tile_entity) => storage.set(&tile_pos, tile_entity),
+                None => storage.remove(&tile_pos),
+            }
         }
     }
 }


### PR DESCRIPTION
I made minimal changes to the code to make it compile. 

I assume `TilemapTexture::Single` is equivalent to the `TilemapTexture` behaviour from 0.7.

Closes https://github.com/Trouv/bevy_ecs_ldtk/issues/121