### PR TITLE
ci: upgrade CI to current bevy_github_ci_template and lint more targets/features

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,74 +1,103 @@
-on:
-  pull_request:
-  push:
-    branches:
-      - main
-
 name: CI
 
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
 jobs:
+  # Run cargo check (with various feature permutations)
   check:
-    name: Check
+    name: Check Package
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - name: Checkout sources
+        uses: actions/checkout@v3
+      - name: Cache
+        uses: actions/cache@v3
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - name: Install alsa and udev
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-check-${{ hashFiles('**/Cargo.toml') }}
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install Dependencies
+        run: sudo apt-get update; sudo apt-get install pkg-config libx11-dev libasound2-dev libudev-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev
+      - name: Run cargo check (no features, exclude examples)
+        run: cargo check --no-default-features
+      - name: Run cargo check (default features)
+        run: cargo check --all-targets
+      - name: Run cargo check (all features)
+        run: cargo check --all-targets --all-features
 
+  # Run cargo test --all-features
   test:
     name: Test Suite
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - name: Checkout sources
+        uses: actions/checkout@v3
+      - name: Cache
+        uses: actions/cache@v3
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - name: Install alsa and udev
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.toml') }}
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install Dependencies
+        run: sudo apt-get update; sudo apt-get install pkg-config libx11-dev libasound2-dev libudev-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev
+      - name: Run cargo test
+        run: cargo test --all-features
 
-  fmt:
-    name: Rustfmt
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - run: rustup component add rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
-
+  # Run cargo clippy --all-targets --all-features -- -D warnings
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - name: Checkout sources
+        uses: actions/checkout@v3
+      - name: Cache
+        uses: actions/cache@v3
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - run: rustup component add clippy
-      - name: Install alsa and udev
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
-      - uses: actions-rs/cargo@v1
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.toml') }}
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
         with:
-          command: clippy
-          args: -- -D warnings
+          components: clippy
+      - name: Install Dependencies
+        run: sudo apt-get update; sudo apt-get install pkg-config libx11-dev libasound2-dev libudev-dev
+      - name: Run clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+  # Run cargo fmt --all -- --check
+  format:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - name: Run cargo fmt
+        run: cargo fmt --all -- --check

--- a/src/tile_makers.rs
+++ b/src/tile_makers.rs
@@ -379,7 +379,7 @@ mod tests {
             tile_maker(TilePos { x: 0, y: 0 }).unwrap().texture_index.0,
             0
         );
-        assert_eq!(tile_maker(TilePos { x: 0, y: 0 }).unwrap().visible.0, false);
+        assert!(!tile_maker(TilePos { x: 0, y: 0 }).unwrap().visible.0);
 
         assert!(tile_maker(TilePos { x: 1, y: 0 }).is_none());
 
@@ -387,13 +387,13 @@ mod tests {
             tile_maker(TilePos { x: 0, y: 1 }).unwrap().texture_index.0,
             1
         );
-        assert_eq!(tile_maker(TilePos { x: 0, y: 1 }).unwrap().visible.0, true);
+        assert!(tile_maker(TilePos { x: 0, y: 1 }).unwrap().visible.0);
 
         assert_eq!(
             tile_maker(TilePos { x: 1, y: 1 }).unwrap().texture_index.0,
             2
         );
-        assert_eq!(tile_maker(TilePos { x: 1, y: 1 }).unwrap().visible.0, true);
+        assert!(tile_maker(TilePos { x: 1, y: 1 }).unwrap().visible.0);
     }
 
     #[test]


### PR DESCRIPTION
This changes the linting CI drastically to be based off the most recent [`bevy_github_ci_template`](https://github.com/bevyengine/bevy_github_ci_template/blob/1b5cf1bc15ef33cc76eb2e7ef1d6150504ed8687/.github/workflows/ci.yaml). This upgrade includes switching to the actively-maintained dtolnay actions, and implements caching.

This template was updated to have all jobs run against all-targets and all-features as necessary. This begins to resolve a couple of code-review pain-points for me, like having to lint the examples/tests myself.

The template was also updated to have a `check` job. I imagine this was excluded from the template since checking compilation is implicitly performed by the test job. However, I think it's a good idea to include some basic checks that various feature permutations are OK, since feature selection can greatly impact compilation. For now, this checks the package with no features (without `--all-targets`, since some of the examples require features), with default features, and with all features.

chore: fix clippy issues for all targets (#208)