### PR TITLE
feat: add LdtkFields trait with convenience methods for accessing field instances

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ regex = "1"
 hex = "0.4"
 anyhow = "1.0"
 thiserror = "1.0"
+paste = "1.0"
 
 [dev-dependencies]
 bevy = "0.10"

--- a/examples/platformer/components.rs
+++ b/examples/platformer/components.rs
@@ -84,10 +84,9 @@ impl From<&EntityInstance> for Items {
     fn from(entity_instance: &EntityInstance) -> Self {
         Items(
             entity_instance
-                .get_enums_field("items")
+                .iter_enums_field("items")
                 .expect("items field should be correctly typed")
-                .into_iter()
-                .map(|s| s.to_string())
+                .cloned()
                 .collect(),
         )
     }
@@ -172,10 +171,10 @@ impl LdtkEntity for Patrol {
         ));
 
         let ldtk_patrol_points = entity_instance
-            .get_points_field("patrol")
+            .iter_points_field("patrol")
             .expect("patrol field should be correclty typed");
 
-        for ldtk_point in ldtk_patrol_points.iter() {
+        for ldtk_point in ldtk_patrol_points {
             // The +1 is necessary here due to the pivot of the entities in the sample
             // file.
             // The patrols set up in the file look flat and grounded,

--- a/examples/platformer/components.rs
+++ b/examples/platformer/components.rs
@@ -82,25 +82,14 @@ pub struct Items(Vec<String>);
 
 impl From<&EntityInstance> for Items {
     fn from(entity_instance: &EntityInstance) -> Self {
-        let mut items: Vec<String> = vec![];
-
-        if let Some(field_instance) = entity_instance
-            .field_instances
-            .iter()
-            .find(|f| f.identifier == *"items")
-        {
-            // convert &String to String which returns vec![String::from("Knife"), String::from("Boot")]
-            items = match &field_instance.value {
-                FieldValue::Enums(v) => v
-                    .iter()
-                    .flatten()
-                    .map(|s| s.into())
-                    .collect::<Vec<String>>(),
-                _ => vec![],
-            };
-        }
-
-        Self(items)
+        Items(
+            entity_instance
+                .get_enums_field("items")
+                .expect("items field should be correctly typed")
+                .into_iter()
+                .map(|s| s.to_string())
+                .collect(),
+        )
     }
 }
 
@@ -182,28 +171,25 @@ impl LdtkEntity for Patrol {
             entity_instance.pivot,
         ));
 
-        let ldtk_patrol = entity_instance
-            .field_instances
-            .iter()
-            .find(|f| f.identifier == *"patrol")
-            .unwrap();
-        if let FieldValue::Points(ldtk_points) = &ldtk_patrol.value {
-            for ldtk_point in ldtk_points.iter().flatten() {
-                // The +1 is necessary here due to the pivot of the entities in the sample
-                // file.
-                // The patrols set up in the file look flat and grounded,
-                // but technically they're not if you consider the pivot,
-                // which is at the bottom-center for the skulls.
-                let pixel_coords = (ldtk_point.as_vec2() + Vec2::new(0.5, 1.))
-                    * Vec2::splat(layer_instance.grid_size as f32);
+        let ldtk_patrol_points = entity_instance
+            .get_points_field("patrol")
+            .expect("patrol field should be correclty typed");
 
-                points.push(ldtk_pixel_coords_to_translation_pivoted(
-                    pixel_coords.as_ivec2(),
-                    layer_instance.c_hei * layer_instance.grid_size,
-                    IVec2::new(entity_instance.width, entity_instance.height),
-                    entity_instance.pivot,
-                ));
-            }
+        for ldtk_point in ldtk_patrol_points.iter() {
+            // The +1 is necessary here due to the pivot of the entities in the sample
+            // file.
+            // The patrols set up in the file look flat and grounded,
+            // but technically they're not if you consider the pivot,
+            // which is at the bottom-center for the skulls.
+            let pixel_coords = (ldtk_point.as_vec2() + Vec2::new(0.5, 1.))
+                * Vec2::splat(layer_instance.grid_size as f32);
+
+            points.push(ldtk_pixel_coords_to_translation_pivoted(
+                pixel_coords.as_ivec2(),
+                layer_instance.c_hei * layer_instance.grid_size,
+                IVec2::new(entity_instance.width, entity_instance.height),
+                entity_instance.pivot,
+            ));
         }
 
         Patrol {

--- a/src/ldtk/all_some_iter.rs
+++ b/src/ldtk/all_some_iter.rs
@@ -1,0 +1,32 @@
+use std::{iter::Flatten, slice::Iter};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+#[error("Option<T> iterator contains one or more Nones")]
+pub struct NotAllSomeError;
+
+pub struct AllSomeIter<'a, T> {
+    flattened: Flatten<Iter<'a, Option<T>>>,
+}
+
+impl<'a, T> Iterator for AllSomeIter<'a, T> {
+    type Item = &'a T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.flattened.next()
+    }
+}
+
+impl<'a, T> TryFrom<&'a [Option<T>]> for AllSomeIter<'a, T> {
+    type Error = NotAllSomeError;
+
+    fn try_from(value: &'a [Option<T>]) -> Result<Self, Self::Error> {
+        if value.iter().all(|v| v.is_some()) {
+            Ok(AllSomeIter {
+                flattened: value.iter().flatten(),
+            })
+        } else {
+            Err(NotAllSomeError)
+        }
+    }
+}

--- a/src/ldtk/all_some_iter.rs
+++ b/src/ldtk/all_some_iter.rs
@@ -1,10 +1,17 @@
+//! Contains [`AllSomeIter`], for coercing a slice of options to an [`Iterator`] of non-options.
 use std::{iter::Flatten, slice::Iter};
 use thiserror::Error;
 
+/// Error that can occur when attempting to construct [AllSomeIter].
 #[derive(Debug, Error)]
-#[error("Option<T> iterator contains one or more Nones")]
+#[error("Option<T> collection contains one or more Nones")]
 pub struct NotAllSomeError;
 
+/// [`Iterator`] for coercing a slice of options to non-options.
+///
+/// Can only be constructed via [`TryFrom<&[Option<T>]>`](TryFrom).
+/// This will error if any of the elements are `None`.
+/// Otherwise, this will iterate over the non-optional `T`.
 pub struct AllSomeIter<'a, T> {
     flattened: Flatten<Iter<'a, Option<T>>>,
 }

--- a/src/ldtk/ldtk_fields.rs
+++ b/src/ldtk/ldtk_fields.rs
@@ -1,4 +1,7 @@
-use crate::ldtk::{FieldInstance, FieldInstanceEntityReference, FieldValue, TilesetRectangle};
+use crate::ldtk::{
+    EntityInstance, FieldInstance, FieldInstanceEntityReference, FieldValue, Level,
+    TilesetRectangle,
+};
 use bevy::prelude::*;
 use paste::paste;
 use thiserror::Error;
@@ -205,4 +208,16 @@ pub trait LdtkFields {
     create_get_plural_fields_methods!(points, Points, Option<IVec2>, &IVec2);
 
     // implement similar methods for all `FieldValue` variants...
+}
+
+impl LdtkFields for EntityInstance {
+    fn field_instances(&self) -> &[FieldInstance] {
+        &self.field_instances
+    }
+}
+
+impl LdtkFields for Level {
+    fn field_instances(&self) -> &[FieldInstance] {
+        &self.field_instances
+    }
 }

