### PR TITLE
feat: add `get_entity_instance` to `LdtkAsset`

### DIFF
--- a/examples/level_set.rs
+++ b/examples/level_set.rs
@@ -2,9 +2,8 @@
 // The setup system puts several level iids in the LevelSet, so an entire LDtk world layer is
 // spawned.
 
-use bevy::prelude::*;
+use bevy::{prelude::*, utils::HashSet};
 use bevy_ecs_ldtk::prelude::*;
-use std::collections::HashSet;
 
 use rand::prelude::*;
 

--- a/examples/platformer/components.rs
+++ b/examples/platformer/components.rs
@@ -1,7 +1,5 @@
-use bevy::prelude::*;
+use bevy::{prelude::*, utils::HashSet};
 use bevy_ecs_ldtk::{prelude::*, utils::ldtk_pixel_coords_to_translation_pivoted};
-
-use std::collections::HashSet;
 
 use bevy_rapier2d::prelude::*;
 

--- a/examples/platformer/systems.rs
+++ b/examples/platformer/systems.rs
@@ -1,8 +1,9 @@
 use crate::components::*;
-use bevy::prelude::*;
+use bevy::{
+    prelude::*,
+    utils::{HashMap, HashSet},
+};
 use bevy_ecs_ldtk::prelude::*;
-
-use std::collections::{HashMap, HashSet};
 
 use bevy_rapier2d::prelude::*;
 

--- a/src/app/ldtk_entity.rs
+++ b/src/app/ldtk_entity.rs
@@ -3,8 +3,8 @@ use crate::{
     ldtk::{EntityInstance, LayerInstance, TilesetDefinition},
     utils,
 };
-use bevy::{ecs::system::EntityCommands, prelude::*};
-use std::{collections::HashMap, marker::PhantomData};
+use bevy::{ecs::system::EntityCommands, prelude::*, utils::HashMap};
+use std::marker::PhantomData;
 
 /// [LdtkEntityAppExt]: super::LdtkEntityAppExt
 /// [Bundle]: bevy::prelude::Bundle

--- a/src/app/ldtk_int_cell.rs
+++ b/src/app/ldtk_int_cell.rs
@@ -2,8 +2,8 @@ use crate::{
     components::{IntGridCell, IntGridCellBundle},
     ldtk::LayerInstance,
 };
-use bevy::{ecs::system::EntityCommands, prelude::*};
-use std::{collections::HashMap, marker::PhantomData};
+use bevy::{ecs::system::EntityCommands, prelude::*, utils::HashMap};
+use std::marker::PhantomData;
 
 /// [LdtkIntCellAppExt]: super::LdtkIntCellAppExt
 /// [Bundle]: bevy::prelude::Bundle

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -6,9 +6,9 @@ use bevy::{
     prelude::*,
     reflect::TypeUuid,
     render::render_resource::{Extent3d, TextureDimension, TextureFormat},
-    utils::BoxedFuture,
+    utils::{BoxedFuture, HashMap},
 };
-use std::{collections::HashMap, path::Path};
+use std::path::Path;
 
 #[allow(unused_imports)]
 use crate::components::LdtkWorldBundle;

--- a/src/components.rs
+++ b/src/components.rs
@@ -2,11 +2,10 @@
 
 pub use crate::ldtk::EntityInstance;
 use crate::ldtk::{LayerInstance, Type};
-use bevy::prelude::*;
+use bevy::{prelude::*, utils::HashSet};
 
 use std::{
     borrow::Cow,
-    collections::HashSet,
     ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign},
 };
 

--- a/src/components.rs
+++ b/src/components.rs
@@ -5,6 +5,7 @@ use crate::ldtk::{LayerInstance, Type};
 use bevy::prelude::*;
 
 use std::{
+    borrow::Cow,
     collections::HashSet,
     ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign},
 };
@@ -18,6 +19,60 @@ use crate::{
 };
 
 use bevy_ecs_tilemap::tiles::{TileBundle, TilePos};
