### PR TITLE
fix!: remove `LdtkAsset::world_height` and correct `UseWorldTranslation` y-calculation

### DIFF
--- a/examples/level_set.rs
+++ b/examples/level_set.rs
@@ -45,7 +45,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(LdtkWorldBundle {
         ldtk_handle: asset_server.load("WorldMap_Free_layout.ldtk"),
         level_set: LevelSet { iids },
-        transform: Transform::from_xyz(-232., -496., 0.),
+        transform: Transform::from_xyz(-256., -144., 0.),
         ..Default::default()
     });
 }

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -75,15 +75,6 @@ impl ldtk::LdtkJson {
 }
 
 impl LdtkAsset {
-    pub fn world_height(&self) -> i32 {
-        let mut world_height = 0;
-        for level in self.iter_levels() {
-            world_height = world_height.max(level.world_y + level.px_hei);
-        }
-
-        world_height
-    }
-
     /// Get an iterator of all the levels in the LDtk file.
     ///
     /// This abstraction avoids compatibility issues between pre-multi-world and post-multi-world

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -186,7 +186,7 @@ fn pre_spawn_level(
             if let Some(level) = ldtk_asset.get_level(&LevelSelection::Iid(level_iid.to_string())) {
                 let level_coords = ldtk_pixel_coords_to_translation(
                     IVec2::new(level.world_x, level.world_y + level.px_hei),
-                    ldtk_asset.world_height(),
+                    0,
                 );
                 translation.x = level_coords.x;
                 translation.y = level_coords.y;


### PR DESCRIPTION
The y-values used for spawning levels in the `UseWorldTranslation` case were incorrect. There were a couple problems:
- the world translation in LDtk was treated as relative to the height of the world, when it was actually relative to the origin
- the method for getting the world height `LdtkAsset::world_height` was incorrect, instead calculating more of a "world depth"

BREAKING-CHANGE: `LdtkAsset::world_height` has been removed