### PR TITLE
feat: Add LevelSet::from_iid

### DIFF
--- a/src/components.rs
+++ b/src/components.rs
@@ -45,6 +45,14 @@ pub struct LevelSet {
     pub iids: HashSet<String>,
 }
 
+impl LevelSet {
+    pub fn from_iid<T: Into<String>>(iid: T) -> Self {
+        let mut iids = HashSet::default();
+        iids.insert(iid.into());
+        Self { iids }
+    }
+}
+
 /// [Component] that indicates that an ldtk entity should be a child of the world, not the level.
 ///
 /// By default, [LdtkEntity]s are children of the level they spawn in.


### PR DESCRIPTION
If you want to spawn multiple levels at once and handle loading unloading yourself (not using global resources), it's useful to be able to do things like this:

```rust
commands.spawn(LdtkWorldBundle {
    ldtk_handle: asset_server.load("levels.ldtk"),
    level_set: LevelSet::from_iid("58e02ac0-5110-11ed-b070-cdccc74eaccd"),
    ..default()
})
```