### PR TITLE
docs: repair doc links to bevy in app module

### DIFF
--- a/src/app/ldtk_entity.rs
+++ b/src/app/ldtk_entity.rs
@@ -9,6 +9,10 @@ use std::{collections::HashMap, marker::PhantomData};
 #[allow(unused_imports)]
 use crate::app::register_ldtk_objects::RegisterLdtkObjects;
 
+/// [Bundle]: bevy::prelude::Bundle
+/// [App]: bevy::prelude::App
+/// [Component]: bevy::prelude::Component
+///
 /// Provides a constructor which can be used for spawning entities from an LDtk file.
 ///
 /// After implementing this trait on a [Bundle], you can register it to spawn automatically for a
@@ -282,14 +286,14 @@ use crate::app::register_ldtk_objects::RegisterLdtkObjects;
 pub trait LdtkEntity {
     /// The constructor used by the plugin when spawning entities from an LDtk file.
     /// Has access to resources/assets most commonly used for spawning 2d objects.
-    /// If you need access to more of the [World], you can create a system that queries for
+    /// If you need access to more of the [World](bevy::prelude::World), you can create a system that queries for
     /// `Added<EntityInstance>`, and flesh out the entity from there, instead of implementing this
     /// trait.
     /// This is because the plugin spawns an entity with an [EntityInstance] component if it's not
     /// registered to the app.
     ///
-    /// Note: whether or not the entity is registered to the app, the plugin will insert [Transform],
-    /// [GlobalTransform], [Name], and [Parent] components to the entity **after** this bundle is
+    /// Note: whether or not the entity is registered to the app, the plugin will insert a
+    /// [SpatialBundle](bevy::prelude::SpatialBundle) to the entity **after** this bundle is
     /// inserted.
     /// So, any custom implementations of these components within this trait will be overwritten.
     fn bundle_entity(

--- a/src/app/ldtk_int_cell.rs
+++ b/src/app/ldtk_int_cell.rs
@@ -5,9 +5,10 @@ use crate::{
 use bevy::{ecs::system::EntityCommands, prelude::*};
 use std::{collections::HashMap, marker::PhantomData};
 
-#[allow(unused_imports)]
-use crate::app::register_ldtk_objects::RegisterLdtkObjects;
-
+/// [Bundle]: bevy::prelude::Bundle
+/// [App]: bevy::prelude::App
+/// [Component]: bevy::prelude::Component
+///
 /// Provides a constructor which can be used for spawning additional components on IntGrid tiles.
 ///
 /// After implementing this trait on a [Bundle], you can register it to spawn automatically for a
@@ -125,14 +126,15 @@ use crate::app::register_ldtk_objects::RegisterLdtkObjects;
 /// ```
 pub trait LdtkIntCell {
     /// The constructor used by the plugin when spawning additional components on IntGrid tiles.
-    /// If you need access to more of the [World], you can create a system that queries for
+    /// If you need access to more of the [World](bevy::prelude::World), you can create a system that queries for
     /// `Added<IntGridCell>`, and flesh out the entity from there, instead of implementing this
     /// trait.
     /// This is because the plugin spawns a tile with an [IntGridCell] component if the tile's
     /// value is not registered to the app.
     ///
-    /// Note: whether or not the entity is registered to the app, the plugin will insert [Transform],
-    /// [GlobalTransform], and [Parent] components to the entity **after** this bundle is inserted.
+    /// Note: whether or not the entity is registered to the app, the plugin will insert a
+    /// [SpatialBundle](bevy::prelude::SpatialBundle) to the entity **after** this bundle is
+    /// inserted.
     /// So, any custom implementations of these components within this trait will be overwritten.
     /// Furthermore, a [bevy_ecs_tilemap::tiles::TileBundle] will be inserted **before** this bundle, so
     /// be careful not to overwrite the components provided by that bundle.


### PR DESCRIPTION
This updates docs to use full paths to external documentation instead of depending on the module's imports. I'm not 100% sure this will work, these links have always worked locally so it's hard to tell what will and won't work on docs.rs. However, I've seen documentation linked like this in `iyes_loopless` [here](https://docs.rs/iyes_loopless/latest/src/iyes_loopless/condition.rs.html#211). In that case, it linked to a bevy subcrate and not a prelude. I could see the indirection of linking to `bevy::prelude` causing problems here too, but I think it's worth a shot.