### PR TITLE
chore: update compatibility chart for 0.8 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ for additional level-loading options.
 | bevy | bevy_ecs_tilemap | LDtk | bevy_ecs_ldtk |
 | --- | --- | --- | --- |
 | 0.11 | 0.11 | 1.3.3 | main |
+| 0.11 | 0.11 | 1.3.3 | 0.8 |
 | 0.10 | 0.10 | 1.1 | 0.7 |
 | 0.10 | 0.10 | 1.1 | 0.6 |
 | 0.9 | 0.9 | 1.1 | 0.5 |


### PR DESCRIPTION
Adds a new `main` line which copies the current compatibility, and updates the previous compatibility to `bevy_ecs_ldtk` 0.8. Would love to automate this with release-please at some point, but it doesn't seem like it'll be very easy unfortunately.