### PR TITLE
example/improve-spawn_wall_collision

### DIFF
--- a/examples/platformer/systems.rs
+++ b/examples/platformer/systems.rs
@@ -84,14 +84,13 @@ pub fn spawn_wall_collision(
 ) {
     /// Represents a wide wall that is 1 tile tall
     /// Used to spawn wall collisions
-    #[derive(Copy, Clone, Eq, PartialEq, Debug, Default, Hash)]
+    #[derive(Clone, Eq, PartialEq, Debug, Default, Hash)]
     struct Plate {
         left: i32,
         right: i32,
     }
 
     /// A simple rectangle type representing a wall of any size
-    #[derive(Copy, Clone, Eq, PartialEq, Debug, Default, Hash)]
     struct Rect {
         left: i32,
         right: i32,
@@ -115,7 +114,7 @@ pub fn spawn_wall_collision(
         if let Ok(grandparent) = parent_query.get(parent.get()) {
             level_to_wall_locations
                 .entry(grandparent.get())
-                .or_insert(HashSet::new())
+                .or_default()
                 .insert(grid_coords);
         }
     });

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -86,7 +86,7 @@ pub fn calculate_transform_from_entity_instance(
 
     let translation = ldtk_pixel_coords_to_translation_pivoted(
         entity_instance.px,
-        level_height as i32,
+        level_height,
         size,
         entity_instance.pivot,
     );


### PR DESCRIPTION
I thought that this part of the collision builder was unnecessarily complicated and I didn't like that it is creating new HashMaps on every row. I tried to measure the the difference with std::time::Instant, but turns out the difference is in microseconds, not much improvement in time. But I still decided to submit this PR because I think it is a slight improvement.
What do you think?