### PR TITLE
Spawn hook

### DIFF
--- a/examples/custom_spawn.rs
+++ b/examples/custom_spawn.rs
@@ -1,0 +1,73 @@
+use bevy::prelude::*;
+use bevy_ecs_ldtk::{prelude::*, spawn::*};
+
+fn main() {
+    App::new()
+        .add_plugins(
+            DefaultPlugins.set(ImagePlugin::default_nearest()), // prevents blurry sprites
+        )
+        .add_plugin(LdtkPluginWithSpawnHook(registy))
+        .add_startup_system(setup)
+        .insert_resource(LevelSelection::Index(0))
+        .run();
+}
+
+fn registy() -> impl SpawnHook {
+    Registry::default()
+        .register_default_ldtk_int_cell(default_int_cell)
+        .register_ldtk_entity_spawner(
+            CustomEntitySpawner
+                .create()
+                .register_ldtk_entity::<ViaLdtkEntity<MyBundle>>("MyEntityIdentifier"),
+        )
+}
+
+fn default_int_cell(In(input): In<IntCellInput>) -> IntGridCell {
+    println!("Int Cell");
+    input.int_grid_cell
+}
+
+struct CustomEntitySpawner;
+
+impl SpawnFunction for CustomEntitySpawner {
+    type Param<'w, 's> = ();
+
+    type SpawnerType = EntitySpawnerType;
+
+    type Input<'a> = EntityInput<'a>;
+
+    fn spawn(
+        &mut self,
+        input: <Self::SpawnerType as SpawnerType>::Input<'_>,
+        commands: &mut bevy::ecs::system::EntityCommands,
+        caster: &dyn Caster<Self>,
+        _: (),
+    ) {
+        println!("Hello Entity");
+        caster.cast_and_insert(input, commands)
+    }
+}
+
+fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+    commands.spawn(Camera2dBundle::default());
+
+    commands.spawn(LdtkWorldBundle {
+        ldtk_handle: asset_server.load("my_project.ldtk"),
+        ..Default::default()
+    });
+}
+
+#[derive(Default, Component)]
+struct ComponentA;
+
+#[derive(Default, Component)]
+struct ComponentB;
+
+#[derive(Bundle, LdtkEntity)]
+pub struct MyBundle {
+    a: ComponentA,
+    b: ComponentB,
+    #[sprite_sheet_bundle]
+    #[bundle]
+    sprite_bundle: SpriteSheetBundle,
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4,8 +4,10 @@ mod entity_app_ext;
 mod int_cell_app_ext;
 mod ldtk_entity;
 mod ldtk_int_cell;
+mod spawn;
 
 pub use entity_app_ext::*;
 pub use int_cell_app_ext::*;
 pub use ldtk_entity::*;
 pub use ldtk_int_cell::*;
+pub use spawn::*;

--- a/src/app/spawn.rs
+++ b/src/app/spawn.rs
@@ -1,0 +1,108 @@
+use bevy::{
+    ecs::system::{EntityCommands, SystemParam, SystemParamFetch},
+    prelude::{AssetServer, Assets, Handle, Image, NonSend},
+    sprite::TextureAtlas,
+};
+
+use crate::{
+    prelude::{LayerInstance, TilesetDefinition},
+    utils::ldtk_map_get_or_default,
+    EntityInstance, EntityInstanceBundle, IntGridCell, IntGridCellBundle,
+};
+
+use super::{
+    LdtkEntityMap, LdtkIntCellMap, PhantomLdtkEntity, PhantomLdtkEntityTrait, PhantomLdtkIntCell,
+    PhantomLdtkIntCellTrait,
+};
+
+pub struct EntityInput<'a> {
+    pub entity_instance: &'a EntityInstance,
+    pub tileset: Option<&'a Handle<Image>>,
+    pub tileset_definition: Option<&'a TilesetDefinition>,
+    pub context: SpawnContext<'a>,
+}
+
+pub struct IntCellInput<'a> {
+    pub int_grid_cell: IntGridCell,
+    pub context: SpawnContext<'a>,
+}
+
+pub struct SpawnContext<'a> {
+    pub layer_instance: &'a LayerInstance,
+    pub asset_server: &'a AssetServer,
+    pub texture_atlases: &'a mut Assets<TextureAtlas>,
+}
+
+pub trait SpawnHook: Send + Sync + 'static {
+    type Param<'w, 's>: SystemParam;
+
+    fn spawn_entity(
+        &mut self,
+        commands: &mut EntityCommands,
+        input: EntityInput,
+        param_value: &mut <<Self::Param<'_, '_> as SystemParam>::Fetch as SystemParamFetch<
+            '_,
+            '_,
+        >>::Item,
+    );
+
+    fn spawn_int_cell(
+        &mut self,
+        commands: &mut EntityCommands,
+        input: IntCellInput,
+        param_value: &mut <<Self::Param<'_, '_> as SystemParam>::Fetch as SystemParamFetch<
+            '_,
+            '_,
+        >>::Item,
+    );
+}
+
+pub struct DefaultSpawnHook;
+
+impl SpawnHook for DefaultSpawnHook {
+    type Param<'w, 's> = (NonSend<'w, LdtkEntityMap>, NonSend<'w, LdtkIntCellMap>);
+
+    fn spawn_entity(
+        &mut self,
+        commands: &mut EntityCommands,
+        input: EntityInput,
+        (ldtk_entity_map, _): &mut (NonSend<LdtkEntityMap>, NonSend<LdtkIntCellMap>),
+    ) {
+        let default_ldtk_entity: Box<dyn PhantomLdtkEntityTrait> =
+            Box::new(PhantomLdtkEntity::<EntityInstanceBundle>::new());
+
+        ldtk_map_get_or_default(
+            input.context.layer_instance.identifier.clone(),
+            input.entity_instance.identifier.clone(),
+            &default_ldtk_entity,
+            ldtk_entity_map,
+        )
+        .evaluate(
+            commands,
+            input.entity_instance,
+            input.context.layer_instance,
+            input.tileset,
+            input.tileset_definition,
+            input.context.asset_server,
+            input.context.texture_atlases,
+        );
+    }
+
+    fn spawn_int_cell(
+        &mut self,
+        commands: &mut EntityCommands,
+        input: IntCellInput,
+        (_, ldtk_int_cell_map): &mut (NonSend<LdtkEntityMap>, NonSend<LdtkIntCellMap>),
+    ) {
+        let default_ldtk_int_cell: Box<dyn PhantomLdtkIntCellTrait> =
+            Box::new(PhantomLdtkIntCell::<IntGridCellBundle>::new());
+
+        ldtk_map_get_or_default(
+            input.context.layer_instance.identifier.clone(),
+            input.int_grid_cell.value,
+            &default_ldtk_int_cell,
+            ldtk_int_cell_map,
+        )
+        .evaluate(commands, input.int_grid_cell, input.context.layer_instance);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,6 +105,7 @@ mod components;
 pub mod ldtk;
 mod level;
 mod resources;
+pub mod spawn;
 pub mod systems;
 mod tile_makers;
 pub mod utils;

--- a/src/spawn/caster.rs
+++ b/src/spawn/caster.rs
@@ -1,0 +1,27 @@
+use std::marker::PhantomData;
+
+use bevy::{ecs::system::EntityCommands, prelude::Bundle};
+
+use super::SpawnFunction;
+
+pub trait Caster<S: SpawnFunction>: Send + Sync + 'static {
+    fn cast_and_insert(&self, input: S::Input<'_>, commands: &mut EntityCommands);
+}
+
+pub struct PhantomCaster<S: SpawnFunction, T>(PhantomData<(S, T)>);
+
+impl<S: SpawnFunction, T> Default for PhantomCaster<S, T> {
+    fn default() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<S: SpawnFunction, T> Caster<S> for PhantomCaster<S, T>
+where
+    T: Bundle,
+    for<'a> S::Input<'a>: Into<T>,
+{
+    fn cast_and_insert(&self, value: S::Input<'_>, commands: &mut EntityCommands) {
+        commands.insert(value.into());
+    }
+}

--- a/src/spawn/collection.rs
+++ b/src/spawn/collection.rs
@@ -1,0 +1,133 @@
+use bevy::{
+    ecs::system::{EntityCommands, SystemParam, SystemParamFetch, SystemParamItem},
+    prelude::{Bundle, ParamSet, SystemParamFunction},
+};
+
+use super::{SpawnFunction, SpawnSystemFunction, Spawner, SpawnerType};
+
+pub trait SpawnerCollection<In: SpawnerType> {
+    type Param<'w, 's>: SystemParam;
+
+    const SIZE: usize;
+
+    fn spawn(
+        &mut self,
+        spawner_index: usize,
+        entry_index: usize,
+        input: In::Input<'_>,
+        commands: &mut EntityCommands,
+        param_value: <<Self::Param<'_, '_> as SystemParam>::Fetch as SystemParamFetch<'_, '_>>::Item,
+    );
+}
+
+impl<In: SpawnerType, A: SpawnerCollection<In>, B: SpawnerCollection<In>> SpawnerCollection<In>
+    for (A, B)
+{
+    type Param<'w, 's> = ParamSet<
+        'w,
+        's,
+        (
+            SystemParamItem<'w, 's, A::Param<'w, 's>>,
+            SystemParamItem<'w, 's, B::Param<'w, 's>>,
+        ),
+    >;
+
+    const SIZE: usize = A::SIZE + B::SIZE;
+
+    fn spawn(
+        &mut self,
+        spawner_index: usize,
+        entry_index: usize,
+        input: In::Input<'_>,
+        commands: &mut EntityCommands,
+        mut param_value: <<Self::Param<'_, '_> as SystemParam>::Fetch as SystemParamFetch<
+            '_,
+            '_,
+        >>::Item,
+    ) {
+        if spawner_index < A::SIZE {
+            self.0.spawn(
+                spawner_index,
+                entry_index,
+                input,
+                commands,
+                param_value.p0(),
+            );
+        } else {
+            self.1.spawn(
+                spawner_index - A::SIZE,
+                entry_index,
+                input,
+                commands,
+                param_value.p1(),
+            );
+        }
+    }
+}
+
+impl<F: SpawnFunction> SpawnerCollection<F::SpawnerType> for Spawner<F> {
+    type Param<'w, 's> = F::Param<'w, 's>;
+
+    const SIZE: usize = 1;
+
+    fn spawn(
+        &mut self,
+        _: usize,
+        entry_index: usize,
+        input: <F::SpawnerType as SpawnerType>::Input<'_>,
+        commands: &mut EntityCommands,
+        param_value: <<Self::Param<'_, '_> as SystemParam>::Fetch as SystemParamFetch<
+            '_,
+            '_,
+        >>::Item,
+    ) {
+        self.system.spawn(
+            input,
+            commands,
+            self.casters[entry_index].as_ref(),
+            param_value,
+        );
+    }
+}
+
+pub struct EmptyCollection;
+
+impl<
+        Type: SpawnerType,
+        Out: Bundle,
+        Param: SystemParam,
+        Marker,
+        F: for<'a> SystemParamFunction<Type::Input<'a>, Out, Param, Marker>,
+    > SpawnerCollection<Type> for SpawnSystemFunction<Type, Out, Param, Marker, F>
+{
+    type Param<'w, 's> = Param;
+
+    const SIZE: usize = 1;
+
+    fn spawn(
+        &mut self,
+        _: usize,
+        _: usize,
+        input: <Type as SpawnerType>::Input<'_>,
+        commands: &mut EntityCommands,
+        param_value: <<Self::Param<'_, '_> as SystemParam>::Fetch as SystemParamFetch<'_, '_>>::Item,
+    ) {
+        commands.insert(self.get_mut().run(input, param_value));
+    }
+}
+
+impl<Type: SpawnerType> SpawnerCollection<Type> for EmptyCollection {
+    type Param<'w, 's> = ();
+
+    const SIZE: usize = 0;
+
+    fn spawn(
+        &mut self,
+        _: usize,
+        _: usize,
+        _: Type::Input<'_>,
+        _: &mut EntityCommands,
+        _: <<Self::Param<'_, '_> as SystemParam>::Fetch as SystemParamFetch<'_, '_>>::Item,
+    ) {
+    }
+}

--- a/src/spawn/entity.rs
+++ b/src/spawn/entity.rs
@@ -1,0 +1,103 @@
+use bevy::{ecs::system::EntityCommands, prelude::Bundle};
+
+use crate::{app::EntityInput, prelude::LdtkEntity};
+
+use super::{Caster, SpawnFunction, Spawner, SpawnerType};
+
+pub struct EntitySpawnerType;
+
+impl SpawnerType for EntitySpawnerType {
+    type Input<'a> = EntityInput<'a>;
+    type Selector = (Option<String>, Option<String>);
+}
+
+impl<F: SpawnFunction<SpawnerType = EntitySpawnerType>> Spawner<F> {
+    pub fn register_default_ldtk_entity<T: Bundle>(self) -> Self
+    where
+        for<'a> F::Input<'a>: Into<T>,
+    {
+        self.register_ldtk_entity_for_layer_optional::<T>(None, None)
+    }
+
+    pub fn register_default_ldtk_entity_for_layer<T: Bundle>(
+        self,
+        layer_identifier: impl Into<String>,
+    ) -> Self
+    where
+        for<'a> F::Input<'a>: Into<T>,
+    {
+        self.register_ldtk_entity_for_layer_optional::<T>(Some(layer_identifier.into()), None)
+    }
+
+    pub fn register_ldtk_entity<T: Bundle>(self, entity_identifier: impl Into<String>) -> Self
+    where
+        for<'a> F::Input<'a>: Into<T>,
+    {
+        self.register_ldtk_entity_for_layer_optional::<T>(None, Some(entity_identifier.into()))
+    }
+
+    pub fn register_ldtk_entity_for_layer<T: Bundle>(
+        self,
+        layer_identifier: impl Into<String>,
+        entity_identifier: impl Into<String>,
+    ) -> Self
+    where
+        for<'a> F::Input<'a>: Into<T>,
+    {
+        self.register_ldtk_entity_for_layer_optional::<T>(
+            Some(layer_identifier.into()),
+            Some(entity_identifier.into()),
+        )
+    }
+
+    pub fn register_ldtk_entity_for_layer_optional<T: Bundle>(
+        self,
+        layer_identifier: Option<String>,
+        entity_identifier: Option<String>,
+    ) -> Self
+    where
+        for<'a> F::Input<'a>: Into<T>,
+    {
+        self.add::<T>((layer_identifier, entity_identifier))
+    }
+}
+
+pub struct DefaultEntitySpawner;
+
+impl SpawnFunction for DefaultEntitySpawner {
+    type Param<'w, 's> = ();
+
+    type SpawnerType = EntitySpawnerType;
+
+    type Input<'a> = EntityInput<'a>;
+
+    fn spawn(
+        &mut self,
+        input: EntityInput,
+        commands: &mut EntityCommands,
+        caster: &dyn Caster<Self>,
+        _: (),
+    ) {
+        caster.cast_and_insert(input, commands)
+    }
+}
+
+#[derive(Bundle)]
+pub struct ViaLdtkEntity<T: Bundle> {
+    pub inner: T,
+}
+
+impl<'a, T: LdtkEntity + Bundle> From<EntityInput<'a>> for ViaLdtkEntity<T> {
+    fn from(value: EntityInput<'a>) -> ViaLdtkEntity<T> {
+        ViaLdtkEntity {
+            inner: T::bundle_entity(
+                value.entity_instance,
+                value.context.layer_instance,
+                value.tileset,
+                value.tileset_definition,
+                value.context.asset_server,
+                value.context.texture_atlases,
+            ),
+        }
+    }
+}

--- a/src/spawn/function.rs
+++ b/src/spawn/function.rs
@@ -1,0 +1,57 @@
+use std::marker::PhantomData;
+
+use bevy::{
+    ecs::system::{EntityCommands, SystemParam, SystemParamFetch},
+    prelude::SystemParamFunction,
+};
+
+use super::{Caster, Spawner, SpawnerType};
+
+pub trait SpawnFunction: Send + Sync + 'static {
+    type Param<'w, 's>: SystemParam;
+    type SpawnerType: SpawnerType;
+    type Input<'a>;
+
+    fn spawn(
+        &mut self,
+        input: <Self::SpawnerType as SpawnerType>::Input<'_>,
+        commands: &mut EntityCommands,
+        caster: &dyn Caster<Self>,
+        param_value: <<Self::Param<'_, '_> as SystemParam>::Fetch as SystemParamFetch<
+            '_,
+            '_,
+        >>::Item,
+    );
+
+    fn create(self) -> Spawner<Self>
+    where
+        Self: Sized,
+    {
+        Spawner::new(self)
+    }
+}
+
+pub struct SpawnSystemFunction<
+    Type: SpawnerType,
+    Out,
+    Param: SystemParam,
+    Marker,
+    F: for<'a> SystemParamFunction<Type::Input<'a>, Out, Param, Marker>,
+>(F, PhantomData<fn(Type, Out, Param, Marker)>);
+
+impl<
+        Type: SpawnerType,
+        Out,
+        Param: SystemParam,
+        Marker,
+        F: for<'a> SystemParamFunction<Type::Input<'a>, Out, Param, Marker>,
+    > SpawnSystemFunction<Type, Out, Param, Marker, F>
+{
+    pub fn new(f: F) -> Self {
+        Self(f, PhantomData)
+    }
+
+    pub fn get_mut(&mut self) -> &mut F {
+        &mut self.0
+    }
+}

--- a/src/spawn/int_cell.rs
+++ b/src/spawn/int_cell.rs
@@ -1,0 +1,115 @@
+use bevy::{ecs::system::EntityCommands, prelude::Bundle};
+
+use crate::{
+    app::{IntCellInput, SpawnContext},
+    prelude::LdtkIntCell,
+};
+
+use super::{Caster, SpawnFunction, Spawner, SpawnerType};
+
+impl<'a> AsRef<SpawnContext<'a>> for IntCellInput<'a> {
+    fn as_ref(&self) -> &SpawnContext<'a> {
+        &self.context
+    }
+}
+
+pub struct IntCellSpawnerType;
+
+impl SpawnerType for IntCellSpawnerType {
+    type Input<'a> = IntCellInput<'a>;
+    type Selector = (Option<String>, Option<i32>);
+}
+
+pub struct DefaultIntCellSpawner;
+
+impl SpawnFunction for DefaultIntCellSpawner {
+    type Param<'w, 's> = ();
+
+    type SpawnerType = IntCellSpawnerType;
+
+    type Input<'a> = IntCellInput<'a>;
+
+    fn spawn(
+        &mut self,
+        input: IntCellInput,
+        commands: &mut EntityCommands,
+        caster: &dyn Caster<Self>,
+        _: (),
+    ) {
+        caster.cast_and_insert(input, commands)
+    }
+}
+
+pub trait IntCellSpawnerExt<F: SpawnFunction>: Sized {
+    fn register_default_ldtk_int_cell<T: Bundle>(self) -> Self
+    where
+        for<'a> F::Input<'a>: Into<T>,
+    {
+        self.register_ldtk_int_cell_for_layer_optional::<T>(None, None)
+    }
+
+    fn register_default_ldtk_int_cell_for_layer<T: Bundle>(
+        self,
+        layer_identifier: impl Into<String>,
+    ) -> Self
+    where
+        for<'a> F::Input<'a>: Into<T>,
+    {
+        self.register_ldtk_int_cell_for_layer_optional::<T>(Some(layer_identifier.into()), None)
+    }
+
+    fn register_ldtk_int_cell<T: Bundle>(self, int_grid_value: i32) -> Self
+    where
+        for<'a> F::Input<'a>: Into<T>,
+    {
+        self.register_ldtk_int_cell_for_layer_optional::<T>(None, Some(int_grid_value))
+    }
+
+    fn register_ldtk_int_cell_for_layer<T: Bundle>(
+        self,
+        layer_identifier: impl Into<String>,
+        int_grid_value: i32,
+    ) -> Self
+    where
+        for<'a> F::Input<'a>: Into<T>,
+    {
+        self.register_ldtk_int_cell_for_layer_optional::<T>(
+            Some(layer_identifier.into()),
+            Some(int_grid_value),
+        )
+    }
+
+    fn register_ldtk_int_cell_for_layer_optional<T: Bundle>(
+        self,
+        layer_identifier: Option<String>,
+        int_grid_value: Option<i32>,
+    ) -> Self
+    where
+        for<'a> F::Input<'a>: Into<T>;
+}
+
+impl<F: SpawnFunction<SpawnerType = IntCellSpawnerType>> IntCellSpawnerExt<F> for Spawner<F> {
+    fn register_ldtk_int_cell_for_layer_optional<T: Bundle>(
+        self,
+        layer_identifier: Option<String>,
+        int_grid_value: Option<i32>,
+    ) -> Self
+    where
+        for<'a> F::Input<'a>: Into<T>,
+    {
+        self.add::<T>((layer_identifier, int_grid_value))
+    }
+}
+
+#[derive(Bundle)]
+pub struct ViaLdtkIntCell<T: Bundle> {
+    inner: T,
+}
+
+impl<'a, T: LdtkIntCell + Bundle> From<IntCellInput<'a>> for ViaLdtkIntCell<T> {
+    fn from(value: IntCellInput<'a>) -> ViaLdtkIntCell<T> {
+        ViaLdtkIntCell {
+            inner: T::bundle_int_cell(value.int_grid_cell, value.context.layer_instance),
+        }
+    }
+}

