### PR TITLE
docs: fix code links in entity_iid module

### DIFF
--- a/src/components/entity_iid.rs
+++ b/src/components/entity_iid.rs
@@ -2,9 +2,12 @@ use bevy::prelude::*;
 
 use std::borrow::Cow;
 
-/// [Component] added to all [LdtkEntity]s by default.
+/// [`Component`] added to all [`LdtkEntity`]s by default.
 ///
-/// The `iid` stored in this component can be used to uniquely identify LDtk entities within an [LdtkAsset].
+/// The `iid` stored in this component can be used to uniquely identify LDtk entities within an [`LdtkAsset`].
+///
+/// [`LdtkEntity`]: crate::app::LdtkEntity
+/// [`LdtkAsset`]: crate::prelude::LdtkAsset
 #[derive(Clone, Debug, Default, Deref, Hash, Eq, PartialEq, Component, FromReflect, Reflect)]
 #[reflect(Component, Default, Debug)]
 pub struct EntityIid(Cow<'static, str>);


### PR DESCRIPTION
These code links were broken since the code they point to isn't imported. This caused warnings when building the documentation.