### PR TITLE
refactor: move plugin module to its own file

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,6 +120,7 @@ mod assets;
 mod components;
 pub mod ldtk;
 mod level;
+mod plugin;
 mod resources;
 pub mod systems;
 mod tile_makers;
@@ -132,98 +133,6 @@ pub use resources::*;
 
 #[cfg(feature = "derive")]
 pub use bevy_ecs_ldtk_macros::*;
-
-mod plugin {
-    //! Provides [LdtkPlugin] and its scheduling-related dependencies.
-
-    use super::*;
-
-    /// Base [SystemSet]s for systems added by the plugin.
-    #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash, SystemSet)]
-    #[system_set(base)]
-    pub enum LdtkSystemSet {
-        /// Scheduled after [CoreSet::UpdateFlush].
-        ///
-        /// Used for systems that process components and resources provided by this plugin's API.
-        /// In particular, this set processes..
-        /// - [resources::LevelSelection]
-        /// - [components::LevelSet]
-        /// - [components::Worldly]
-        /// - [components::Respawn]
-        ///
-        /// As a result, you can expect minimal frame delay when updating these in
-        /// [CoreSet::Update].
-        ///
-        /// You might need to add additional scheduling constraints to prevent race conditions
-        /// between systems in this set and other external systems. As an example, `bevy_rapier`'s
-        /// `PhysicsSet::BackendSync` should be scheduled after `LdtkSystemSet::ProcessApi`.
-        ProcessApi,
-    }
-
-    #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash, SystemSet)]
-    enum ProcessApiSet {
-        PreClean,
-        Clean,
-    }
-
-    /// Adds the default systems, assets, and resources used by `bevy_ecs_ldtk`.
-    ///
-    /// Add it to your [App] to gain LDtk functionality!
-    #[derive(Copy, Clone, Debug, Default)]
-    pub struct LdtkPlugin;
-
-    impl Plugin for LdtkPlugin {
-        fn build(&self, mut app: &mut App) {
-            // Check if we have added the TileMap plugin
-            if !app.is_plugin_added::<bevy_ecs_tilemap::TilemapPlugin>() {
-                app = app.add_plugin(bevy_ecs_tilemap::TilemapPlugin);
-            }
-
-            app.configure_set(
-                LdtkSystemSet::ProcessApi
-                    .after(CoreSet::UpdateFlush)
-                    .before(CoreSet::PostUpdate),
-            )
-            .configure_sets(
-                (ProcessApiSet::PreClean, ProcessApiSet::Clean)
-                    .chain()
-                    .in_base_set(LdtkSystemSet::ProcessApi),
-            )
-            .init_non_send_resource::<app::LdtkEntityMap>()
-            .init_non_send_resource::<app::LdtkIntCellMap>()
-            .init_resource::<resources::LdtkSettings>()
-            .add_asset::<assets::LdtkAsset>()
-            .init_asset_loader::<assets::LdtkLoader>()
-            .add_asset::<assets::LdtkLevel>()
-            .init_asset_loader::<assets::LdtkLevelLoader>()
-            .add_event::<resources::LevelEvent>()
-            .add_systems(
-                (systems::process_ldtk_assets, systems::process_ldtk_levels)
-                    .in_base_set(CoreSet::PreUpdate),
-            )
-            .add_system(systems::worldly_adoption.in_set(ProcessApiSet::PreClean))
-            .add_systems(
-                (systems::apply_level_selection, systems::apply_level_set)
-                    .chain()
-                    .in_set(ProcessApiSet::PreClean),
-            )
-            .add_systems(
-                (apply_system_buffers, systems::clean_respawn_entities)
-                    .chain()
-                    .in_set(ProcessApiSet::Clean),
-            )
-            .add_system(
-                systems::detect_level_spawned_events
-                    .pipe(systems::fire_level_transformed_events)
-                    .in_base_set(CoreSet::PostUpdate),
-            )
-            .register_type::<GridCoords>()
-            .register_type::<TileMetadata>()
-            .register_type::<TileEnumTags>()
-            .register_type::<LayerMetadata>();
-        }
-    }
-}
 
 pub mod prelude {
     //! `use bevy_ecs_ldtk::prelude::*;` to import commonly used items.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,6 +108,9 @@
 //!
 //! The `derive` and `render` features are enabled by default.
 //!
+//! [App]: bevy::prelude::App
+//! [Commands]: bevy::prelude::Commands
+//! [Transform]: bevy::prelude::Transform
 //! [feature flags]: https://doc.rust-lang.org/cargo/reference/features.html#the-features-section
 //! [LdtkEntity]: app::LdtkEntity
 //! [LdtkIntCell]: app::LdtkEntity

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,8 +113,6 @@
 //! [LdtkIntCell]: app::LdtkEntity
 //! [bevy_ecs_tilemap]: https://docs.rs/bevy_ecs_tilemap
 
-use bevy::prelude::*;
-
 pub mod app;
 mod assets;
 mod components;

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,6 +1,6 @@
 //! Provides [LdtkPlugin] and its scheduling-related dependencies.
-
-use super::*;
+use crate::{app, assets, components, resources, systems};
+use bevy::prelude::*;
 
 /// Base [SystemSet]s for systems added by the plugin.
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash, SystemSet)]
@@ -81,9 +81,9 @@ impl Plugin for LdtkPlugin {
                 .pipe(systems::fire_level_transformed_events)
                 .in_base_set(CoreSet::PostUpdate),
         )
