### PR TITLE
fix: use normal sprite for background color instead of tile

### DIFF
--- a/src/level.rs
+++ b/src/level.rs
@@ -238,39 +238,17 @@ pub fn spawn_level(
         if ldtk_settings.level_background == LevelBackground::Rendered {
             let background_entity = commands.spawn_empty().id();
 
-            let mut storage = TileStorage::empty(TilemapSize { x: 1, y: 1 });
-
-            let tile_entity = commands
-                .spawn(TileBundle {
-                    color: TileColor(level.bg_color),
-                    tilemap_id: TilemapId(background_entity),
-                    ..default()
-                })
-                .insert(SpatialBundle::default())
-                .id();
-
-            storage.set(&TilePos::default(), tile_entity);
-
-            let tile_size = TilemapTileSize {
-                x: level.px_wid as f32,
-                y: level.px_hei as f32,
-            };
-            let texture = TilemapTexture::Single(white_image_handle.clone());
-
             let translation = Vec3::new(level.px_wid as f32, level.px_hei as f32, 0.) / 2.;
 
-            commands
-                .entity(background_entity)
-                .insert(TilemapBundle {
-                    tile_size,
-                    storage,
-                    texture,
+            commands.entity(background_entity).insert(SpriteBundle {
+                sprite: Sprite {
+                    color: level.bg_color,
+                    custom_size: Some(Vec2::new(level.px_wid as f32, level.px_hei as f32)),
                     ..default()
-                })
-                .insert(SpatialBundle::from_transform(Transform::from_translation(
-                    translation,
-                )))
-                .add_child(tile_entity);
+                },
+                transform: Transform::from_translation(translation),
+                ..default()
+            });
             commands.entity(ldtk_entity).add_child(background_entity);
 
             layer_z += 1;

--- a/src/level.rs
+++ b/src/level.rs
@@ -221,7 +221,7 @@ pub fn spawn_level(
     if let Some(layer_instances) = &level.layer_instances {
         let mut layer_z = 0;
 
-        // creating an image to use for the background color, and for intgrid colors
+        // creating an image to use for intgrid colors
         let white_image = Image::new_fill(
             Extent3d {
                 width: level.px_wid as u32,
@@ -236,19 +236,20 @@ pub fn spawn_level(
         let white_image_handle = images.add(white_image);
 
         if ldtk_settings.level_background == LevelBackground::Rendered {
-            let background_entity = commands.spawn_empty().id();
-
             let translation = Vec3::new(level.px_wid as f32, level.px_hei as f32, 0.) / 2.;
 
-            commands.entity(background_entity).insert(SpriteBundle {
-                sprite: Sprite {
-                    color: level.bg_color,
-                    custom_size: Some(Vec2::new(level.px_wid as f32, level.px_hei as f32)),
+            let background_entity = commands
+                .spawn(SpriteBundle {
+                    sprite: Sprite {
+                        color: level.bg_color,
+                        custom_size: Some(Vec2::new(level.px_wid as f32, level.px_hei as f32)),
+                        ..default()
+                    },
+                    transform: Transform::from_translation(translation),
                     ..default()
-                },
-                transform: Transform::from_translation(translation),
-                ..default()
-            });
+                })
+                .id();
+
             commands.entity(ldtk_entity).add_child(background_entity);
 
             layer_z += 1;

--- a/src/level.rs
+++ b/src/level.rs
@@ -21,7 +21,7 @@ use bevy_ecs_tilemap::{
     map::{
         TilemapGridSize, TilemapId, TilemapSize, TilemapSpacing, TilemapTexture, TilemapTileSize,
     },
-    tiles::{TileBundle, TileColor, TilePos, TileStorage},
+    tiles::{TilePos, TileStorage},
     TilemapBundle,
 };
 use std::collections::{HashMap, HashSet};


### PR DESCRIPTION
Our solution for background colors was pretty bad due to a previous limitation with `bevy`'s sprites. We can now use a normal sprite for the background color instead of a single-tile tilemap. This PR makes that change.

This also unblocks #169, since it seems the z-indexing issue was partially due to our weird use background image solution. Though, I expect bevy_ecs_tilemap to release an `0.11` somewhat soon to make the 3d-iso changes optional.