### PR TITLE
feat: Register types `GridCoords` and `LayerMetadata`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,7 +206,9 @@ mod plugin {
                 systems::detect_level_spawned_events
                     .pipe(systems::fire_level_transformed_events)
                     .label(LdtkSystemLabel::Other),
-            );
+            )
+            .register_type::<GridCoords>()
+            .register_type::<LayerMetadata>();
         }
     }
 }


### PR DESCRIPTION
Types need to be registered for `bevy-inspector-egui` (and other tools) to know about them. Do it in the plugin so it's convenient for users.