### PR TITLE
fix!: create IntGrid white-image on asset load and minimize its size

### DIFF
--- a/src/assets.rs
+++ b/src/assets.rs
@@ -250,3 +250,113 @@ impl AssetLoader for LdtkLevelLoader {
         &["ldtkl"]
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::ldtk::{Definitions, LayerDefinition, Type};
+
+    use super::*;
+
+    #[test]
+    fn int_grid_image_is_white() {
+        let definitions = Definitions {
+            layers: vec![LayerDefinition {
+                purple_type: Type::IntGrid,
+                grid_size: 16,
+                ..default()
+            }],
+            ..default()
+        };
+
+        let image = definitions.create_int_grid_image().unwrap();
+
+        for byte in image.data.iter() {
+            assert_eq!(*byte, 255);
+        }
+    }
+
+    #[test]
+    fn int_grid_image_is_size_of_max_int_grid_layer() {
+        let definitions = Definitions {
+            layers: vec![
+                LayerDefinition {
+                    purple_type: Type::IntGrid,
+                    grid_size: 16,
+                    ..default()
+                },
+                LayerDefinition {
+                    purple_type: Type::IntGrid,
+                    grid_size: 32,
+                    ..default()
+                },
+                LayerDefinition {
+                    purple_type: Type::IntGrid,
+                    grid_size: 2,
+                    ..default()
+                },
+                // Excludes non-intgrid layers
+                LayerDefinition {
+                    purple_type: Type::AutoLayer,
+                    grid_size: 64,
+                    ..default()
+                },
+                LayerDefinition {
+                    purple_type: Type::Tiles,
+                    grid_size: 64,
+                    ..default()
+                },
+                LayerDefinition {
+                    purple_type: Type::Entities,
+                    grid_size: 64,
+                    ..default()
+                },
+                // Excludes intgrid layers w/ tileset
+                LayerDefinition {
+                    purple_type: Type::IntGrid,
+                    grid_size: 64,
+                    tileset_def_uid: Some(1),
+                    ..default()
+                },
+            ],
+            ..default()
+        };
+
+        let image = definitions.create_int_grid_image().unwrap();
+
+        assert_eq!(image.size(), Vec2::splat(32.));
+    }
+
+    #[test]
+    fn no_int_grid_image_for_no_elligible_int_grid_layers() {
+        let definitions = Definitions {
+            layers: vec![
+                // Excludes non-intgrid layers
+                LayerDefinition {
+                    purple_type: Type::AutoLayer,
+                    grid_size: 64,
+                    ..default()
+                },
+                LayerDefinition {
+                    purple_type: Type::Tiles,
+                    grid_size: 64,
+                    ..default()
+                },
+                LayerDefinition {
+                    purple_type: Type::Entities,
+                    grid_size: 64,
+                    ..default()
+                },
+                // Excludes intgrid layers w/ tileset
+                LayerDefinition {
+                    purple_type: Type::IntGrid,
+                    grid_size: 64,
+                    tileset_def_uid: Some(1),
+                    ..default()
+                },
+            ],
+            ..default()
+        };
+
+        assert!(definitions.create_int_grid_image().is_none());
+    }
+}

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -33,6 +33,7 @@ pub struct LdtkAsset {
     pub project: ldtk::LdtkJson,
     pub tileset_map: TilesetMap,
     pub level_map: LevelMap,
+    /// Image used for rendering int grid colors.
     pub int_grid_image_handle: Option<Handle<Image>>,
 }
 

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -2,7 +2,6 @@
 
 use crate::{
     ldtk::{self, Type},
-    level,
     resources::LevelSelection,
 };
 use bevy::{

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -47,6 +47,13 @@ impl ldtk::LdtkJson {
             .chain(self.worlds.iter().flat_map(|w| &w.levels))
     }
 
+    /// Creates image that will be used for rendering IntGrid colors.
+    ///
+    /// The resulting image is completely white and can be thought of as a single tile of the grid.
+    /// The image is only as big as the biggest int grid layer's grid size.
+    ///
+    /// Can return `None` if there are no IntGrid layers that will be rendered by color.
+    /// IntGrid layers that have a tileset are excluded since they will not be rendered by color.
     fn create_int_grid_image(&self) -> Option<Image> {
         self.defs
             .layers

--- a/src/ldtk/mod.rs
+++ b/src/ldtk/mod.rs
@@ -544,7 +544,7 @@ pub struct EnumValueDefinition {
     pub tile_id: Option<i32>,
 }
 
-#[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
+#[derive(PartialEq, Debug, Default, Clone, Serialize, Deserialize)]
 pub struct LayerDefinition {
     /// Type of the layer (*IntGrid, Entities, Tiles or AutoLayer*)
     #[serde(rename = "__type")]

--- a/src/level.rs
+++ b/src/level.rs
@@ -16,7 +16,7 @@ use crate::{
     utils::*,
 };
 
-use bevy::{prelude::*, render::render_resource::*};
+use bevy::prelude::*;
 use bevy_ecs_tilemap::{
     map::{
         TilemapGridSize, TilemapId, TilemapSize, TilemapSpacing, TilemapTexture, TilemapTileSize,

--- a/src/level.rs
+++ b/src/level.rs
@@ -222,20 +222,6 @@ pub fn spawn_level(
     if let Some(layer_instances) = &level.layer_instances {
         let mut layer_z = 0;
 
-        // creating an image to use for intgrid colors
-        let white_image = Image::new_fill(
-            Extent3d {
-                width: level.px_wid as u32,
-                height: level.px_hei as u32,
-                depth_or_array_layers: 1,
-            },
-            TextureDimension::D2,
-            &[255, 255, 255, 255],
-            TextureFormat::Rgba8UnormSrgb,
-        );
-
-        let white_image_handle = images.add(white_image);
-
         if ldtk_settings.level_background == LevelBackground::Rendered {
             let translation = Vec3::new(level.px_wid as f32, level.px_hei as f32, 0.) / 2.;
 
@@ -403,11 +389,15 @@ pub fn spawn_level(
                         _ => TilemapSpacing::default(),
                     };
 
-                    let texture = match tileset_definition {
-                        Some(tileset_definition) => TilemapTexture::Single(
+                    let texture = match (tileset_definition, int_grid_image_handle) {
+                        (Some(tileset_definition), _) => TilemapTexture::Single(
                             tileset_map.get(&tileset_definition.uid).unwrap().clone(),
                         ),
-                        None => TilemapTexture::Single(white_image_handle.clone()),
+                        (None, Some(handle)) => TilemapTexture::Single(handle.clone()),
+                        _ => {
+                            warn!("unable to render tilemap layer, it has no tileset and no intgrid layers were expected");
+                            continue;
+                        }
                     };
 
                     let metadata_map: HashMap<i32, TileMetadata> = tileset_definition

--- a/src/level.rs
+++ b/src/level.rs
@@ -212,6 +212,7 @@ pub fn spawn_level(
     layer_definition_map: &HashMap<i32, &LayerDefinition>,
     tileset_map: &TilesetMap,
     tileset_definition_map: &HashMap<i32, &TilesetDefinition>,
+    int_grid_image_handle: &Option<Handle<Image>>,
     worldly_set: HashSet<Worldly>,
     ldtk_entity: Entity,
     ldtk_settings: &LdtkSettings,

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -267,6 +267,8 @@ pub fn process_ldtk_levels(
                     let layer_definition_map =
                         create_layer_definition_map(&ldtk_asset.project.defs.layers);
 
+                    let int_grid_image_handle = &ldtk_asset.int_grid_image_handle;
+
                     let worldly_set = worldly_query.iter().cloned().collect();
 
                     if let Some(level) = level_assets.get(level_handle) {
@@ -282,6 +284,7 @@ pub fn process_ldtk_levels(
                             &layer_definition_map,
                             &ldtk_asset.tileset_map,
                             &tileset_definition_map,
+                            int_grid_image_handle,
                             worldly_set,
                             ldtk_entity,
                             &ldtk_settings,


### PR DESCRIPTION
Closes #172, and resolves an issue brought up by @Mattincho in #176 

# Summary
The white image generated for levels is now only used for intgrid coloring. This means it no longer needs to be the size of the level - it can just be the size of the maximum-sized intgrid layer. The maximum-sized intgrid tile is easy to determine during asset loading. This PR creates a small white-image for the maximum-sized intgrid tile once for the entire asset, rather than a large one once per level. This should improve performance, and also hopefully resolve issues with hitting hardware limits on larger levels.

BREAKING CHANGE: Most likely won't affect users - `LdtkAsset` has gained a `int_grid_image_handle` field, breaking any manual construction of it.