### PR TITLE
Made pivot the new location of entities spawned in the world

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -84,12 +84,7 @@ pub fn calculate_transform_from_entity_instance(
 
     let size = IVec2::new(entity_instance.width, entity_instance.height);
 
-    let translation = ldtk_pixel_coords_to_translation_pivoted(
-        entity_instance.px,
-        level_height as i32,
-        size,
-        entity_instance.pivot,
-    );
+    let translation = ldtk_coord_conversion(entity_instance.px, level_height as i32).as_vec2();
     let scale = size.as_vec2() / def_size.as_vec2();
 
     Transform::from_translation(translation.extend(z_value)).with_scale(scale.extend(1.))


### PR DESCRIPTION
The size of the visual area for an entity should only be an indicator to the user about how big it will seem, changing the size should not change where the entity spawned. 

This change is how it works in most other engines I've seen deal with it, and I believe it's better to have a defined point which can be seen in the editor to represent the translation of the entity, rather than arbitrarily moving them half way up their *visual* area.