--- a/src/spawn/mod.rs
+++ b/src/spawn/mod.rs
@@ -1,0 +1,45 @@
+use bevy::prelude::Bundle;
+
+mod caster;
+mod collection;
+mod entity;
+mod function;
+mod int_cell;
+mod registry;
+
+pub use self::{caster::*, collection::*, entity::*, function::*, int_cell::*, registry::*};
+
+pub trait SpawnerType {
+    type Input<'a>;
+    type Selector;
+}
+
+pub struct Spawner<F: SpawnFunction> {
+    system: F,
+    selectors: Vec<<F::SpawnerType as SpawnerType>::Selector>,
+    casters: Vec<Box<dyn Caster<F>>>,
+}
+
+impl<F: SpawnFunction> Spawner<F> {
+    fn new(function: F) -> Self {
+        Self {
+            system: function,
+            selectors: Vec::new(),
+            casters: Vec::new(),
+        }
+    }
+
+    fn add<T: Bundle>(mut self, selector: <F::SpawnerType as SpawnerType>::Selector) -> Self
+    where
+        for<'a> F::Input<'a>: Into<T>,
+    {
+        self.selectors.push(selector);
+        self.casters.push(Box::<PhantomCaster<F, T>>::default());
+        self
+    }
+}
+
+pub struct SpawnSelector {
+    spawner_index: usize,
+    entry_index: usize,
+}