-        .register_type::<GridCoords>()
-        .register_type::<TileMetadata>()
-        .register_type::<TileEnumTags>()
-        .register_type::<LayerMetadata>();
+        .register_type::<components::GridCoords>()
+        .register_type::<components::TileMetadata>()
+        .register_type::<components::TileEnumTags>()
+        .register_type::<components::LayerMetadata>();
     }
 }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,0 +1,89 @@
+//! Provides [LdtkPlugin] and its scheduling-related dependencies.
+
+use super::*;
+
+/// Base [SystemSet]s for systems added by the plugin.
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Hash, SystemSet)]
+#[system_set(base)]
+pub enum LdtkSystemSet {
+    /// Scheduled after [CoreSet::UpdateFlush].
+    ///
+    /// Used for systems that process components and resources provided by this plugin's API.
+    /// In particular, this set processes..
+    /// - [resources::LevelSelection]
+    /// - [components::LevelSet]
+    /// - [components::Worldly]
+    /// - [components::Respawn]
+    ///
+    /// As a result, you can expect minimal frame delay when updating these in
+    /// [CoreSet::Update].
+    ///
+    /// You might need to add additional scheduling constraints to prevent race conditions
+    /// between systems in this set and other external systems. As an example, `bevy_rapier`'s
+    /// `PhysicsSet::BackendSync` should be scheduled after `LdtkSystemSet::ProcessApi`.
+    ProcessApi,
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Hash, SystemSet)]
+enum ProcessApiSet {
+    PreClean,
+    Clean,
+}
+
+/// Adds the default systems, assets, and resources used by `bevy_ecs_ldtk`.
+///
+/// Add it to your [App] to gain LDtk functionality!
+#[derive(Copy, Clone, Debug, Default)]
+pub struct LdtkPlugin;
+
+impl Plugin for LdtkPlugin {
+    fn build(&self, mut app: &mut App) {
+        // Check if we have added the TileMap plugin
+        if !app.is_plugin_added::<bevy_ecs_tilemap::TilemapPlugin>() {
+            app = app.add_plugin(bevy_ecs_tilemap::TilemapPlugin);
+        }
+
+        app.configure_set(
+            LdtkSystemSet::ProcessApi
+                .after(CoreSet::UpdateFlush)
+                .before(CoreSet::PostUpdate),
+        )
+        .configure_sets(
+            (ProcessApiSet::PreClean, ProcessApiSet::Clean)
+                .chain()
+                .in_base_set(LdtkSystemSet::ProcessApi),
+        )
+        .init_non_send_resource::<app::LdtkEntityMap>()
+        .init_non_send_resource::<app::LdtkIntCellMap>()
+        .init_resource::<resources::LdtkSettings>()
+        .add_asset::<assets::LdtkAsset>()
+        .init_asset_loader::<assets::LdtkLoader>()
+        .add_asset::<assets::LdtkLevel>()
+        .init_asset_loader::<assets::LdtkLevelLoader>()
+        .add_event::<resources::LevelEvent>()
+        .add_systems(
+            (systems::process_ldtk_assets, systems::process_ldtk_levels)
+                .in_base_set(CoreSet::PreUpdate),
+        )
+        .add_system(systems::worldly_adoption.in_set(ProcessApiSet::PreClean))
+        .add_systems(
+            (systems::apply_level_selection, systems::apply_level_set)
+                .chain()
+                .in_set(ProcessApiSet::PreClean),
+        )
+        .add_systems(
+            (apply_system_buffers, systems::clean_respawn_entities)
+                .chain()
+                .in_set(ProcessApiSet::Clean),
+        )
+        .add_system(
+            systems::detect_level_spawned_events
+                .pipe(systems::fire_level_transformed_events)
+                .in_base_set(CoreSet::PostUpdate),
+        )
+        .register_type::<GridCoords>()
+        .register_type::<TileMetadata>()
+        .register_type::<TileEnumTags>()
+        .register_type::<LayerMetadata>();
+    }
+}


### PR DESCRIPTION
This minor change helps clean up the root `lib.rs` file. No import paths have been changed, so this is not a breaking change for users.