### PR TITLE
improve ground detection

### DIFF
--- a/examples/platformer/main.rs
+++ b/examples/platformer/main.rs
@@ -15,6 +15,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugin(LdtkPlugin)
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(100.0))
+        .add_plugin(RapierDebugRenderPlugin::default()) // draws borders around colliders
         .insert_resource(RapierConfiguration {
             gravity: Vec2::new(0.0, -2000.0),
             ..Default::default()
@@ -38,6 +39,7 @@ fn main() {
         .add_system(systems::dbg_player_items)
         .add_system(systems::spawn_ground_sensor)
         .add_system(systems::ground_detection)
+        .add_system(systems::update_on_ground)
         .add_system(systems::restart_level)
         .register_ldtk_int_cell::<components::WallBundle>(1)
         .register_ldtk_int_cell::<components::LadderBundle>(2)

--- a/examples/platformer/main.rs
+++ b/examples/platformer/main.rs
@@ -15,7 +15,6 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugin(LdtkPlugin)
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(100.0))
-        .add_plugin(RapierDebugRenderPlugin::default()) // draws borders around colliders
         .insert_resource(RapierConfiguration {
             gravity: Vec2::new(0.0, -2000.0),
             ..Default::default()


### PR DESCRIPTION
The ground detection was checked every tick,
and the collision event system was always iterating the sensor before the collision events. I'm not sure, but it feels like bad practice.
This PR might be just a personal preference. But it feels to me more readable and better practice/performance.
Thank you for the consideration and any response.

PS: I left the DebugRender in, as recently the grid update shifted the colliders (nicely visible with this plugin). I'm sure somebody is already considering a fix for this.