--- a/src/ldtk/ldtk_fields.rs
+++ b/src/ldtk/ldtk_fields.rs
@@ -127,10 +127,10 @@ macro_rules! create_get_maybe_field_method_copy {
 /// and returning a copy to it instead of a reference.
 ///
 /// Intended only for variants whose internal type is **not** optional and can be cheaply copied.
-macro_rules! create_just_get_field_method_copy {
+macro_rules! create_just_get_field_method {
     ($type_name:ident, $variant:ident, $type:ty) => {
         paste! {
-            create_base_get_field_method!("", $type_name, $type_name, $variant, $type, *$type_name);
+            create_base_get_field_method!("", $type_name, $type_name, $variant, $type, $type_name);
         }
     };
 }
@@ -204,14 +204,14 @@ pub trait LdtkFields {
         Ok(&self.get_field_instance(identifier)?.value)
     }
 
-    create_get_field_methods_copy!(int, Int, i32);
-    create_get_field_methods_copy!(float, Float, f32);
+    create_get_field_methods!(int, Int, &Option<i32>, &i32);
+    create_get_field_methods!(float, Float, &Option<f32>, &f32);
 
-    create_just_get_field_method_copy!(bool, Bool, bool);
+    create_just_get_field_method!(bool, Bool, &bool);
 
     create_get_field_methods!(string, String, &Option<String>, &String);
 
-    create_just_get_field_method_copy!(color, Color, Color);
+    create_just_get_field_method!(color, Color, &Color);
 
     create_get_field_methods!(file_path, FilePath, &Option<String>, &String);
     create_get_field_methods!(enum, Enum, &Option<String>, &String);
@@ -223,7 +223,7 @@ pub trait LdtkFields {
         &FieldInstanceEntityReference
     );
 
-    create_get_field_methods_copy!(point, Point, IVec2);
+    create_get_field_methods!(point, Point, &Option<IVec2>, &IVec2);
 
     create_get_plural_fields_methods!(ints, Ints, Option<i32>, i32);
     create_get_plural_fields_methods!(floats, Floats, Option<f32>, f32);

--- a/src/ldtk/ldtk_fields.rs
+++ b/src/ldtk/ldtk_fields.rs
@@ -98,7 +98,7 @@ macro_rules! create_get_field_methods {
 }
 
 macro_rules! create_get_plural_fields_method {
-    ($type_name:ident, $variant:ident, $collected_type:ty) => {
+    ($type_name:ident, $variant:ident, $collected_type:ty, $map:expr) => {
         paste! {
             #[doc = " Get this item's non-null " $type_name " field value for the given identifier."]
             ///
@@ -110,7 +110,7 @@ macro_rules! create_get_plural_fields_method {
                 let $type_name = self.[< get_maybe_ $type_name _field >](identifier)?;
 
                 if $type_name.iter().all(|e| e.is_some()) {
-                    Ok($type_name.iter().flatten().collect())
+                    Ok($type_name.iter().flatten().map($map).collect())
                 } else {
                     Err(LdtkFieldsError::UnexpectedNull {
                         identifier: identifier.to_string(),
@@ -124,7 +124,11 @@ macro_rules! create_get_plural_fields_method {
 macro_rules! create_get_plural_fields_methods {
     ($type_name:ident, $variant:ident, $maybe_type:ty, $as_ref_type: ty) => {
         create_get_maybe_field_method!($type_name, $variant, &[$maybe_type]);
-        create_get_plural_fields_method!($type_name, $variant, Vec<$as_ref_type>);
+        create_get_plural_fields_method!($type_name, $variant, Vec<$as_ref_type>, |e| e);
+    };
+    ($type_name:ident, $variant:ident, $maybe_type:ty, $as_ref_type: ty, $map:expr) => {
+        create_get_maybe_field_method!($type_name, $variant, &[$maybe_type]);
+        create_get_plural_fields_method!($type_name, $variant, Vec<$as_ref_type>, $map);
     };
 }
 

--- a/src/ldtk/ldtk_fields.rs
+++ b/src/ldtk/ldtk_fields.rs
@@ -125,6 +125,19 @@ macro_rules! create_get_plural_fields_methods {
     };
 }
 
+macro_rules! create_just_get_plural_fields_method {
+    ($type_name:ident, $variant:ident, $type:ty) => {
+        create_get_ambiguous_field_method!(
+            "",
+            $type_name,
+            $type_name,
+            $variant,
+            &[$type],
+            $type_name
+        );
+    };
+}
+
 pub trait LdtkFields {
     /// Immutable accessor for this item's field instances, by reference.
     fn field_instances(&self) -> &[FieldInstance];
@@ -160,6 +173,7 @@ pub trait LdtkFields {
     create_just_get_field_method_copy!(color, Color, Color);
 
     create_get_field_methods!(file_path, FilePath, &Option<String>, &str);
+    create_get_field_methods!(enumerator, Enum, &Option<String>, &str);
     create_get_field_methods!(tile, Tile, &Option<TilesetRectangle>, &TilesetRectangle);
     create_get_field_methods!(
         entity_ref,
@@ -171,6 +185,24 @@ pub trait LdtkFields {
     create_get_field_methods_copy!(point, Point, IVec2);
 
     create_get_plural_fields_methods!(ints, Ints, Option<i32>, &i32);
+    create_get_plural_fields_methods!(floats, Floats, Option<f32>, &f32);
+
+    create_just_get_plural_fields_method!(bools, Bools, bool);
+
+    create_get_plural_fields_methods!(strings, Strings, Option<String>, &String);
+
+    create_just_get_plural_fields_method!(colors, Colors, Color);
+
+    create_get_plural_fields_methods!(file_paths, FilePaths, Option<String>, &String);
+    create_get_plural_fields_methods!(enums, Enums, Option<String>, &String);
+    create_get_plural_fields_methods!(tiles, Tiles, Option<TilesetRectangle>, &TilesetRectangle);
+    create_get_plural_fields_methods!(
+        entity_refs,
+        EntityRefs,
+        Option<FieldInstanceEntityReference>,
+        &FieldInstanceEntityReference
+    );
+    create_get_plural_fields_methods!(points, Points, Option<IVec2>, &IVec2);
 
     // implement similar methods for all `FieldValue` variants...
 }

--- a/src/ldtk/ldtk_fields.rs
+++ b/src/ldtk/ldtk_fields.rs
@@ -6,13 +6,17 @@ use bevy::prelude::*;
 use paste::paste;
 use thiserror::Error;
 
+/// Errors related to the [LdtkFields] trait.
 #[derive(Debug, Error)]
 pub enum LdtkFieldsError {
+    /// Could not find a field instance with the given identifier.
     #[error("could not find {identifier} field")]
     FieldNotFound { identifier: String },
+    /// The field instance exists, but is the wrong [FieldValue] variant.
     #[error("found {identifier} field, but its type is not correct")]
     WrongFieldType { identifier: String },
-    #[error("found {identifier} field of the correct type, but it is null")]
+    /// The field instance exists and is the correct variant, but the value is null.
+    #[error("found {identifier} field of the correct type, but the value is null")]
     UnexpectedNull { identifier: String },
 }
 

--- a/src/ldtk/ldtk_fields.rs
+++ b/src/ldtk/ldtk_fields.rs
@@ -196,12 +196,12 @@ pub trait LdtkFields {
 
     create_just_get_plural_fields_method!(bools, Bools, bool);
 
-    create_get_plural_fields_methods!(strings, Strings, Option<String>, &String);
+    create_get_plural_fields_methods!(strings, Strings, Option<String>, &str, |e| e.as_str());
 
     create_just_get_plural_fields_method!(colors, Colors, Color);
 
-    create_get_plural_fields_methods!(file_paths, FilePaths, Option<String>, &String);
-    create_get_plural_fields_methods!(enums, Enums, Option<String>, &String);
+    create_get_plural_fields_methods!(file_paths, FilePaths, Option<String>, &str, |e| e.as_str());
+    create_get_plural_fields_methods!(enums, Enums, Option<String>, &str, |e| e.as_str());
     create_get_plural_fields_methods!(tiles, Tiles, Option<TilesetRectangle>, &TilesetRectangle);
     create_get_plural_fields_methods!(
         entity_refs,

--- a/src/ldtk/ldtk_fields.rs
+++ b/src/ldtk/ldtk_fields.rs
@@ -109,19 +109,6 @@ macro_rules! create_get_maybe_field_method {
     }
 }
 
-/// Generates a `get_maybe_type_field` method for the given [FieldValue] variant,
-/// accessing a field instance and unwrapping it to the given variant or erroring,
-/// and returning a copy to it instead of a reference.
-///
-/// Intended only for variants whose internal type is optional and can be cheaply copied.
-macro_rules! create_get_maybe_field_method_copy {
-    ($type_name:ident, $variant:ident, $maybe_type:ty) => {
-        paste! {
-            create_base_get_field_method!("nullable ", $type_name, [< maybe_ $type_name >], $variant, $maybe_type, *[< maybe_ $type_name >]);
-        }
-    }
-}
-
 /// Generates a `get_type_field` method for the given [FieldValue] variant,
 /// accessing a field instance and unwrapping it to the given variant or erroring,
 /// and returning a copy to it instead of a reference.
@@ -132,17 +119,6 @@ macro_rules! create_just_get_field_method {
         paste! {
             create_base_get_field_method!("", $type_name, $type_name, $variant, $type, $type_name);
         }
-    };
-}
-
-/// Generates both `get_maybe_type_field` and `get_type_field` methods for the given [FieldValue]
-/// variant.
-///
-/// Intended only for variants whose internal type is optional and can be cheaply copied.
-macro_rules! create_get_field_methods_copy {
-    ($type_name:ident, $variant:ident, $type:ty) => {
-        create_get_maybe_field_method_copy!($type_name, $variant, Option<$type>);
-        create_get_field_method!($type_name, $variant, $type);
     };
 }
 

--- a/src/ldtk/ldtk_fields.rs
+++ b/src/ldtk/ldtk_fields.rs
@@ -74,7 +74,7 @@ macro_rules! create_get_field_method {
 /// Generates a `get_types_field` method corresponding to a `get_maybe_types_field` method,
 /// unwrapping the optionals if they are all `Some` or erroring.
 macro_rules! create_get_plural_fields_method {
-    ($type_name:ident, $variant:ident, $item:ty, $map:expr) => {
+    ($type_name:ident, $variant:ident, $item:ty) => {
         paste! {
             #[doc = " Get this item's non-null " $type_name " field value for the given identifier."]
             ///
@@ -150,7 +150,7 @@ macro_rules! create_just_get_plural_fields_method {
 macro_rules! create_get_plural_fields_methods {
     ($type_name:ident, $variant:ident, $maybe_type:ty, $as_ref_type: ty) => {
         create_get_maybe_field_method!($type_name, $variant, &[$maybe_type]);
-        create_get_plural_fields_method!($type_name, $variant, $as_ref_type, |e| e);
+        create_get_plural_fields_method!($type_name, $variant, $as_ref_type);
     };
 }
 

--- a/src/ldtk/ldtk_fields.rs
+++ b/src/ldtk/ldtk_fields.rs
@@ -1,3 +1,4 @@
+//! Contains [LdtkFields] trait, providing convenience methods for accessing field instances.
 use crate::ldtk::{
     EntityInstance, FieldInstance, FieldInstanceEntityReference, FieldValue, Level,
     TilesetRectangle,
@@ -142,6 +143,7 @@ macro_rules! create_just_get_plural_fields_method {
     };
 }
 
+/// Convenience methods for accessing field instances.
 pub trait LdtkFields {
     /// Immutable accessor for this item's field instances, by reference.
     fn field_instances(&self) -> &[FieldInstance];

--- a/src/ldtk/ldtk_fields.rs
+++ b/src/ldtk/ldtk_fields.rs
@@ -445,7 +445,7 @@ mod tests {
                         field_instances
                             .$method_name($ident)
                             .unwrap()
-                            .copied()
+                            .cloned()
                             .collect::<Vec<_>>(),
                         $value
                     );
@@ -576,11 +576,141 @@ mod tests {
 
     test_ambiguous_get_field_method!(
         get_maybe_ints_field,
-        "Bool",
+        "Bools",
         "IntsNullable",
         [None, Some(5)],
         "Ints",
         [Some(6), Some(7)]
     );
-    test_iter_fields_method!(iter_ints_field, "Bool", "IntsNullable", "Ints", [6, 7]);
+    test_iter_fields_method!(iter_ints_field, "Bools", "IntsNullable", "Ints", [6, 7]);
+
+    test_ambiguous_get_field_method!(
+        get_maybe_floats_field,
+        "Bools",
+        "FloatsNullable",
+        [None, Some(8.)],
+        "Floats",
+        [Some(9.), Some(10.)]
+    );
+    test_iter_fields_method!(
+        iter_floats_field,
+        "Bools",
+        "FloatsNullable",
+        "Floats",
+        [9., 10.]
+    );
+
+    test_ambiguous_get_field_method!(get_bools_field, "Colors", "Bools", [false, true]);
+
+    test_ambiguous_get_field_method!(
+        get_maybe_strings_field,
+        "Bools",
+        "StringsNullable",
+        [None, Some("eleven".to_string())],
+        "Strings",
+        [Some("twelve".to_string()), Some("thirteen".to_string())]
+    );
+    test_iter_fields_method!(
+        iter_strings_field,
+        "Bools",
+        "StringsNullable",
+        "Strings",
+        ["twelve".to_string(), "thirteen".to_string()]
+    );
+
+    test_ambiguous_get_field_method!(
+        get_colors_field,
+        "Bools",
+        "Colors",
+        [Color::BLACK, Color::WHITE]
+    );
+
+    test_ambiguous_get_field_method!(
+        get_maybe_file_paths_field,
+        "Bools",
+        "FilePathsNullable",
+        [None, Some("fourteen".to_string())],
+        "FilePaths",
+        [Some("fifteen".to_string()), Some("sixteen".to_string())]
+    );
+    test_iter_fields_method!(
+        iter_file_paths_field,
+        "Bools",
+        "FilePathsNullable",
+        "FilePaths",
+        ["fifteen".to_string(), "sixteen".to_string()]
+    );
+
+    test_ambiguous_get_field_method!(
+        get_maybe_enums_field,
+        "Bools",
+        "EnumsNullable",
+        [None, Some("Seventeen".to_string())],
+        "Enums",
+        [Some("Eighteen".to_string()), Some("Nineteen".to_string())]
+    );
+    test_iter_fields_method!(
+        iter_enums_field,
+        "Bools",
+        "EnumsNullable",
+        "Enums",
+        ["Eighteen".to_string(), "Nineteen".to_string()]
+    );
+
+    test_ambiguous_get_field_method!(
+        get_maybe_tiles_field,
+        "Bools",
+        "TilesNullable",
+        [None, Some(TilesetRectangle::default())],
+        "Tiles",
+        [
+            Some(TilesetRectangle::default()),
+            Some(TilesetRectangle::default())
+        ]
+    );
+    test_iter_fields_method!(
+        iter_tiles_field,
+        "Bools",
+        "TilesNullable",
+        "Tiles",
+        [TilesetRectangle::default(), TilesetRectangle::default()]
+    );
+
+    test_ambiguous_get_field_method!(
+        get_maybe_entity_refs_field,
+        "Bools",
+        "EntityRefsNullable",
+        [None, Some(FieldInstanceEntityReference::default())],
+        "EntityRefs",
+        [
+            Some(FieldInstanceEntityReference::default()),
+            Some(FieldInstanceEntityReference::default())
+        ]
+    );
+    test_iter_fields_method!(
+        iter_entity_refs_field,
+        "Bools",
+        "EntityRefsNullable",
+        "EntityRefs",
+        [
+            FieldInstanceEntityReference::default(),
+            FieldInstanceEntityReference::default()
+        ]
+    );
+
+    test_ambiguous_get_field_method!(
+        get_maybe_points_field,
+        "Bools",
+        "PointsNullable",
+        [None, Some(IVec2::default())],
+        "Points",
+        [Some(IVec2::default()), Some(IVec2::default())]
+    );
+    test_iter_fields_method!(
+        iter_points_field,
+        "Bools",
+        "PointsNullable",
+        "Points",
+        [IVec2::default(), IVec2::default()]
+    );
 }

--- a/src/ldtk/ldtk_fields.rs
+++ b/src/ldtk/ldtk_fields.rs
@@ -260,3 +260,124 @@ impl LdtkFields for Level {
         &self.field_instances
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    impl LdtkFields for Vec<FieldInstance> {
+        fn field_instances(&self) -> &[FieldInstance] {
+            &self
+        }
+    }
+
+    fn field_instance_from_value(identifier: &str, value: FieldValue) -> FieldInstance {
+        FieldInstance {
+            identifier: identifier.to_string(),
+            value,
+            field_instance_type: "".to_string(),
+            tile: None,
+            def_uid: 0,
+            real_editor_values: Vec::new(),
+        }
+    }
+
+    fn sample_field_instances() -> Vec<FieldInstance> {
+        use FieldValue::*;
+        vec![
+            field_instance_from_value("IntNone", Int(None)),
+            field_instance_from_value("IntSome", Int(Some(0))),
+            field_instance_from_value("FloatNone", Float(None)),
+            field_instance_from_value("FloatSome", Float(Some(1.0))),
+            field_instance_from_value("Bool", Bool(true)),
+            field_instance_from_value("StringNone", String(None)),
+            field_instance_from_value("StringSome", String(Some("two".to_string()))),
+            field_instance_from_value("Color", Color(bevy::prelude::Color::BLACK)),
+            field_instance_from_value("FilePathNone", FilePath(None)),
+            field_instance_from_value("FilePathSome", FilePath(Some("three".to_string()))),
+            field_instance_from_value("EnumNone", Enum(None)),
+            field_instance_from_value("EnumSome", Enum(Some("Four".to_string()))),
+            field_instance_from_value("TileNone", Tile(None)),
+            field_instance_from_value("TileSome", Tile(Some(TilesetRectangle::default()))),
+            field_instance_from_value("EntityRefNone", EntityRef(None)),
+            field_instance_from_value(
+                "EntityRefSome",
+                EntityRef(Some(FieldInstanceEntityReference::default())),
+            ),
+            field_instance_from_value("PointNone", Point(None)),
+            field_instance_from_value("PointSome", Point(Some(IVec2::default()))),
+            field_instance_from_value("IntsNullable", Ints(vec![None, Some(5)])),
+            field_instance_from_value("Ints", Ints(vec![Some(6), Some(7)])),
+            field_instance_from_value("FloatsNullable", Floats(vec![None, Some(8.)])),
+            field_instance_from_value("Floats", Floats(vec![Some(9.), Some(10.)])),
+            field_instance_from_value("Bools", Bools(vec![false, true])),
+            field_instance_from_value(
+                "StringsNullable",
+                Strings(vec![None, Some("eleven".to_string())]),
+            ),
+            field_instance_from_value(
+                "Strings",
+                Strings(vec![
+                    Some("twelve".to_string()),
+                    Some("thirteen".to_string()),
+                ]),
+            ),
+            field_instance_from_value(
+                "Colors",
+                Colors(vec![
+                    bevy::prelude::Color::BLACK,
+                    bevy::prelude::Color::WHITE,
+                ]),
+            ),
+            field_instance_from_value(
+                "FilePathsNullable",
+                FilePaths(vec![None, Some("fourteen".to_string())]),
+            ),
+            field_instance_from_value(
+                "FilePaths",
+                FilePaths(vec![
+                    Some("fifteen".to_string()),
+                    Some("sixteen".to_string()),
+                ]),
+            ),
+            field_instance_from_value(
+                "EnumsNullable",
+                Enums(vec![None, Some("Seventeen".to_string())]),
+            ),
+            field_instance_from_value(
+                "Enums",
+                Enums(vec![
+                    Some("Eighteen".to_string()),
+                    Some("Nineteen".to_string()),
+                ]),
+            ),
+            field_instance_from_value(
+                "TilesNullable",
+                Tiles(vec![None, Some(TilesetRectangle::default())]),
+            ),
+            field_instance_from_value(
+                "Tiles",
+                Tiles(vec![
+                    Some(TilesetRectangle::default()),
+                    Some(TilesetRectangle::default()),
+                ]),
+            ),
+            field_instance_from_value(
+                "EntityRefsNullable",
+                EntityRefs(vec![None, Some(FieldInstanceEntityReference::default())]),
+            ),
+            field_instance_from_value(
+                "EntityRefs",
+                EntityRefs(vec![
+                    Some(FieldInstanceEntityReference::default()),
+                    Some(FieldInstanceEntityReference::default()),
+                ]),
+            ),
+            field_instance_from_value("PointsNullable", Points(vec![None, Some(IVec2::default())])),
+            field_instance_from_value(
+                "Points",
+                Points(vec![Some(IVec2::default()), Some(IVec2::default())]),
+            ),
+        ]
+    }
+}

--- a/src/ldtk/ldtk_fields.rs
+++ b/src/ldtk/ldtk_fields.rs
@@ -27,7 +27,7 @@ pub enum LdtkFieldsError {
 ///
 /// This macro is not intended for doing any further unwrapping, such as unwrapping an option.
 macro_rules! create_base_get_field_method {
-    ($adjective:literal, $doc_name:ident, $var_name:ident, $variant:ident, $return_type:ty, $return_expr:expr) => {
+    ($adjective:literal, $doc_name:ident, $var_name:ident, $variant:ident, $return_type:ty) => {
         paste! {
             #[doc = " Get this item's " $adjective $doc_name " field value for the given identifier."]
             ///
@@ -39,7 +39,7 @@ macro_rules! create_base_get_field_method {
                 identifier: &str,
             ) -> Result<$return_type, LdtkFieldsError> {
                 match self.get_field(identifier)? {
-                    FieldValue::$variant($var_name) => Ok($return_expr),
+                    FieldValue::$variant($var_name) => Ok($var_name),
                     _ => Err(LdtkFieldsError::WrongFieldType {
                         identifier: identifier.to_string(),
                     }),
@@ -104,7 +104,7 @@ macro_rules! create_get_plural_fields_method {
 macro_rules! create_get_maybe_field_method {
     ($type_name:ident, $variant:ident, $maybe_type:ty) => {
         paste! {
-            create_base_get_field_method!("nullable ", $type_name, [< maybe_ $type_name >], $variant, $maybe_type, [< maybe_ $type_name >]);
+            create_base_get_field_method!("nullable ", $type_name, [< maybe_ $type_name >], $variant, $maybe_type);
         }
     }
 }
@@ -117,7 +117,7 @@ macro_rules! create_get_maybe_field_method {
 macro_rules! create_just_get_field_method {
     ($type_name:ident, $variant:ident, $type:ty) => {
         paste! {
-            create_base_get_field_method!("", $type_name, $type_name, $variant, $type, $type_name);
+            create_base_get_field_method!("", $type_name, $type_name, $variant, $type);
         }
     };
 }
@@ -139,7 +139,7 @@ macro_rules! create_get_field_methods {
 /// Intended only for variants whose internal type is a collection of a **non-optional** type.
 macro_rules! create_just_get_plural_fields_method {
     ($type_name:ident, $variant:ident, $type:ty) => {
-        create_base_get_field_method!("", $type_name, $type_name, $variant, &[$type], $type_name);
+        create_base_get_field_method!("", $type_name, $type_name, $variant, &[$type]);
     };
 }
 

--- a/src/ldtk/ldtk_fields.rs
+++ b/src/ldtk/ldtk_fields.rs
@@ -60,8 +60,8 @@ macro_rules! create_get_field_method {
             #[doc = " - returns [`LdtkFieldsError::WrongFieldType`] if the field is not [`FieldValue::" $variant "`]."]
             /// - returns [`LdtkFieldsError::UnexpectedNull`] if the field is null.
             fn [< get_ $type_name _field >](&self, identifier: &str) -> Result<$type, LdtkFieldsError> {
-                if let Some($type_name) = self.[< get_maybe_ $type_name _field >](identifier.clone())? {
-                    Ok($type_name)
+                if let Some([< $type_name _ >]) = self.[< get_maybe_ $type_name _field >](identifier.clone())? {
+                    Ok([< $type_name _ >])
                 } else {
                     Err(LdtkFieldsError::UnexpectedNull { identifier: identifier.to_string() })
                 }
@@ -217,7 +217,7 @@ pub trait LdtkFields {
     create_just_get_field_method_copy!(color, Color, Color);
 
     create_get_field_methods!(file_path, FilePath, &Option<String>, &str);
-    create_get_field_methods!(enumerator, Enum, &Option<String>, &str);
+    create_get_field_methods!(enum, Enum, &Option<String>, &str);
     create_get_field_methods!(tile, Tile, &Option<TilesetRectangle>, &TilesetRectangle);
     create_get_field_methods!(
         entity_ref,

--- a/src/ldtk/ldtk_fields.rs
+++ b/src/ldtk/ldtk_fields.rs
@@ -380,4 +380,49 @@ mod tests {
             ),
         ]
     }
+
+    macro_rules! test_get_field_methods {
+        ($type_name:ident, $maybe_ident:literal, $just_ident:literal, $wrong_ident:literal, $expected_maybe:expr, $expected_just:expr) => {
+            paste! {
+                #[test]
+                fn [< test_get_ $type_name _field_methods >]() {
+                    let field_instances = sample_field_instances();
+
+                    assert!(matches!(
+                        field_instances.[< get_maybe_ $type_name _field >]("NonExistent"),
+                        Err(LdtkFieldsError::FieldNotFound { .. })
+                    ));
+                    assert!(matches!(
+                        field_instances.[< get_maybe_ $type_name _field >]($wrong_ident),
+                        Err(LdtkFieldsError::WrongFieldType { .. })
+                    ));
+                    assert_eq!(
+                        field_instances.[< get_maybe_ $type_name _field >]($maybe_ident).unwrap(),
+                        None
+                    );
+                    assert_eq!(
+                        field_instances.[< get_maybe_ $type_name _field >]($just_ident).unwrap(),
+                        $expected_maybe
+                    );
+
+                    assert!(matches!(
+                        field_instances.[< get_ $type_name _field >]("NonExistent"),
+                        Err(LdtkFieldsError::FieldNotFound { .. })
+                    ));
+                    assert!(matches!(
+                        field_instances.[< get_ $type_name _field >]($wrong_ident),
+                        Err(LdtkFieldsError::WrongFieldType { .. })
+                    ));
+                    assert!(matches!(
+                        field_instances.[< get_ $type_name _field >]($maybe_ident),
+                        Err(LdtkFieldsError::UnexpectedNull { .. })
+                    ));
+                    assert_eq!(field_instances.[< get_ $type_name _field >]($just_ident).unwrap(), $expected_just);
+                }
+            }
+        };
+    }
+
+    test_get_field_methods!(int, "IntNone", "IntSome", "Bool", Some(0), 0);
+    test_get_field_methods!(float, "FloatNone", "FloatSome", "Bool", Some(1.0), 1.0);
 }

--- a/src/ldtk/ldtk_fields.rs
+++ b/src/ldtk/ldtk_fields.rs
@@ -23,12 +23,12 @@ macro_rules! create_get_ambiguous_field_method_copy {
             #[doc = " - returns [LdtkFieldsError::WrongFieldType] if the field is not " $variant "."]
             fn [< get_ $type_name _field >](
                 &self,
-                identifier: String,
+                identifier: &str,
             ) -> Result<$type, LdtkFieldsError> {
-                match self.get_field(identifier.clone())? {
+                match self.get_field(identifier)? {
                     FieldValue::$variant($type_name) => Ok(*$type_name),
                     _ => Err(LdtkFieldsError::WrongFieldType {
-                        identifier,
+                        identifier: identifier.to_string(),
                     }),
                 }
             }
@@ -46,12 +46,12 @@ macro_rules! create_get_maybe_field_method {
             #[doc = " - returns [LdtkFieldsError::WrongFieldType] if the field is not " $variant "."]
             fn [< get_maybe_ $type_name _field >](
                 &self,
-                identifier: String,
+                identifier: &str,
             ) -> Result<$maybe_type, LdtkFieldsError> {
-                match self.get_field(identifier.clone())? {
+                match self.get_field(identifier)? {
                     FieldValue::$variant($type_name) => Ok($type_name),
                     _ => Err(LdtkFieldsError::WrongFieldType {
-                        identifier,
+                        identifier: identifier.to_string(),
                     }),
                 }
             }
@@ -68,11 +68,11 @@ macro_rules! create_get_field_method {
             /// - returns [LdtkFieldsError::FieldNotFound] if no field with the given identifier exists.
             #[doc = " - returns [LdtkFieldsError::WrongFieldType] if the field is not " $variant "."]
             /// - returns [LdtkFieldsError::UnexpectedNull] if the field is null.
-            fn [< get_ $type_name _field >](&self, identifier: String) -> Result<$type, LdtkFieldsError> {
+            fn [< get_ $type_name _field >](&self, identifier: &str) -> Result<$type, LdtkFieldsError> {
                 if let Some($type_name) = self.[< get_maybe_ $type_name _field >](identifier.clone())? {
                     Ok($type_name)
                 } else {
-                    Err(LdtkFieldsError::UnexpectedNull { identifier })
+                    Err(LdtkFieldsError::UnexpectedNull { identifier: identifier.to_string() })
                 }
             }
         }
@@ -103,18 +103,20 @@ pub trait LdtkFields {
     ///
     /// # Errors
     /// - returns [LdtkFieldsError::FieldNotFound] if no field with the given identifier exists.
-    fn get_field_instance(&self, identifier: String) -> Result<&FieldInstance, LdtkFieldsError> {
+    fn get_field_instance(&self, identifier: &str) -> Result<&FieldInstance, LdtkFieldsError> {
         self.field_instances()
             .iter()
             .find(|f| f.identifier == identifier)
-            .ok_or(LdtkFieldsError::FieldNotFound { identifier })
+            .ok_or(LdtkFieldsError::FieldNotFound {
+                identifier: identifier.to_string(),
+            })
     }
 
     /// Get this item's field value for the given identifier.
     ///
     /// # Errors
     /// - returns [LdtkFieldsError::FieldNotFound] if no field with the given identifier exists.
-    fn get_field(&self, identifier: String) -> Result<&FieldValue, LdtkFieldsError> {
+    fn get_field(&self, identifier: &str) -> Result<&FieldValue, LdtkFieldsError> {
         Ok(&self.get_field_instance(identifier)?.value)
     }
 

--- a/src/ldtk/ldtk_fields.rs
+++ b/src/ldtk/ldtk_fields.rs
@@ -1,0 +1,50 @@
+use crate::ldtk::{FieldInstance, FieldValue};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum LdtkFieldsError {
+    #[error("could not find {identifier} field")]
+    FieldNotFound { identifier: String },
+    #[error("found {identifier} field, but its type is not {requested_type}")]
+    WrongFieldType {
+        identifier: String,
+        requested_type: String,
+    },
+    #[error("found {identifier} field of the correct type, but it is null")]
+    UnexpectedNull { identifier: String },
+}
+
+pub trait LdtkFields {
+    fn field_instances(&self) -> &[FieldInstance];
+
+    fn get_field_instance(&self, identifier: String) -> Result<&FieldInstance, LdtkFieldsError> {
+        self.field_instances()
+            .iter()
+            .find(|f| f.identifier == identifier)
+            .ok_or(LdtkFieldsError::FieldNotFound { identifier })
+    }
+
+    fn get_field(&self, identifier: String) -> Result<&FieldValue, LdtkFieldsError> {
+        Ok(&self.get_field_instance(identifier)?.value)
+    }
+
+    fn get_maybe_int_field(&self, identifier: String) -> Result<Option<i32>, LdtkFieldsError> {
+        match self.get_field(identifier.clone())? {
+            FieldValue::Int(maybe_int) => Ok(*maybe_int),
+            _ => Err(LdtkFieldsError::WrongFieldType {
+                identifier,
+                requested_type: "Int".to_string(),
+            }),
+        }
+    }
+
+    fn get_int_field(&self, identifier: String) -> Result<i32, LdtkFieldsError> {
+        if let Some(int) = self.get_maybe_int_field(identifier.clone())? {
+            Ok(int)
+        } else {
+            Err(LdtkFieldsError::UnexpectedNull { identifier })
+        }
+    }
+
+    // implement similar methods for all `FieldValue` variants...
+}

--- a/src/ldtk/ldtk_fields.rs
+++ b/src/ldtk/ldtk_fields.rs
@@ -101,16 +101,16 @@ macro_rules! create_get_field_method {
 
 /// Generates a `get_types_field` method corresponding to a `get_maybe_types_field` method,
 /// unwrapping the optionals if they are all `Some` or erroring.
-macro_rules! create_get_plural_fields_method {
+macro_rules! create_iter_plural_fields_method {
     ($variant:ident, $item:ty) => {
         paste! {
-            #[doc = " Get this item's non-null " $variant " field value for the given identifier."]
+            #[doc = " Iterate over this item's non-null " $variant " field value for the given identifier."]
             ///
             /// # Errors
             /// - returns [`LdtkFieldsError::FieldNotFound`] if no field with the given identifier exists.
             #[doc = " - returns [`LdtkFieldsError::WrongFieldType`] if the field is not [`FieldValue::" $variant "`]."]
             /// - returns [`LdtkFieldsError::UnexpectedNull`] if **any** element of the field is null.
-            fn [< get_ $variant:snake _field >](&self, identifier: &str) -> Result<AllSomeIter<$item>, LdtkFieldsError> {
+            fn [< iter_ $variant:snake _field >](&self, identifier: &str) -> Result<AllSomeIter<$item>, LdtkFieldsError> {
                 let [< $variant:snake >]= self.[< get_maybe_ $variant:snake _field >](identifier)?;
 
                 [< $variant:snake >].try_into().map_err(|_| LdtkFieldsError::UnexpectedNull { identifier: identifier.to_string() })
@@ -171,10 +171,10 @@ macro_rules! create_just_get_plural_fields_method {
 /// variant.
 ///
 /// Intended only for variants whose internal type is a collection of an optional type.
-macro_rules! create_get_plural_fields_methods {
+macro_rules! create_plural_fields_methods {
     ($variant:ident, $type:ty) => {
         create_get_maybe_field_method!($variant, &[Option<$type>]);
-        create_get_plural_fields_method!($variant, $type);
+        create_iter_plural_fields_method!($variant, $type);
     };
 }
 
@@ -220,20 +220,20 @@ pub trait LdtkFields {
 
     create_get_field_methods!(Point, IVec2);
 
-    create_get_plural_fields_methods!(Ints, i32);
-    create_get_plural_fields_methods!(Floats, f32);
+    create_plural_fields_methods!(Ints, i32);
+    create_plural_fields_methods!(Floats, f32);
 
     create_just_get_plural_fields_method!(Bools, bool);
 
-    create_get_plural_fields_methods!(Strings, String);
+    create_plural_fields_methods!(Strings, String);
 
     create_just_get_plural_fields_method!(Colors, Color);
 
-    create_get_plural_fields_methods!(FilePaths, String);
-    create_get_plural_fields_methods!(Enums, String);
-    create_get_plural_fields_methods!(Tiles, TilesetRectangle);
-    create_get_plural_fields_methods!(EntityRefs, FieldInstanceEntityReference);
-    create_get_plural_fields_methods!(Points, IVec2);
+    create_plural_fields_methods!(FilePaths, String);
+    create_plural_fields_methods!(Enums, String);
+    create_plural_fields_methods!(Tiles, TilesetRectangle);
+    create_plural_fields_methods!(EntityRefs, FieldInstanceEntityReference);
+    create_plural_fields_methods!(Points, IVec2);
 }
 
 impl LdtkFields for EntityInstance {

--- a/src/ldtk/ldtk_fields.rs
+++ b/src/ldtk/ldtk_fields.rs
@@ -60,7 +60,7 @@ macro_rules! create_get_field_method {
             /// - returns [`LdtkFieldsError::FieldNotFound`] if no field with the given identifier exists.
             #[doc = " - returns [`LdtkFieldsError::WrongFieldType`] if the field is not [`FieldValue::" $variant "`]."]
             /// - returns [`LdtkFieldsError::UnexpectedNull`] if the field is null.
-            fn [< get_ $type_name _field >](&self, identifier: &str) -> Result<$type, LdtkFieldsError> {
+            fn [< get_ $type_name _field >](&self, identifier: &str) -> Result<&$type, LdtkFieldsError> {
                 if let Some([< $type_name _ >]) = self.[< get_maybe_ $type_name _field >](identifier.clone())? {
                     Ok([< $type_name _ >])
                 } else {
@@ -129,7 +129,7 @@ macro_rules! create_just_get_field_method {
 macro_rules! create_get_field_methods {
     ($type_name:ident, $variant:ident, $type:ty) => {
         create_get_maybe_field_method!($type_name, $variant, &Option<$type>);
-        create_get_field_method!($type_name, $variant, &$type);
+        create_get_field_method!($type_name, $variant, $type);
     };
 }
 

--- a/src/ldtk/ldtk_fields.rs
+++ b/src/ldtk/ldtk_fields.rs
@@ -117,7 +117,7 @@ macro_rules! create_get_maybe_field_method {
 macro_rules! create_just_get_field_method {
     ($type_name:ident, $variant:ident, $type:ty) => {
         paste! {
-            create_base_get_field_method!("", $type_name, $type_name, $variant, $type);
+            create_base_get_field_method!("", $type_name, $type_name, $variant, &$type);
         }
     };
 }
@@ -183,11 +183,11 @@ pub trait LdtkFields {
     create_get_field_methods!(int, Int, i32);
     create_get_field_methods!(float, Float, f32);
 
-    create_just_get_field_method!(bool, Bool, &bool);
+    create_just_get_field_method!(bool, Bool, bool);
 
     create_get_field_methods!(string, String, String);
 
-    create_just_get_field_method!(color, Color, &Color);
+    create_just_get_field_method!(color, Color, Color);
 
     create_get_field_methods!(file_path, FilePath, String);
     create_get_field_methods!(enum, Enum, String);

--- a/src/ldtk/ldtk_fields.rs
+++ b/src/ldtk/ldtk_fields.rs
@@ -1,40 +1,11 @@
 //! Contains [`LdtkFields`] trait, providing convenience methods for accessing field instances.
 use crate::ldtk::{
-    EntityInstance, FieldInstance, FieldInstanceEntityReference, FieldValue, Level,
-    TilesetRectangle,
+    all_some_iter::AllSomeIter, EntityInstance, FieldInstance, FieldInstanceEntityReference,
+    FieldValue, Level, TilesetRectangle,
 };
 use bevy::prelude::*;
 use paste::paste;
-use std::{iter::Flatten, slice::Iter};
 use thiserror::Error;
-
-pub struct NotAllSomeError;
-
-pub struct AllSomeIter<'a, T> {
-    flattened: Flatten<Iter<'a, Option<T>>>,
-}
-
-impl<'a, T> Iterator for AllSomeIter<'a, T> {
-    type Item = &'a T;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.flattened.next()
-    }
-}
-
-impl<'a, T> TryFrom<&'a [Option<T>]> for AllSomeIter<'a, T> {
-    type Error = NotAllSomeError;
-
-    fn try_from(value: &'a [Option<T>]) -> Result<Self, Self::Error> {
-        if value.iter().all(|v| v.is_some()) {
-            Ok(AllSomeIter {
-                flattened: value.iter().flatten(),
-            })
-        } else {
-            Err(NotAllSomeError)
-        }
-    }
-}
 
 /// Errors related to the [`LdtkFields`] trait.
 #[derive(Debug, PartialEq, Eq, Error)]

--- a/src/ldtk/ldtk_fields.rs
+++ b/src/ldtk/ldtk_fields.rs
@@ -127,9 +127,9 @@ macro_rules! create_just_get_field_method {
 ///
 /// Intended only for variants whose internal type is optional.
 macro_rules! create_get_field_methods {
-    ($type_name:ident, $variant:ident, $maybe_type:ty, $as_ref_type: ty) => {
-        create_get_maybe_field_method!($type_name, $variant, $maybe_type);
-        create_get_field_method!($type_name, $variant, $as_ref_type);
+    ($type_name:ident, $variant:ident, $type:ty) => {
+        create_get_maybe_field_method!($type_name, $variant, &Option<$type>);
+        create_get_field_method!($type_name, $variant, &$type);
     };
 }
 
@@ -180,26 +180,21 @@ pub trait LdtkFields {
         Ok(&self.get_field_instance(identifier)?.value)
     }
 
-    create_get_field_methods!(int, Int, &Option<i32>, &i32);
-    create_get_field_methods!(float, Float, &Option<f32>, &f32);
+    create_get_field_methods!(int, Int, i32);
+    create_get_field_methods!(float, Float, f32);
 
     create_just_get_field_method!(bool, Bool, &bool);
 
-    create_get_field_methods!(string, String, &Option<String>, &String);
+    create_get_field_methods!(string, String, String);
 
     create_just_get_field_method!(color, Color, &Color);
 
-    create_get_field_methods!(file_path, FilePath, &Option<String>, &String);
-    create_get_field_methods!(enum, Enum, &Option<String>, &String);
-    create_get_field_methods!(tile, Tile, &Option<TilesetRectangle>, &TilesetRectangle);
-    create_get_field_methods!(
-        entity_ref,
-        EntityRef,
-        &Option<FieldInstanceEntityReference>,
-        &FieldInstanceEntityReference
-    );
+    create_get_field_methods!(file_path, FilePath, String);
+    create_get_field_methods!(enum, Enum, String);
+    create_get_field_methods!(tile, Tile, TilesetRectangle);
+    create_get_field_methods!(entity_ref, EntityRef, FieldInstanceEntityReference);
 
-    create_get_field_methods!(point, Point, &Option<IVec2>, &IVec2);
+    create_get_field_methods!(point, Point, IVec2);
 
     create_get_plural_fields_methods!(ints, Ints, Option<i32>, i32);
     create_get_plural_fields_methods!(floats, Floats, Option<f32>, f32);

--- a/src/ldtk/ldtk_fields.rs
+++ b/src/ldtk/ldtk_fields.rs
@@ -103,10 +103,9 @@ macro_rules! create_get_maybe_field_method {
 }
 
 /// Generates a `get_type_field` method for the given [FieldValue] variant,
-/// accessing a field instance and unwrapping it to the given variant or erroring,
-/// and returning a copy to it instead of a reference.
+/// accessing a field instance and unwrapping it to the given variant or erroring.
 ///
-/// Intended only for variants whose internal type is **not** optional and can be cheaply copied.
+/// Intended only for variants whose internal type is **not** optional.
 macro_rules! create_just_get_field_method {
     ($variant:ident, $type:ty) => {
         paste! {

--- a/src/ldtk/ldtk_fields.rs
+++ b/src/ldtk/ldtk_fields.rs
@@ -21,6 +21,10 @@ pub enum LdtkFieldsError {
     UnexpectedNull { identifier: String },
 }
 
+/// Base macro for generating a method that accesses a field instance and unwraps its [FieldValue]
+/// variant into the assigned type, or errors if it isn't the correct variant.
+///
+/// This macro is not intended for doing any further unwrapping, such as unwrapping an option.
 macro_rules! create_base_get_field_method {
     ($adjective:literal, $doc_name:ident, $var_name:ident, $variant:ident, $return_type:ty, $return_expr:expr) => {
         paste! {
@@ -44,6 +48,8 @@ macro_rules! create_base_get_field_method {
     }
 }
 
+/// Generates a `get_type_field` method corresponding to a `get_maybe_type_field` method,
+/// unwrapping the optional or erroring.
 macro_rules! create_get_field_method {
     ($type_name:ident, $variant:ident, $type:ty) => {
         paste! {
@@ -64,6 +70,8 @@ macro_rules! create_get_field_method {
     };
 }
 
+/// Generates a `get_types_field` method corresponding to a `get_maybe_types_field` method,
+/// unwrapping the optionals if they are all `Some` or erroring.
 macro_rules! create_get_plural_fields_method {
     ($type_name:ident, $variant:ident, $collected_type:ty, $map:expr) => {
         paste! {
@@ -88,6 +96,10 @@ macro_rules! create_get_plural_fields_method {
     };
 }
 
+/// Generates a `get_maybe_type_field` method for the given [FieldValue] variant,
+/// accessing a field instance and unwrapping it to the given variant or erroring.
+///
+/// Intended only for variants whose internal type is optional.
 macro_rules! create_get_maybe_field_method {
     ($type_name:ident, $variant:ident, $maybe_type:ty) => {
         paste! {
@@ -96,6 +108,11 @@ macro_rules! create_get_maybe_field_method {
     }
 }
 
+/// Generates a `get_maybe_type_field` method for the given [FieldValue] variant,
+/// accessing a field instance and unwrapping it to the given variant or erroring,
+/// and returning a copy to it instead of a reference.
+///
+/// Intended only for variants whose internal type is optional and can be cheaply copied.
 macro_rules! create_get_maybe_field_method_copy {
     ($type_name:ident, $variant:ident, $maybe_type:ty) => {
         paste! {
@@ -104,6 +121,11 @@ macro_rules! create_get_maybe_field_method_copy {
     }
 }
 
+/// Generates a `get_type_field` method for the given [FieldValue] variant,
+/// accessing a field instance and unwrapping it to the given variant or erroring,
+/// and returning a copy to it instead of a reference.
+///
+/// Intended only for variants whose internal type is **not** optional and can be cheaply copied.
 macro_rules! create_just_get_field_method_copy {
     ($type_name:ident, $variant:ident, $type:ty) => {
         paste! {
@@ -112,6 +134,10 @@ macro_rules! create_just_get_field_method_copy {
     };
 }
 
+/// Generates both `get_maybe_type_field` and `get_type_field` methods for the given [FieldValue]
+/// variant.
+///
+/// Intended only for variants whose internal type is optional and can be cheaply copied.
 macro_rules! create_get_field_methods_copy {
     ($type_name:ident, $variant:ident, $type:ty) => {
         create_get_maybe_field_method_copy!($type_name, $variant, Option<$type>);
@@ -119,6 +145,10 @@ macro_rules! create_get_field_methods_copy {
     };
 }
 
+/// Generates both `get_maybe_type_field` and `get_type_field` methods for the given [FieldValue]
+/// variant.
+///
+/// Intended only for variants whose internal type is optional.
 macro_rules! create_get_field_methods {
     ($type_name:ident, $variant:ident, $maybe_type:ty, $as_ref_type: ty) => {
         create_get_maybe_field_method!($type_name, $variant, $maybe_type);
@@ -126,6 +156,20 @@ macro_rules! create_get_field_methods {
     };
 }
 
+/// Generates a `get_types_field` method for the given [FieldValue] variant,
+/// accessing a field instance and unwrapping it to the given variant or erroring.
+///
+/// Intended only for variants whose internal type is a collection of a **non-optional** type.
+macro_rules! create_just_get_plural_fields_method {
+    ($type_name:ident, $variant:ident, $type:ty) => {
+        create_base_get_field_method!("", $type_name, $type_name, $variant, &[$type], $type_name);
+    };
+}
+
+/// Generates both `get_maybe_types_field` and `get_types_field` methods for the given [FieldValue]
+/// variant.
+///
+/// Intended only for variants whose internal type is a collection of an optional type.
 macro_rules! create_get_plural_fields_methods {
     ($type_name:ident, $variant:ident, $maybe_type:ty, $as_ref_type: ty) => {
         create_get_maybe_field_method!($type_name, $variant, &[$maybe_type]);
@@ -134,12 +178,6 @@ macro_rules! create_get_plural_fields_methods {
     ($type_name:ident, $variant:ident, $maybe_type:ty, $as_ref_type: ty, $map:expr) => {
         create_get_maybe_field_method!($type_name, $variant, &[$maybe_type]);
         create_get_plural_fields_method!($type_name, $variant, Vec<$as_ref_type>, $map);
-    };
-}
-
-macro_rules! create_just_get_plural_fields_method {
-    ($type_name:ident, $variant:ident, $type:ty) => {
-        create_base_get_field_method!("", $type_name, $type_name, $variant, &[$type], $type_name);
     };
 }
 

--- a/src/ldtk/ldtk_fields.rs
+++ b/src/ldtk/ldtk_fields.rs
@@ -1,4 +1,4 @@
-//! Contains [LdtkFields] trait, providing convenience methods for accessing field instances.
+//! Contains [`LdtkFields`] trait, providing convenience methods for accessing field instances.
 use crate::ldtk::{
     EntityInstance, FieldInstance, FieldInstanceEntityReference, FieldValue, Level,
     TilesetRectangle,
@@ -7,13 +7,13 @@ use bevy::prelude::*;
 use paste::paste;
 use thiserror::Error;
 
-/// Errors related to the [LdtkFields] trait.
+/// Errors related to the [`LdtkFields`] trait.
 #[derive(Debug, Error)]
 pub enum LdtkFieldsError {
     /// Could not find a field instance with the given identifier.
     #[error("could not find {identifier} field")]
     FieldNotFound { identifier: String },
-    /// The field instance exists, but is the wrong [FieldValue] variant.
+    /// The field instance exists, but is the wrong [`FieldValue`] variant.
     #[error("found {identifier} field, but its type is not correct")]
     WrongFieldType { identifier: String },
     /// The field instance exists and is the correct variant, but the value is null.
@@ -27,8 +27,8 @@ macro_rules! create_base_get_field_method {
             #[doc = " Get this item's " $adjective $doc_name " field value for the given identifier."]
             ///
             /// # Errors
-            /// - returns [LdtkFieldsError::FieldNotFound] if no field with the given identifier exists.
-            #[doc = " - returns [LdtkFieldsError::WrongFieldType] if the field is not " $variant "."]
+            /// - returns [`LdtkFieldsError::FieldNotFound`] if no field with the given identifier exists.
+            #[doc = " - returns [`LdtkFieldsError::WrongFieldType`] if the field is not [`FieldValue::" $variant "`]."]
             fn [< get_ $var_name _field >](
                 &self,
                 identifier: &str,
@@ -50,9 +50,9 @@ macro_rules! create_get_field_method {
             #[doc = " Get this item's non-null " $type_name " field value for the given identifier."]
             ///
             /// # Errors
-            /// - returns [LdtkFieldsError::FieldNotFound] if no field with the given identifier exists.
-            #[doc = " - returns [LdtkFieldsError::WrongFieldType] if the field is not " $variant "."]
-            /// - returns [LdtkFieldsError::UnexpectedNull] if the field is null.
+            /// - returns [`LdtkFieldsError::FieldNotFound`] if no field with the given identifier exists.
+            #[doc = " - returns [`LdtkFieldsError::WrongFieldType`] if the field is not [`FieldValue::" $variant "`]."]
+            /// - returns [`LdtkFieldsError::UnexpectedNull`] if the field is null.
             fn [< get_ $type_name _field >](&self, identifier: &str) -> Result<$type, LdtkFieldsError> {
                 if let Some($type_name) = self.[< get_maybe_ $type_name _field >](identifier.clone())? {
                     Ok($type_name)
@@ -70,9 +70,9 @@ macro_rules! create_get_plural_fields_method {
             #[doc = " Get this item's non-null " $type_name " field value for the given identifier."]
             ///
             /// # Errors
-            /// - returns [LdtkFieldsError::FieldNotFound] if no field with the given identifier exists.
-            #[doc = " - returns [LdtkFieldsError::WrongFieldType] if the field is not " $variant "."]
-            /// - returns [LdtkFieldsError::UnexpectedNull] if **any** element of the field is null.
+            /// - returns [`LdtkFieldsError::FieldNotFound`] if no field with the given identifier exists.
+            #[doc = " - returns [`LdtkFieldsError::WrongFieldType`] if the field is not [`FieldValue::" $variant "`]."]
+            /// - returns [`LdtkFieldsError::UnexpectedNull`] if **any** element of the field is null.
             fn [< get_ $type_name _field >](&self, identifier: &str) -> Result<$collected_type, LdtkFieldsError> {
                 let $type_name = self.[< get_maybe_ $type_name _field >](identifier)?;
 
@@ -148,10 +148,10 @@ pub trait LdtkFields {
     /// Immutable accessor for this item's field instances, by reference.
     fn field_instances(&self) -> &[FieldInstance];
 
-    /// Get this item's field instance (with metadata) for given identifier.
+    /// Get this item's field instance (with metadata) for the given identifier.
     ///
     /// # Errors
-    /// - returns [LdtkFieldsError::FieldNotFound] if no field with the given identifier exists.
+    /// - returns [`LdtkFieldsError::FieldNotFound`] if no field with the given identifier exists.
     fn get_field_instance(&self, identifier: &str) -> Result<&FieldInstance, LdtkFieldsError> {
         self.field_instances()
             .iter()
@@ -164,7 +164,7 @@ pub trait LdtkFields {
     /// Get this item's field value for the given identifier.
     ///
     /// # Errors
-    /// - returns [LdtkFieldsError::FieldNotFound] if no field with the given identifier exists.
+    /// - returns [`LdtkFieldsError::FieldNotFound`] if no field with the given identifier exists.
     fn get_field(&self, identifier: &str) -> Result<&FieldValue, LdtkFieldsError> {
         Ok(&self.get_field_instance(identifier)?.value)
     }

--- a/src/ldtk/ldtk_fields.rs
+++ b/src/ldtk/ldtk_fields.rs
@@ -148,9 +148,9 @@ macro_rules! create_just_get_plural_fields_method {
 ///
 /// Intended only for variants whose internal type is a collection of an optional type.
 macro_rules! create_get_plural_fields_methods {
-    ($type_name:ident, $variant:ident, $maybe_type:ty, $as_ref_type: ty) => {
-        create_get_maybe_field_method!($type_name, $variant, &[$maybe_type]);
-        create_get_plural_fields_method!($type_name, $variant, $as_ref_type);
+    ($type_name:ident, $variant:ident, $type:ty) => {
+        create_get_maybe_field_method!($type_name, $variant, &[Option<$type>]);
+        create_get_plural_fields_method!($type_name, $variant, $type);
     };
 }
 
@@ -196,25 +196,20 @@ pub trait LdtkFields {
 
     create_get_field_methods!(point, Point, IVec2);
 
-    create_get_plural_fields_methods!(ints, Ints, Option<i32>, i32);
-    create_get_plural_fields_methods!(floats, Floats, Option<f32>, f32);
+    create_get_plural_fields_methods!(ints, Ints, i32);
+    create_get_plural_fields_methods!(floats, Floats, f32);
 
     create_just_get_plural_fields_method!(bools, Bools, bool);
 
-    create_get_plural_fields_methods!(strings, Strings, Option<String>, String);
+    create_get_plural_fields_methods!(strings, Strings, String);
 
     create_just_get_plural_fields_method!(colors, Colors, Color);
 
-    create_get_plural_fields_methods!(file_paths, FilePaths, Option<String>, String);
-    create_get_plural_fields_methods!(enums, Enums, Option<String>, String);
-    create_get_plural_fields_methods!(tiles, Tiles, Option<TilesetRectangle>, TilesetRectangle);
-    create_get_plural_fields_methods!(
-        entity_refs,
-        EntityRefs,
-        Option<FieldInstanceEntityReference>,
-        FieldInstanceEntityReference
-    );
-    create_get_plural_fields_methods!(points, Points, Option<IVec2>, IVec2);
+    create_get_plural_fields_methods!(file_paths, FilePaths, String);
+    create_get_plural_fields_methods!(enums, Enums, String);
+    create_get_plural_fields_methods!(tiles, Tiles, TilesetRectangle);
+    create_get_plural_fields_methods!(entity_refs, EntityRefs, FieldInstanceEntityReference);
+    create_get_plural_fields_methods!(points, Points, IVec2);
 }
 
 impl LdtkFields for EntityInstance {

--- a/src/ldtk/ldtk_fields.rs
+++ b/src/ldtk/ldtk_fields.rs
@@ -27,9 +27,9 @@ pub enum LdtkFieldsError {
 ///
 /// This macro is not intended for doing any further unwrapping, such as unwrapping an option.
 macro_rules! create_base_get_field_method {
-    ($adjective:literal, $doc_name:ident, $var_name:ident, $variant:ident, $return_type:ty) => {
+    ($adjective:literal, $var_name:ident, $variant:ident, $return_type:ty) => {
         paste! {
-            #[doc = " Get this item's " $adjective $doc_name " field value for the given identifier."]
+            #[doc = " Get this item's " $adjective $variant " field value for the given identifier."]
             ///
             /// # Errors
             /// - returns [`LdtkFieldsError::FieldNotFound`] if no field with the given identifier exists.
@@ -104,7 +104,7 @@ macro_rules! create_get_plural_fields_method {
 macro_rules! create_get_maybe_field_method {
     ($type_name:ident, $variant:ident, $maybe_type:ty) => {
         paste! {
-            create_base_get_field_method!("nullable ", $type_name, [< maybe_ $type_name >], $variant, $maybe_type);
+            create_base_get_field_method!("nullable ", [< maybe_ $type_name >], $variant, $maybe_type);
         }
     }
 }
@@ -117,7 +117,7 @@ macro_rules! create_get_maybe_field_method {
 macro_rules! create_just_get_field_method {
     ($type_name:ident, $variant:ident, $type:ty) => {
         paste! {
-            create_base_get_field_method!("", $type_name, $type_name, $variant, &$type);
+            create_base_get_field_method!("", $type_name, $variant, &$type);
         }
     };
 }
@@ -139,7 +139,7 @@ macro_rules! create_get_field_methods {
 /// Intended only for variants whose internal type is a collection of a **non-optional** type.
 macro_rules! create_just_get_plural_fields_method {
     ($type_name:ident, $variant:ident, $type:ty) => {
-        create_base_get_field_method!("", $type_name, $type_name, $variant, &[$type]);
+        create_base_get_field_method!("", $type_name, $variant, &[$type]);
     };
 }
 

--- a/src/ldtk/ldtk_fields.rs
+++ b/src/ldtk/ldtk_fields.rs
@@ -423,6 +423,29 @@ mod tests {
         };
     }
 
+    macro_rules! test_just_get_field_method {
+        ($type_name:ident, $ident:literal, $wrong_ident:literal, $expected:expr)  => {
+            paste! {
+                #[test]
+                fn [< test_get_ $type_name _field_methods >]() {
+                    let field_instances = sample_field_instances();
+
+                    assert!(matches!(
+                        field_instances.[< get_ $type_name _field >]("NonExistent"),
+                        Err(LdtkFieldsError::FieldNotFound { .. })
+                    ));
+                    assert!(matches!(
+                        field_instances.[< get_ $type_name _field >]($wrong_ident),
+                        Err(LdtkFieldsError::WrongFieldType { .. })
+                    ));
+                    assert_eq!(field_instances.[< get_ $type_name _field >]($ident).unwrap(), $expected);
+                }
+            }
+        };
+    }
+
     test_get_field_methods!(int, "IntNone", "IntSome", "Bool", Some(0), 0);
     test_get_field_methods!(float, "FloatNone", "FloatSome", "Bool", Some(1.0), 1.0);
+
+    test_just_get_field_method!(bool, "Bool", "Color", true);
 }

--- a/src/ldtk/mod.rs
+++ b/src/ldtk/mod.rs
@@ -32,6 +32,7 @@ use std::collections::HashMap;
 #[allow(unused_imports)]
 use crate::prelude::LdtkEntity;
 
+pub mod all_some_iter;
 mod color;
 mod field_instance;
 pub mod ldtk_fields;

--- a/src/ldtk/mod.rs
+++ b/src/ldtk/mod.rs
@@ -34,6 +34,7 @@ use crate::prelude::LdtkEntity;
 
 mod color;
 mod field_instance;
+mod ldtk_fields;
 
 pub use field_instance::*;
 

--- a/src/ldtk/mod.rs
+++ b/src/ldtk/mod.rs
@@ -34,7 +34,7 @@ use crate::prelude::LdtkEntity;
 
 mod color;
 mod field_instance;
-mod ldtk_fields;
+pub mod ldtk_fields;
 
 pub use field_instance::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -235,7 +235,7 @@ pub mod prelude {
             EntityInstance, GridCoords, IntGridCell, LayerMetadata, LdtkWorldBundle, LevelSet,
             Respawn, TileEnumTags, TileMetadata, Worldly,
         },
-        ldtk::{self, FieldValue, LayerInstance, TilesetDefinition},
+        ldtk::{self, ldtk_fields::LdtkFields, FieldValue, LayerInstance, TilesetDefinition},
         plugin::{LdtkPlugin, LdtkSystemSet},
         resources::{
             IntGridRendering, LdtkSettings, LevelBackground, LevelEvent, LevelSelection,


### PR DESCRIPTION
Closes #175.

# Summary
Users have predictable LDtk entities and know the exact nature of any ldtk field they've created: its identifier, its type, and whether or not it's nullable. However, finding an instance and coercing it to the type the user *knows* it should be involves a lot of boilerplate with several layers of `.iter().find(...)`s, `match`es, `if let`s and `.unwrap()`s.

This PR adds many extension methods to `Level` and `EntityInstance` to take that burden from the user. For every variant of `FieldValue`, this adds a method (or two) for accessing a field instance at a given identifier with that type - unwrapping the variant to its internal type. For example, there is a `.get_maybe_int_field("MyIdentifier")` which, if the field instance exists and is an `Int`, will return an `&Option<i32>` referencing its value. There's also a `.get_int_field("MyIdentifier")` which unwraps it further to a `&i32`, if possible. If any of these assumptions doesn't hold, an `Err(LdtkFieldsError)` is returned instead.

# Implementation
Most of these methods, and their tests, have been generated by macros. This is a good use case for macros since the code for each of the methods is very similar, though there are some hiccups:
- The `Bool` and `Color` variants aren't optional. This is because it's impossible to set them as nullable in ldtk. This difference in typing made some of the macro writing difficult, and resulted in more special-case macros.
- Half of the methods are for accessing plural variants whose internal type is `Vec<_>`. These methods return slices to the data, and their non-optional versions return a special iterator whose design I'll touch on later.

All of these methods access the data and return it by reference. This includes those whose types are cheap to copy. This makes the methods less opinionated about what is and isn't "cheap" to copy, and makes them more consistent. This consistency made the macro writing a little bit easier.

The identifier itself is passed into the methods as `&str`, despite the fact that each of them contains a `.to_string()`. This `.to_string()` only ever occurs in the error case, so its prevalence here doesn't affect the "happy path".

The methods for accessing `Vec<Option<T>>` variants in a non-optional way has some special considerations. One design question is whether to only return all elements if they are all `Some`, erroring otherwise, or to return all `Some` elements even if some of the elements are `None`. I went with the first option as the intention of these particular methods is to allow users to easily access the data if they've specified it as non-nullable in LDtk. All of these methods act as type coercion, and they should be homomorphic with LDtk's (very limited) field type system.

Furthermore, unlike the normal optional accessors, we cannot simply return a slice to this `Vec<Option<T>>` data as `&[T]`. This is because it is not contiguous in memory - the `Option` wrapping "gets in the way". Another option is to return it as a `Vec<&T>`, since this preserves the reference to the original data and unwraps the options. However, this involves iterating over the original collection and re-collecting it, even though the user may just want to iterate over it again. The solution chosen here is to instead return an iterator instead of a collection. Specifically, it returns an `AllSomeIter<'a, T>`, which is a new type added in this PR to provide some type safety and helpful naming to the return type. `AllSomeIter` just wraps around a `Flatten<Iter<'a, Option<T>>`, but guarantees that every element of the original collection is `Some` on construction. This preserves the original references, unwraps the options in the original data, and provides type guarantees while returning as early an [intermediate result](https://rust-lang.github.io/api-guidelines/flexibility.html#functions-expose-intermediate-results-to-avoid-duplicate-work-c-intermediate) as possible.

Since it's kind of hard to see what methods have been added here due to most of them being generated by macros, here's a list:
- `field_instances`
- `get_field_instance`
- `get_field`
- `get_maybe_int_field`
- `get_int_field`
- `get_maybe_float_field`
- `get_float_field`
- `get_bool_field`
- `get_maybe_string_field`
- `get_string_field`
- `get_color_field`
- `get_maybe_file_path_field`
- `get_file_path_field`
- `get_maybe_enum_field`
- `get_enum_field`
- `get_maybe_tile_field`
- `get_tile_field`
- `get_maybe_entity_ref_field`
- `get_entity_ref_field`
- `get_maybe_point_field`
- `get_point_field`
- `get_maybe_ints_field`
- `iter_ints_field`
- `get_maybe_floats_field`
- `iter_floats_field`
- `get_bools_field`
- `get_maybe_strings_field`
- `iter_strings_field`
- `get_colors_field`
- `get_maybe_file_paths_field`
- `iter_file_paths_field`
- `get_maybe_enums_field`
- `iter_enums_field`
- `get_maybe_tiles_field`
- `iter_tiles_field`
- `get_maybe_entity_refs_field`
- `iter_entity_refs_field`
- `get_maybe_points_field`
- `iter_points_field`