### PR TITLE
tile_pos_to_int_grid_with_grid_tiles_tile_maker checks grid_tiles

### DIFF
--- a/src/level.rs
+++ b/src/level.rs
@@ -524,9 +524,9 @@ pub fn spawn_level(
                                                         tile_pos_to_tile_if_int_grid_nonzero_maker(
                                                             tile_pos_to_invisible_tile,
                                                             &layer_instance.int_grid_csv,
+                                                            &grid_tiles,
                                                             layer_instance.c_wid,
                                                             layer_instance.c_hei,
-                                                            None
                                                         ),
                                                         layer_instance.opacity,
                                                     ),

--- a/src/level.rs
+++ b/src/level.rs
@@ -526,6 +526,7 @@ pub fn spawn_level(
                                                             &layer_instance.int_grid_csv,
                                                             layer_instance.c_wid,
                                                             layer_instance.c_hei,
+                                                            None
                                                         ),
                                                         layer_instance.opacity,
                                                     ),

--- a/src/tile_makers.rs
+++ b/src/tile_makers.rs
@@ -141,14 +141,34 @@ pub(crate) fn tile_pos_to_tile_if_int_grid_nonzero_maker(
     int_grid_csv: &[i32],
     layer_width_in_tiles: i32,
     layer_height_in_tiles: i32,
+    grid_tiles: Option<&[TileInstance]>,
 ) -> impl FnMut(TilePos) -> Option<TileBundle> {
     let int_grid_map =
         tile_pos_to_int_grid_map(int_grid_csv, layer_width_in_tiles, layer_height_in_tiles);
+
+    let grid_tile_positions_option:Option<Vec<TilePos>> = if let Some(t) = grid_tiles {
+        Some(t.iter()
+            .map(|x| TilePos::new(x.src.x as u32,x.src.y as u32) ) // x.src.x + x.src.y * layer_width_in_tiles)
+            .collect())
+    } else {
+        None
+    };
 
     move |tile_pos: TilePos| -> Option<TileBundle> {
         int_grid_map
             .get(&tile_pos)
             .and_then(|_| tile_maker(tile_pos))
+            .and_then(|tb| {
+                if let Some(grid_tile_positions) = &grid_tile_positions_option {
+                    if grid_tile_positions.contains(&tb.position) {
+                        Some(tb)
+                    }else{
+                        None
+                    }
+                }else{
+                    Some(tb)
+                }
+            })
     }
 }
 
@@ -173,6 +193,7 @@ pub(crate) fn tile_pos_to_int_grid_with_grid_tiles_tile_maker(
         int_grid_csv,
         layer_width_in_tiles,
         layer_height_in_tiles,
+        Some(grid_tiles)
     );
 
     move |tile_pos: TilePos| -> Option<TileBundle> {

--- a/src/tile_makers.rs
+++ b/src/tile_makers.rs
@@ -139,34 +139,27 @@ pub(crate) fn tile_pos_to_tile_maker(
 pub(crate) fn tile_pos_to_tile_if_int_grid_nonzero_maker(
     mut tile_maker: impl FnMut(TilePos) -> Option<TileBundle>,
     int_grid_csv: &[i32],
+    grid_tiles: &[TileInstance],
     layer_width_in_tiles: i32,
     layer_height_in_tiles: i32,
-    grid_tiles: Option<&[TileInstance]>,
 ) -> impl FnMut(TilePos) -> Option<TileBundle> {
     let int_grid_map =
         tile_pos_to_int_grid_map(int_grid_csv, layer_width_in_tiles, layer_height_in_tiles);
 
-    let grid_tile_positions_option:Option<Vec<TilePos>> = if let Some(t) = grid_tiles {
-        Some(t.iter()
-            .map(|x| TilePos::new(x.src.x as u32,x.src.y as u32) ) // x.src.x + x.src.y * layer_width_in_tiles)
-            .collect())
-    } else {
-        None
-    };
+    let grid_tile_positions: Vec<TilePos> = grid_tiles
+        .iter()
+        .map(|x| TilePos::new(x.src.x as u32, x.src.y as u32)) 
+        .collect();
 
     move |tile_pos: TilePos| -> Option<TileBundle> {
         int_grid_map
             .get(&tile_pos)
             .and_then(|_| tile_maker(tile_pos))
             .and_then(|tb| {
-                if let Some(grid_tile_positions) = &grid_tile_positions_option {
-                    if grid_tile_positions.contains(&tb.position) {
-                        Some(tb)
-                    }else{
-                        None
-                    }
-                }else{
+                if grid_tile_positions.contains(&tb.position) {
                     Some(tb)
+                } else {
+                    None
                 }
             })
     }
@@ -191,9 +184,9 @@ pub(crate) fn tile_pos_to_int_grid_with_grid_tiles_tile_maker(
     let mut invisible_tile_maker = tile_pos_to_tile_if_int_grid_nonzero_maker(
         tile_pos_to_invisible_tile,
         int_grid_csv,
+        grid_tiles,
         layer_width_in_tiles,
         layer_height_in_tiles,
-        Some(grid_tiles)
     );
 
     move |tile_pos: TilePos| -> Option<TileBundle> {


### PR DESCRIPTION
A possible solution to https://github.com/Trouv/bevy_ecs_ldtk/issues/227, this PR changes `tile_pos_to_tile_if_int_grid_nonzero_maker` to take in an `grid_tiles` array as an argument and checks against it to see if an invisible tile should be made or not.