### PR TITLE
early exit in apply_level_selection if nothing would cause the LevelSet to change

### DIFF
--- a/src/systems.rs
+++ b/src/systems.rs
@@ -73,6 +73,11 @@ pub fn apply_level_selection(
     #[cfg(feature = "render")] mut clear_color: ResMut<ClearColor>,
 ) {
     if let Some(level_selection) = level_selection {
+        if !level_selection.is_changed() && !ldtk_settings.is_changed() && !ldtk_assets.is_changed()
+        {
+            return;
+        }
+
         for (ldtk_handle, mut level_set) in level_set_query.iter_mut() {
             if let Some(ldtk_asset) = ldtk_assets.get(ldtk_handle) {
                 if let Some(level) = ldtk_asset.get_level(&level_selection) {


### PR DESCRIPTION
I'm sure there are some pitfalls here, but I've been trying to extend the `LevelSelection` behaviour, and rather than completely replace it (because I want neighbours, and why rewrite it?) I've been trying to extend it by shoving a system in the middle.

```
apply_level_selection
    .in_base_set(bevy_ecs_ldtk::LdtkSystemSet::ProcessApi)
    .after(bevy_ecs_ldtk::systems::apply_level_selection)
    .before(bevy_ecs_ldtk::systems::apply_level_set),
```

In doing so I noticed the `bevy_ecs_ldtk::systems::apply_level_selection` system runs every single frame, even when nothing should be being updated. This meant that my system also had to run every frame - in order to stop the changed being overridden - except my calculations were considerably more expensive so I really didn't want that to happen.

As with my other PR, it's a little brute-force but hopefully a starting point for discussion.

Sidenote: should `LevelSelection` be a component rather than a `Resource`? Similar to `LevelSet`.