--- a/src/spawn/registry.rs
+++ b/src/spawn/registry.rs
@@ -1,0 +1,439 @@
+use std::collections::HashMap;
+
+use bevy::{
+    ecs::system::{EntityCommands, SystemParam, SystemParamFetch, SystemParamItem},
+    prelude::{ParamSet, SystemParamFunction},
+};
+
+use crate::{
+    app::{EntityInput, IntCellInput, SpawnHook},
+    utils::ldtk_map_get,
+};
+
+use super::{
+    EmptyCollection, EntitySpawnerType, IntCellSpawnerType, SpawnFunction, SpawnSelector,
+    SpawnSystemFunction, Spawner, SpawnerCollection, SpawnerType,
+};
+
+pub struct Registry<E, I> {
+    entity_spawners: E,
+    int_cell_spawners: I,
+    entity_map: HashMap<<EntitySpawnerType as SpawnerType>::Selector, SpawnSelector>,
+    int_cell_map: HashMap<<IntCellSpawnerType as SpawnerType>::Selector, SpawnSelector>,
+}
+
+impl Default for Registry<EmptyCollection, EmptyCollection> {
+    fn default() -> Self {
+        Self {
+            entity_spawners: EmptyCollection,
+            int_cell_spawners: EmptyCollection,
+            entity_map: Default::default(),
+            int_cell_map: Default::default(),
+        }
+    }
+}
+
+impl<E: for<'a> SpawnerCollection<EntitySpawnerType>, I> Registry<E, I> {
+    pub fn register_ldtk_entity_spawner<F: SpawnFunction<SpawnerType = EntitySpawnerType>>(
+        mut self,
+        spawner: Spawner<F>,
+    ) -> Registry<(E, Spawner<F>), I> {
+        let spawner_index = E::SIZE;
+        for (entry_index, selector) in spawner.selectors.iter().cloned().enumerate() {
+            self.entity_map.insert(
+                selector,
+                SpawnSelector {
+                    entry_index,
+                    spawner_index,
+                },
+            );
+        }
+        Registry {
+            entity_map: self.entity_map,
+            entity_spawners: (self.entity_spawners, spawner),
+            int_cell_map: self.int_cell_map,
+            int_cell_spawners: self.int_cell_spawners,
+        }
+    }
+
+    #[allow(clippy::type_complexity)]
+    pub fn register_ldtk_entity_in_layer_optional<
+        Out,
+        Param: SystemParam,
+        Marker,
+        F: for<'a> SystemParamFunction<
+            <EntitySpawnerType as SpawnerType>::Input<'a>,
+            Out,
+            Param,
+            Marker,
+        >,
+    >(
+        mut self,
+        layer_identifier: Option<String>,
+        entity_identifier: Option<String>,
+        f: F,
+    ) -> Registry<
+        (
+            E,
+            SpawnSystemFunction<EntitySpawnerType, Out, Param, Marker, F>,
+        ),
+        I,
+    > {
+        self.entity_map.insert(
+            (layer_identifier, entity_identifier),
+            SpawnSelector {
+                entry_index: 0,
+                spawner_index: E::SIZE,
+            },
+        );
+        Registry {
+            entity_map: self.entity_map,
+            entity_spawners: (
+                self.entity_spawners,
+                SpawnSystemFunction::<EntitySpawnerType, Out, Param, Marker, F>::new(f),
+            ),
+            int_cell_map: self.int_cell_map,
+            int_cell_spawners: self.int_cell_spawners,
+        }
+    }
+
+    #[allow(clippy::type_complexity)]
+    pub fn register_ldtk_entity_in_layer<
+        Out,
+        Param: SystemParam,
+        Marker,
+        F: for<'a> SystemParamFunction<
+            <EntitySpawnerType as SpawnerType>::Input<'a>,
+            Out,
+            Param,
+            Marker,
+        >,
+    >(
+        self,
+        layer_identifier: impl Into<String>,
+        entity_identifier: impl Into<String>,
+        f: F,
+    ) -> Registry<
+        (
+            E,
+            SpawnSystemFunction<EntitySpawnerType, Out, Param, Marker, F>,
+        ),
+        I,
+    > {
+        self.register_ldtk_entity_in_layer_optional(
+            Some(layer_identifier.into()),
+            Some(entity_identifier.into()),
+            f,
+        )
+    }
+
+    #[allow(clippy::type_complexity)]
+    pub fn register_ldtk_entity<
+        Out,
+        Param: SystemParam,
+        Marker,
+        F: for<'a> SystemParamFunction<
+            <EntitySpawnerType as SpawnerType>::Input<'a>,
+            Out,
+            Param,
+            Marker,
+        >,
+    >(
+        self,
+        entity_identifier: impl Into<String>,
+        f: F,
+    ) -> Registry<
+        (
+            E,
+            SpawnSystemFunction<EntitySpawnerType, Out, Param, Marker, F>,
+        ),
+        I,
+    > {
+        self.register_ldtk_entity_in_layer_optional(None, Some(entity_identifier.into()), f)
+    }
+
+    #[allow(clippy::type_complexity)]
+    pub fn register_default_ldtk_entity_for_layer<
+        Out,
+        Param: SystemParam,
+        Marker,
+        F: for<'a> SystemParamFunction<
+            <EntitySpawnerType as SpawnerType>::Input<'a>,
+            Out,
+            Param,
+            Marker,
+        >,
+    >(
+        self,
+        layer_identifier: impl Into<String>,
+        f: F,
+    ) -> Registry<
+        (
+            E,
+            SpawnSystemFunction<EntitySpawnerType, Out, Param, Marker, F>,
+        ),
+        I,
+    > {
+        self.register_ldtk_entity_in_layer_optional(Some(layer_identifier.into()), None, f)
+    }
+
+    #[allow(clippy::type_complexity)]
+    pub fn register_default_ldtk_entity<
+        Out,
+        Param: SystemParam,
+        Marker,
+        F: for<'a> SystemParamFunction<
+            <EntitySpawnerType as SpawnerType>::Input<'a>,
+            Out,
+            Param,
+            Marker,
+        >,
+    >(
+        self,
+        f: F,
+    ) -> Registry<
+        (
+            E,
+            SpawnSystemFunction<EntitySpawnerType, Out, Param, Marker, F>,
+        ),
+        I,
+    > {
+        self.register_ldtk_entity_in_layer_optional(None, None, f)
+    }
+}
+
+impl<E, I: for<'a> SpawnerCollection<IntCellSpawnerType>> Registry<E, I> {
+    pub fn register_ldtk_int_cell_spawner<F: SpawnFunction<SpawnerType = IntCellSpawnerType>>(
+        mut self,
+        spawner: Spawner<F>,
+    ) -> Registry<E, (I, Spawner<F>)> {
+        let spawner_index = I::SIZE;
+        for (entry_index, selector) in spawner.selectors.iter().cloned().enumerate() {
+            self.int_cell_map.insert(
+                selector,
+                SpawnSelector {
+                    entry_index,
+                    spawner_index,
+                },
+            );
+        }
+        Registry {
+            entity_map: self.entity_map,
+            entity_spawners: self.entity_spawners,
+            int_cell_map: self.int_cell_map,
+            int_cell_spawners: (self.int_cell_spawners, spawner),
+        }
+    }
+
+    #[allow(clippy::type_complexity)]
+    pub fn register_ldtk_int_cell_in_layer_optional<
+        Out,
+        Param: SystemParam,
+        Marker,
+        F: for<'a> SystemParamFunction<
+            <IntCellSpawnerType as SpawnerType>::Input<'a>,
+            Out,
+            Param,
+            Marker,
+        >,
+    >(
+        mut self,
+        layer_identifier: Option<String>,
+        int_cell_value: Option<i32>,
+        f: F,
+    ) -> Registry<
+        E,
+        (
+            I,
+            SpawnSystemFunction<IntCellSpawnerType, Out, Param, Marker, F>,
+        ),
+    > {
+        self.int_cell_map.insert(
+            (layer_identifier, int_cell_value),
+            SpawnSelector {
+                entry_index: 0,
+                spawner_index: I::SIZE,
+            },
+        );
+        Registry {
+            entity_map: self.entity_map,
+            entity_spawners: self.entity_spawners,
+            int_cell_map: self.int_cell_map,
+            int_cell_spawners: (
+                self.int_cell_spawners,
+                SpawnSystemFunction::<IntCellSpawnerType, Out, Param, Marker, F>::new(f),
+            ),
+        }
+    }
+
+    #[allow(clippy::type_complexity)]
+    pub fn register_ldtk_int_cell_in_layer<
+        Out,
+        Param: SystemParam,
+        Marker,
+        F: for<'a> SystemParamFunction<
+            <IntCellSpawnerType as SpawnerType>::Input<'a>,
+            Out,
+            Param,
+            Marker,
+        >,
+    >(
+        self,
+        layer_identifier: impl Into<String>,
+        int_cell_value: i32,
+        f: F,
+    ) -> Registry<
+        E,
+        (
+            I,
+            SpawnSystemFunction<IntCellSpawnerType, Out, Param, Marker, F>,
+        ),
+    > {
+        self.register_ldtk_int_cell_in_layer_optional(
+            Some(layer_identifier.into()),
+            Some(int_cell_value),
+            f,
+        )
+    }
+
+    #[allow(clippy::type_complexity)]
+    pub fn register_ldtk_int_cell<
+        Out,
+        Param: SystemParam,
+        Marker,
+        F: for<'a> SystemParamFunction<
+            <IntCellSpawnerType as SpawnerType>::Input<'a>,
+            Out,
+            Param,
+            Marker,
+        >,
+    >(
+        self,
+        int_cell_value: i32,
+        f: F,
+    ) -> Registry<
+        E,
+        (
+            I,
+            SpawnSystemFunction<IntCellSpawnerType, Out, Param, Marker, F>,
+        ),
+    > {
+        self.register_ldtk_int_cell_in_layer_optional(None, Some(int_cell_value), f)
+    }
+
+    #[allow(clippy::type_complexity)]
+    pub fn register_default_ldtk_int_cell_for_layer<
+        Out,
+        Param: SystemParam,
+        Marker,
+        F: for<'a> SystemParamFunction<
+            <IntCellSpawnerType as SpawnerType>::Input<'a>,
+            Out,
+            Param,
+            Marker,
+        >,
+    >(
+        self,
+        layer_identifier: impl Into<String>,
+        f: F,
+    ) -> Registry<
+        E,
+        (
+            I,
+            SpawnSystemFunction<IntCellSpawnerType, Out, Param, Marker, F>,
+        ),
+    > {
+        self.register_ldtk_int_cell_in_layer_optional(Some(layer_identifier.into()), None, f)
+    }
+
+    #[allow(clippy::type_complexity)]
+    pub fn register_default_ldtk_int_cell<
+        Out,
+        Param: SystemParam,
+        Marker,
+        F: for<'a> SystemParamFunction<
+            <IntCellSpawnerType as SpawnerType>::Input<'a>,
+            Out,
+            Param,
+            Marker,
+        >,
+    >(
+        self,
+        f: F,
+    ) -> Registry<
+        E,
+        (
+            I,
+            SpawnSystemFunction<IntCellSpawnerType, Out, Param, Marker, F>,
+        ),
+    > {
+        self.register_ldtk_int_cell_in_layer_optional(None, None, f)
+    }
+}
+
+impl<
+        E: for<'a> SpawnerCollection<EntitySpawnerType> + Send + Sync + 'static,
+        I: for<'a> SpawnerCollection<IntCellSpawnerType> + Send + Sync + 'static,
+    > SpawnHook for Registry<E, I>
+{
+    type Param<'w, 's> = ParamSet<
+        'w,
+        's,
+        (
+            SystemParamItem<'w, 's, E::Param<'w, 's>>,
+            SystemParamItem<'w, 's, I::Param<'w, 's>>,
+        ),
+    >;
+
+    fn spawn_entity(
+        &mut self,
+        commands: &mut EntityCommands,
+        input: EntityInput,
+        param_value: &mut <<Self::Param<'_, '_> as SystemParam>::Fetch as SystemParamFetch<
+            '_,
+            '_,
+        >>::Item,
+    ) {
+        if let Some(selector) = ldtk_map_get(
+            input.context.layer_instance.identifier.clone(),
+            input.entity_instance.identifier.clone(),
+            &self.entity_map,
+        ) {
+            self.entity_spawners.spawn(
+                selector.spawner_index,
+                selector.entry_index,
+                input,
+                commands,
+                param_value.p0(),
+            )
+        } else {
+            commands.insert(input.entity_instance.clone());
+        }
+    }
+
+    fn spawn_int_cell(
+        &mut self,
+        commands: &mut EntityCommands,
+        input: IntCellInput,
+        param_value: &mut <<Self::Param<'_, '_> as SystemParam>::Fetch as SystemParamFetch<
+            '_,
+            '_,
+        >>::Item,
+    ) {
+        if let Some(selector) = ldtk_map_get(
+            input.context.layer_instance.identifier.clone(),
+            input.int_grid_cell.value,
+            &self.int_cell_map,
+        ) {
+            self.int_cell_spawners.spawn(
+                selector.spawner_index,
+                selector.entry_index,
+                input,
+                commands,
+                param_value.p1(),
+            )
+        } else {
+            commands.insert(input.int_grid_cell);
+        }
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -291,6 +291,18 @@ where
 /// instance of an LDtk entity or int grid tile may match multiple registrations.
 /// This function is responsible for picking the correct registration while spawning these
 /// entities/tiles.
+pub(crate) fn ldtk_map_get<A, B, L>(
+    a: A,
+    b: B,
+    map: &HashMap<(Option<A>, Option<B>), L>,
+) -> Option<&L>
+where
+    A: Hash + Eq + Clone,
+    B: Hash + Eq + Clone,
+{
+    try_each_optional_permutation(a, b, |x, y| map.get(&(x, y)))
+}
+
 pub(crate) fn ldtk_map_get_or_default<'a, A, B, L>(
     a: A,
     b: B,
@@ -301,7 +313,7 @@ where
     A: Hash + Eq + Clone,
     B: Hash + Eq + Clone,
 {
-    try_each_optional_permutation(a, b, |x, y| map.get(&(x, y))).unwrap_or(default)
+    ldtk_map_get(a, b, map).unwrap_or(default)
 }
 
 /// Creates a [SpriteSheetBundle] from the entity information available to the


### PR DESCRIPTION
Hello, first I want to thank you for this useful crate. I am currently using it for a hobby project.

This is my suggestion for a possible solution of #47. It is implemented without breaking changes.

The first commit adds a new `SpawnHook` trait.  It defines an associated `Param` type which allows accessing more from the world when executing the `process_ldtk_levels` system. The `DefaultSpawnHook` type implements `SpawnHook` and does the spawning in the same way as before.

The second commit adds a new `spawn` module that adds another implementation of the `SpawnHook` trait, the `Registry`. The registry allows hooking up individual functions that implement `SystemParamFunction` and using another trait called `SpawnFunction` that can be used with types that implement `From<SpawnFunction::Input<'a>>`.

I would add documentation and more examples if there is an interest in these additions. 