### PR TITLE
fix: insert Name component before evaluating `LdtkEntity`

### DIFF
--- a/src/level.rs
+++ b/src/level.rs
@@ -314,6 +314,11 @@ pub fn spawn_level(
                                     Box::new(PhantomLdtkEntity::<EntityInstanceBundle>::new());
                                 let mut entity_commands = commands.spawn_empty();
 
+                                // insert Name before evaluating LdtkEntitys so that user-provided
+                                // names aren't overwritten
+                                entity_commands
+                                    .insert(Name::new(entity_instance.identifier.to_owned()));
+
                                 ldtk_map_get_or_default(
                                     layer_instance.identifier.clone(),
                                     entity_instance.identifier.clone(),
@@ -330,12 +335,10 @@ pub fn spawn_level(
                                     texture_atlases,
                                 );
 
-                                entity_commands
-                                    .insert(SpatialBundle {
-                                        transform,
-                                        ..default()
-                                    })
-                                    .insert(Name::new(entity_instance.identifier.to_owned()));
+                                entity_commands.insert(SpatialBundle {
+                                    transform,
+                                    ..default()
+                                });
                             }
                         }
                     });


### PR DESCRIPTION
Currently, if a user provides a custom constructor for `Name` via `LdtkEntity` registration, it will be overwritten by the plugin since it automatically inserts a name from the ldtk entity identifier. This change performs this insertion *before* evaluating `LdtkEntity` so that a user-provided `Name` will overwrite the plugin-provided `Name` instead.