### PR TITLE
fix!: adjust tile transformations for bevy_ecs_tilemap 0.8 tile position changes

### DIFF
--- a/src/level.rs
+++ b/src/level.rs
@@ -131,7 +131,7 @@ fn spatial_bundle_for_tiles(
     layer_scale: Vec3,
 ) -> SpatialBundle {
     let mut translation =
-        grid_coords_to_translation_centered(grid_coords, IVec2::splat(grid_size)).extend(0.);
+        grid_coords_to_translation(grid_coords, IVec2::splat(grid_size)).extend(0.);
     translation /= layer_scale;
 
     SpatialBundle {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -500,20 +500,20 @@ mod tests {
     }
 
     #[test]
-    fn test_tile_pos_to_translation_centered() {
+    fn test_grid_coords_to_translation() {
         assert_eq!(
-            grid_coords_to_translation_centered(GridCoords::new(1, 2), IVec2::splat(32)),
-            Vec2::new(48., 80.)
+            grid_coords_to_translation(GridCoords::new(1, 2), IVec2::splat(32)),
+            Vec2::new(32., 64.)
         );
 
         assert_eq!(
-            grid_coords_to_translation_centered(GridCoords::new(1, 0), IVec2::splat(100)),
-            Vec2::new(150., 50.)
+            grid_coords_to_translation(GridCoords::new(1, 0), IVec2::splat(100)),
+            Vec2::new(100., 0.)
         );
 
         assert_eq!(
-            grid_coords_to_translation_centered(GridCoords::new(0, 5), IVec2::splat(1)),
-            Vec2::new(0.5, 5.5)
+            grid_coords_to_translation(GridCoords::new(0, 5), IVec2::splat(1)),
+            Vec2::new(0.0, 5.0)
         );
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -486,18 +486,18 @@ mod tests {
     #[test]
     fn test_ldtk_grid_coords_to_translation_centered() {
         assert_eq!(
-            ldtk_grid_coords_to_translation_centered(IVec2::new(1, 1), 4, IVec2::splat(32)),
-            Vec2::new(48., 80.)
+            ldtk_grid_coords_to_translation(IVec2::new(1, 1), 4, IVec2::splat(32)),
+            Vec2::new(32., 64.)
         );
 
         assert_eq!(
-            ldtk_grid_coords_to_translation_centered(IVec2::new(1, 1), 2, IVec2::splat(100)),
-            Vec2::new(150., 50.)
+            ldtk_grid_coords_to_translation(IVec2::new(1, 1), 2, IVec2::splat(100)),
+            Vec2::new(100., 0.)
         );
 
         assert_eq!(
-            ldtk_grid_coords_to_translation_centered(IVec2::new(0, 4), 10, IVec2::splat(1)),
-            Vec2::new(0.5, 5.5)
+            ldtk_grid_coords_to_translation(IVec2::new(0, 4), 10, IVec2::splat(1)),
+            Vec2::new(0., 5.)
         );
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -145,13 +145,13 @@ pub fn translation_to_grid_coords(translation: Vec2, grid_size: IVec2) -> GridCo
 /// Performs [GridCoords] to translation conversion, so that the resulting translation is in the
 /// the center of the tile.
 ///
-/// Assumes that the origin the grid is at [Vec2::ZERO].
+/// Assumes that the center of the origin tile of the grid is at [Vec2::ZERO].
 ///
 /// Internally, this transform is used to place [IntGridCell]s as children of the level.
-pub fn grid_coords_to_translation_centered(grid_coords: GridCoords, tile_size: IVec2) -> Vec2 {
+pub fn grid_coords_to_translation(grid_coords: GridCoords, tile_size: IVec2) -> Vec2 {
     let tile_coords: IVec2 = grid_coords.into();
     let tile_size = tile_size.as_vec2();
-    (tile_size * tile_coords.as_vec2()) + (tile_size / Vec2::splat(2.))
+    tile_size * tile_coords.as_vec2()
 }
 
 /// Performs LDtk pixel coordinate to [GridCoords] conversion.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -167,13 +167,15 @@ pub fn ldtk_pixel_coords_to_grid_coords(
 
 /// Performs LDtk grid coordinate to translation conversion, so that the resulting translation is
 /// in the center of the tile.
-pub fn ldtk_grid_coords_to_translation_centered(
+///
+/// Assumes that the center of the origin tile of the grid is at [Vec2::ZERO].
+pub fn ldtk_grid_coords_to_translation(
     ldtk_coords: IVec2,
     ldtk_grid_height: i32,
     grid_size: IVec2,
 ) -> Vec2 {
     ldtk_pixel_coords_to_translation(ldtk_coords * grid_size, ldtk_grid_height * grid_size.y)
-        + Vec2::new(grid_size.x as f32 / 2., -grid_size.y as f32 / 2.)
+        + Vec2::new(0., -grid_size.y as f32)
 }
 
 /// Performs LDtk pixel coordinate to translation conversion, with "pivot" support.


### PR DESCRIPTION
`bevy_ecs_tilemap` 0.7 anchored tiles to the bottom-left, while 0.8 anchors tiles to the center.

For example, the (0,0) tile used to render the bottom-left pixel of the tile at the origin, but it now renders the *center* of the tile at the origin.

Since `bevy_ecs_ldtk` adds transforms to tiles, the transform logic needed to be adjusted after updating to `bevy_ecs_tilemap` 0.8. This PR performs that update, which introduces a breaking change to some utility functions