+
+/// [Component] added to all [LdtkEntity]s by default.
+///
+/// The `iid` stored in this component can be used to uniquely identify LDtk entities within an [LdtkAsset].
+#[derive(Clone, Debug, Default, Deref, DerefMut, Hash, Eq, PartialEq, Component, Reflect)]
+#[reflect(Component)]
+pub struct EntityIid(Cow<'static, str>);
+
+impl EntityIid {
+    pub fn new(iid: impl Into<Cow<'static, str>>) -> Self {
+        let iid = iid.into();
+        EntityIid(iid)
+    }
+
+    #[inline(always)]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<&str> for EntityIid {
+    #[inline(always)]
+    fn from(value: &str) -> Self {
+        EntityIid::new(value.to_owned())
+    }
+}
+
+impl From<String> for EntityIid {
+    #[inline(always)]
+    fn from(value: String) -> Self {
+        EntityIid::new(value)
+    }
+}
+
+impl AsRef<str> for EntityIid {
+    #[inline(always)]
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<&EntityIid> for String {
+    #[inline(always)]
+    fn from(value: &EntityIid) -> String {
+        value.as_str().to_owned()
+    }
+}
+
+impl From<EntityIid> for String {
+    #[inline(always)]
+    fn from(value: EntityIid) -> String {
+        value.0.into_owned()
+    }
+}
 
 /// [Component] added to any `IntGrid` tile by default.
 ///

--- a/src/ldtk/mod.rs
+++ b/src/ldtk/mod.rs
@@ -25,9 +25,11 @@
 //! 13. All urls in docs have been changed to hyperlinks with `<>`
 //! 14. `Reflect` has been derived for [Type].
 
-use bevy::prelude::{Color, IVec2, Vec2};
+use bevy::{
+    prelude::{Color, IVec2, Vec2},
+    utils::HashMap,
+};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 
 #[allow(unused_imports)]
 use crate::prelude::LdtkEntity;

--- a/src/level.rs
+++ b/src/level.rs
@@ -16,7 +16,10 @@ use crate::{
     utils::*,
 };
 
-use bevy::prelude::*;
+use bevy::{
+    prelude::*,
+    utils::{HashMap, HashSet},
+};
 use bevy_ecs_tilemap::{
     map::{
         TilemapGridSize, TilemapId, TilemapSize, TilemapSpacing, TilemapTexture, TilemapTileSize,
@@ -24,7 +27,6 @@ use bevy_ecs_tilemap::{
     tiles::{TilePos, TileStorage},
     TilemapBundle,
 };
-use std::collections::{HashMap, HashSet};
 
 use thiserror::Error;
 

--- a/src/level.rs
+++ b/src/level.rs
@@ -303,8 +303,10 @@ pub fn spawn_level(
 
                                 // insert Name before evaluating LdtkEntitys so that user-provided
                                 // names aren't overwritten
-                                entity_commands
-                                    .insert(Name::new(entity_instance.identifier.to_owned()));
+                                entity_commands.insert((
+                                    EntityIid::new(entity_instance.iid.to_owned()),
+                                    Name::new(entity_instance.identifier.to_owned()),
+                                ));
 
                                 ldtk_map_get_or_default(
                                     layer_instance.identifier.clone(),

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -81,6 +81,7 @@ impl Plugin for LdtkPlugin {
                 .pipe(systems::fire_level_transformed_events)
                 .in_base_set(CoreSet::PostUpdate),
         )
+        .register_type::<components::EntityIid>()
         .register_type::<components::GridCoords>()
         .register_type::<components::TileMetadata>()
         .register_type::<components::TileEnumTags>()

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -12,8 +12,11 @@ use crate::{
     utils::*,
 };
 
-use bevy::{ecs::system::SystemState, prelude::*};
-use std::collections::{HashMap, HashSet};
+use bevy::{
+    ecs::system::SystemState,
+    prelude::*,
+    utils::{HashMap, HashSet},
+};
 
 /// Detects [LdtkAsset] events and spawns levels as children of the [LdtkWorldBundle].
 #[allow(clippy::too_many_arguments)]

--- a/src/tile_makers.rs
+++ b/src/tile_makers.rs
@@ -13,12 +13,10 @@ use crate::{
     level::tile_to_grid_coords,
     utils::*,
 };
-use bevy::prelude::*;
+use bevy::{prelude::*, utils::HashMap};
 use bevy_ecs_tilemap::tiles::{
     TileBundle, TileColor, TileFlip, TilePos, TileTextureIndex, TileVisible,
 };
-
-use std::collections::HashMap;
 
 #[derive(Clone, Eq, PartialEq, Debug, Default, Hash)]
 pub(crate) struct TilePosMap<T> {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,7 @@
 //! Utility functions used internally by the plugin that have been exposed to the public api.
 
+use std::hash::Hash;
+
 #[allow(unused_imports)]
 use crate::{
     app::LdtkEntity,
@@ -7,13 +9,11 @@ use crate::{
 };
 
 use crate::{components::TileGridBundle, ldtk::*};
-use bevy::prelude::*;
+use bevy::{prelude::*, utils::HashMap};
 use bevy_ecs_tilemap::{
     map::{TilemapId, TilemapSize},
     tiles::{TilePos, TileStorage},
 };
-
-use std::{collections::HashMap, hash::Hash};
 
 /// The `int_grid_csv` field of a [LayerInstance] is a 1-dimensional [`Vec<i32>`].
 /// This function can map the indices of this [Vec] to a corresponding [GridCoords].


### PR DESCRIPTION
This builds on the work in https://github.com/Trouv/bevy_ecs_ldtk/pull/194. I've split into two PRs in order to keep discussion focused, and because I think https://github.com/Trouv/bevy_ecs_ldtk/pull/194 in isolation still gives some benefits if this PR takes a little longer to get over the line. Unfortunately I can only set the base branch to one which exists in this repo (rather than my fork) so the diff includes all the other changes for now.

I went down this route rather than creating a `SystemParam` as discussed in https://github.com/Trouv/bevy_ecs_ldtk/pull/192 as it felt more natural for it to live alongside `get_level` and it massively simplifies the implementation.

I'm going to give some thought to how this can be extended to enable https://github.com/Trouv/bevy_ecs_ldtk/issues/70 as that is closely related to my actual use-case.

**Questions**
* Should the `traitless` example be updated to use this? Full trait less will still work the same, but with this you can mix both approaches. It removes a potential footgun.