### PR TITLE
ci: add more changelog sections for release-please to generate

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,3 +13,4 @@ jobs:
           release-type: rust
           package-name: bevy_ecs_ldtk
           bump-minor-pre-major: true
+          changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"docs","section":"Documentation Changes","hidden":false},{"type":"example","section":"Example Changes","hidden":false},{"type":"refactor","section":"Code Refactors","hidden":true},{"type":"ci","section":"CI Changes","hidden":true}]'


### PR DESCRIPTION
The changelog currently only shows breaking changes, features, and bug fixes. In other words, only changes that release-please deems worthy for users to care about. For our purposes, changes to docs and examples are also good for users to know. Furthermore, I'd just like to give credit where credit is due in the changelog, especially for changes to the examples since the platformer example is pretty extensive. 

This PR adds more sections to the changelog - docs, examples, refactors, and CI. The latter two are deemed as "hidden" for now. I'm hoping that the hidden option gives them an expandable section rather than completely hiding them from the changelog, we will see.