### PR TITLE
feat: add `EntityIid` component which is added to all entities by default

### DIFF
--- a/examples/field_instances/enemy.rs
+++ b/examples/field_instances/enemy.rs
@@ -1,9 +1,5 @@
 //! Contains [EnemyBundle] which is the main [LdtkEntity] for this example.
-use crate::{
-    equipment::EquipmentDrops,
-    health::Health,
-    mother::{LdtkEntityIid, UnresolvedMotherRef},
-};
+use crate::{equipment::EquipmentDrops, health::Health, mother::UnresolvedMotherRef};
 use bevy::prelude::*;
 use bevy_ecs_ldtk::prelude::*;
 
@@ -18,8 +14,6 @@ pub struct EnemyBundle {
     equipment_drops: EquipmentDrops,
     #[with(UnresolvedMotherRef::from_mother_field)]
     unresolved_mother: UnresolvedMotherRef,
-    #[from_entity_instance]
-    ldtk_entity_iid: LdtkEntityIid,
     #[sprite_sheet_bundle]
     sprite_sheet_bundle: SpriteSheetBundle,
 }

--- a/examples/field_instances/main.rs
+++ b/examples/field_instances/main.rs
@@ -45,7 +45,6 @@ fn main() {
         .add_plugin(WorldInspectorPlugin::new())
         .register_type::<health::Health>()
         .register_type::<equipment::EquipmentDrops>()
-        .register_type::<mother::LdtkEntityIid>()
         .register_type::<mother::Mother>()
         .register_type::<level_title::LevelTitle>()
         .run();

--- a/examples/field_instances/mother.rs
+++ b/examples/field_instances/mother.rs
@@ -2,23 +2,13 @@
 use bevy::prelude::*;
 use bevy_ecs_ldtk::prelude::*;
 
-/// Component storing an ldtk entity's iid.
-#[derive(Clone, Debug, Default, Eq, PartialEq, Deref, DerefMut, Component, Reflect)]
-pub struct LdtkEntityIid(String);
-
-impl From<&EntityInstance> for LdtkEntityIid {
-    fn from(value: &EntityInstance) -> Self {
-        LdtkEntityIid(value.iid.clone())
-    }
-}
-
 /// Component that eventually transforms into the [Mother] component.
 ///
 /// This just stores the entity iid of the mother entity.
 /// The initial value of this is sourced from the entity's "mother" field in LDtk.
 /// In [resolve_mother_references], this gets resolved to the actual bevy Entity of the mother.
 #[derive(Debug, Default, Deref, DerefMut, Component)]
-pub struct UnresolvedMotherRef(Option<LdtkEntityIid>);
+pub struct UnresolvedMotherRef(Option<EntityIid>);
 
 impl UnresolvedMotherRef {
     pub fn from_mother_field(entity_instance: &EntityInstance) -> UnresolvedMotherRef {
@@ -27,7 +17,7 @@ impl UnresolvedMotherRef {
                 .get_maybe_entity_ref_field("mother")
                 .expect("expected entity to have mother entity ref field")
                 .as_ref()
-                .map(|entity_ref| LdtkEntityIid(entity_ref.entity_iid.clone())),
+                .map(|entity_ref| EntityIid::new(entity_ref.entity_iid.clone())),
         )
     }
 }
@@ -39,7 +29,7 @@ pub struct Mother(Entity);
 pub fn resolve_mother_references(
     mut commands: Commands,
     unresolved_mothers: Query<(Entity, &UnresolvedMotherRef), Added<UnresolvedMotherRef>>,
-    ldtk_entities: Query<(Entity, &LdtkEntityIid)>,
+    ldtk_entities: Query<(Entity, &EntityIid)>,
 ) {
     for (child_entity, unresolved_mother_ref) in unresolved_mothers.iter() {
         if let Some(mother_iid) = unresolved_mother_ref.0.as_ref() {

--- a/src/components.rs
+++ b/src/components.rs
@@ -5,6 +5,7 @@ use crate::ldtk::{LayerInstance, Type};
 use bevy::prelude::*;
 
 use std::{
+    borrow::Cow,
     collections::HashSet,
     ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign},
 };
@@ -18,6 +19,60 @@ use crate::{
 };
 
 use bevy_ecs_tilemap::tiles::{TileBundle, TilePos};
+
+/// [Component] added to all [LdtkEntity]s by default.
+///
+/// The `iid` stored in this component can be used to uniquely identify LDtk entities within an [LdtkAsset].
+#[derive(Clone, Debug, Default, Deref, Hash, Eq, PartialEq, Component, FromReflect, Reflect)]
+#[reflect(Component, Default, Debug)]
+pub struct EntityIid(Cow<'static, str>);
+
+impl EntityIid {
+    pub fn new(iid: impl Into<Cow<'static, str>>) -> Self {
+        let iid = iid.into();
+        EntityIid(iid)
+    }
+
+    #[inline(always)]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<&str> for EntityIid {
+    #[inline(always)]
+    fn from(value: &str) -> Self {
+        EntityIid::new(value.to_owned())
+    }
+}
+
+impl From<String> for EntityIid {
+    #[inline(always)]
+    fn from(value: String) -> Self {
+        EntityIid::new(value)
+    }
+}
+
+impl AsRef<str> for EntityIid {
+    #[inline(always)]
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<&EntityIid> for String {
+    #[inline(always)]
+    fn from(value: &EntityIid) -> String {
+        value.as_str().to_owned()
+    }
+}
+
+impl From<EntityIid> for String {
+    #[inline(always)]
+    fn from(value: EntityIid) -> String {
+        value.0.into_owned()
+    }
+}
 
 /// [Component] added to any `IntGrid` tile by default.
 ///

--- a/src/components/entity_iid.rs
+++ b/src/components/entity_iid.rs
@@ -10,11 +10,13 @@ use std::borrow::Cow;
 pub struct EntityIid(Cow<'static, str>);
 
 impl EntityIid {
+    /// Construct an [`EntityIid`].
     pub fn new(iid: impl Into<Cow<'static, str>>) -> Self {
         let iid = iid.into();
         EntityIid(iid)
     }
 
+    /// Returns the internal entity iid as a `&str`.
     #[inline(always)]
     pub fn as_str(&self) -> &str {
         &self.0

--- a/src/components/entity_iid.rs
+++ b/src/components/entity_iid.rs
@@ -1,0 +1,57 @@
+use bevy::prelude::*;
+
+use std::borrow::Cow;
+
+/// [Component] added to all [LdtkEntity]s by default.
+///
+/// The `iid` stored in this component can be used to uniquely identify LDtk entities within an [LdtkAsset].
+#[derive(Clone, Debug, Default, Deref, Hash, Eq, PartialEq, Component, FromReflect, Reflect)]
+#[reflect(Component, Default, Debug)]
+pub struct EntityIid(Cow<'static, str>);
+
+impl EntityIid {
+    pub fn new(iid: impl Into<Cow<'static, str>>) -> Self {
+        let iid = iid.into();
+        EntityIid(iid)
+    }
+
+    #[inline(always)]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<&str> for EntityIid {
+    #[inline(always)]
+    fn from(value: &str) -> Self {
+        EntityIid::new(value.to_owned())
+    }
+}
+
+impl From<String> for EntityIid {
+    #[inline(always)]
+    fn from(value: String) -> Self {
+        EntityIid::new(value)
+    }
+}
+
+impl AsRef<str> for EntityIid {
+    #[inline(always)]
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<&EntityIid> for String {
+    #[inline(always)]
+    fn from(value: &EntityIid) -> String {
+        value.as_str().to_owned()
+    }
+}
+
+impl From<EntityIid> for String {
+    #[inline(always)]
+    fn from(value: EntityIid) -> String {
+        value.0.into_owned()
+    }
+}

--- a/src/components/entity_iid.rs
+++ b/src/components/entity_iid.rs
@@ -10,13 +10,13 @@ use std::borrow::Cow;
 pub struct EntityIid(Cow<'static, str>);
 
 impl EntityIid {
-    /// Construct an [`EntityIid`].
+    /// Creates a new [`EntityIid`] from any string-like type.
     pub fn new(iid: impl Into<Cow<'static, str>>) -> Self {
         let iid = iid.into();
         EntityIid(iid)
     }
 
-    /// Returns the internal entity iid as a `&str`.
+    /// Gets the Iid of the entity as a &str.
     #[inline(always)]
     pub fn as_str(&self) -> &str {
         &self.0

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -1,11 +1,12 @@
 //! [Component]s and [Bundle]s used by the plugin.
+mod entity_iid;
+pub use entity_iid::EntityIid;
 
 pub use crate::ldtk::EntityInstance;
 use crate::ldtk::{LayerInstance, Type};
 use bevy::prelude::*;
 
 use std::{
-    borrow::Cow,
     collections::HashSet,
     ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign},
 };
@@ -19,60 +20,6 @@ use crate::{
 };
 
 use bevy_ecs_tilemap::tiles::{TileBundle, TilePos};
-
-/// [Component] added to all [LdtkEntity]s by default.
-///
-/// The `iid` stored in this component can be used to uniquely identify LDtk entities within an [LdtkAsset].
-#[derive(Clone, Debug, Default, Deref, Hash, Eq, PartialEq, Component, FromReflect, Reflect)]
-#[reflect(Component, Default, Debug)]
-pub struct EntityIid(Cow<'static, str>);
-
-impl EntityIid {
-    pub fn new(iid: impl Into<Cow<'static, str>>) -> Self {
-        let iid = iid.into();
-        EntityIid(iid)
-    }
-
-    #[inline(always)]
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-}
-
-impl From<&str> for EntityIid {
-    #[inline(always)]
-    fn from(value: &str) -> Self {
-        EntityIid::new(value.to_owned())
-    }
-}
-
-impl From<String> for EntityIid {
-    #[inline(always)]
-    fn from(value: String) -> Self {
-        EntityIid::new(value)
-    }
-}
-
-impl AsRef<str> for EntityIid {
-    #[inline(always)]
-    fn as_ref(&self) -> &str {
-        &self.0
-    }
-}
-
-impl From<&EntityIid> for String {
-    #[inline(always)]
-    fn from(value: &EntityIid) -> String {
-        value.as_str().to_owned()
-    }
-}
-
-impl From<EntityIid> for String {
-    #[inline(always)]
-    fn from(value: EntityIid) -> String {
-        value.0.into_owned()
-    }
-}
 
 /// [Component] added to any `IntGrid` tile by default.
 ///

--- a/src/level.rs
+++ b/src/level.rs
@@ -303,8 +303,10 @@ pub fn spawn_level(
 
                                 // insert Name before evaluating LdtkEntitys so that user-provided
                                 // names aren't overwritten
-                                entity_commands
-                                    .insert(Name::new(entity_instance.identifier.to_owned()));
+                                entity_commands.insert((
+                                    EntityIid::new(entity_instance.iid.to_owned()),
+                                    Name::new(entity_instance.identifier.to_owned()),
+                                ));
 
                                 ldtk_map_get_or_default(
                                     layer_instance.identifier.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,8 +142,8 @@ pub mod prelude {
         app::{LdtkEntity, LdtkEntityAppExt, LdtkIntCell, LdtkIntCellAppExt},
         assets::{LdtkAsset, LdtkLevel},
         components::{
-            EntityInstance, GridCoords, IntGridCell, LayerMetadata, LdtkWorldBundle, LevelSet,
-            Respawn, TileEnumTags, TileMetadata, Worldly,
+            EntityIid, EntityInstance, GridCoords, IntGridCell, LayerMetadata, LdtkWorldBundle,
+            LevelSet, Respawn, TileEnumTags, TileMetadata, Worldly,
         },
         ldtk::{self, ldtk_fields::LdtkFields, FieldValue, LayerInstance, TilesetDefinition},
         plugin::{LdtkPlugin, LdtkSystemSet},

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -81,6 +81,7 @@ impl Plugin for LdtkPlugin {
                 .pipe(systems::fire_level_transformed_events)
                 .in_base_set(CoreSet::PostUpdate),
         )
+        .register_type::<components::EntityIid>()
         .register_type::<components::GridCoords>()
         .register_type::<components::TileMetadata>()
         .register_type::<components::TileEnumTags>()


### PR DESCRIPTION
This is a first step on the road to having an easy way of looking up entity information from `LdtkAsset`.

**Questions**
* ~~Should it be possible to disable this using `LdtkSettings`? I'm not sure it's worth worrying about as the memory usage should be minimal as the IID are always GUIDs. Perhaps a feature?~~
* ~~Should this be a newtype? It makes sense to me and I can't see any reason for it to ever gain fields, but the other components within the crate all have named fields.~~
* ~~Should the `EntityIid` also carry its `Handle<LdtkAsset>`? I don’t think so personally as `LevelSelection` doesn’t have this concept.~~