### PR TITLE
chore: prepare 0.6 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = ["macros"]
 
 [dependencies]
 bevy_ecs_ldtk_macros = { version = "0.5.0", optional = true, path = "macros" }
-bevy_ecs_tilemap = { version = "0.9", default-features = false }
+bevy_ecs_tilemap = { version = "0.10", default-features = false }
 bevy = { version = "0.10", default-features = false, features = ["bevy_sprite"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -38,6 +38,3 @@ render = ["bevy_ecs_tilemap/render"]
 [[example]]
 name = "platformer"
 path = "examples/platformer/main.rs"
-
-[patch.crates-io]
-bevy_ecs_tilemap = { version = "0.9", git = "https://github.com/geieredgar/bevy_ecs_tilemap", branch = "bevy_track" }

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ for additional level-loading options.
 ### Compatibility
 | bevy | bevy_ecs_tilemap | LDtk | bevy_ecs_ldtk |
 | --- | --- | --- | --- |
+| 0.10 | 0.10 | 1.1+ | 0.6 |
 | 0.9 | 0.9 | 1.1 | 0.5 |
 | 0.8 | 0.7 | 1.1 | 0.4 |
 | 0.7 | 0.6 | 1.1 | 0.3 |


### PR DESCRIPTION
Getting this up pre-emptively so we can quickly release after `bevy_ecs_tilemap`. This branch will fail to compile until `bevy_ecs_tilemap` 0.10 is released. If you want to preview the upgrade to bevy 0.10 in your own game, you can point to the main branch of this repo and use the patch removed in this diff in your dependencies:
```
bevy_ecs_ldtk = { git = "https://github.com/Trouv/bevy_ecs_ldtk", branch = "main" }

[patch.crates-io]
bevy_ecs_tilemap = { git = "https://github.com/geieredgar/bevy_ecs_tilemap", branch = "bevy_track" }
```