### PR TITLE
feat: add types and traits around LevelMetadata

### DIFF
--- a/src/assets/level_metadata.rs
+++ b/src/assets/level_metadata.rs
@@ -7,27 +7,39 @@ use derive_getters::Getters;
 
 use crate::assets::LdtkLevel;
 
+/// Metadata produced for every level during [`LdtkProject`] loading.
+///
+/// [`LdtkProject`]: crate::assets::LdtkProject
 #[derive(Clone, Debug, Default, Eq, PartialEq, TypeUuid, TypePath, Getters)]
 #[uuid = "bba47e30-5036-4994-acde-d62a440b16b8"]
 pub struct LevelMetadata {
+    /// Image handle for the background image of this level, if it has one.
     bg_image: Option<Handle<Image>>,
+    /// Indices of this level in the project.
     indices: LevelIndices,
 }
 
 impl LevelMetadata {
+    /// Construct a new [`LevelMetadata`].
     pub fn new(bg_image: Option<Handle<Image>>, indices: LevelIndices) -> Self {
         LevelMetadata { bg_image, indices }
     }
 }
 
+/// Metadata produced for every level during [`LdtkProject`] loading for external-levels projects.
+///
+/// [`LdtkProject`]: crate::assets::LdtkProject
 #[derive(Clone, Debug, Default, Eq, PartialEq, TypeUuid, TypePath, Getters)]
 #[uuid = "d3190ad4-6fa4-4f47-b15b-87f92f191738"]
 pub struct ExternalLevelMetadata {
+    /// Common metadata for this level.
     metadata: LevelMetadata,
+    /// Handle to this external level's asset data.
     external_handle: Handle<LdtkLevel>,
 }
 
 impl ExternalLevelMetadata {
+    /// Construct a new [`ExternalLevelMetadata`].
     pub fn new(metadata: LevelMetadata, external_handle: Handle<LdtkLevel>) -> Self {
         ExternalLevelMetadata {
             metadata,

--- a/src/assets/level_metadata.rs
+++ b/src/assets/level_metadata.rs
@@ -1,0 +1,37 @@
+use crate::assets::LevelIndices;
+use bevy::{
+    prelude::*,
+    reflect::{TypePath, TypeUuid},
+};
+use derive_getters::Getters;
+
+use crate::assets::LdtkLevel;
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, TypeUuid, TypePath, Getters)]
+#[uuid = "bba47e30-5036-4994-acde-d62a440b16b8"]
+pub struct LevelMetadata {
+    bg_image: Option<Handle<Image>>,
+    indices: LevelIndices,
+}
+
+impl LevelMetadata {
+    pub fn new(bg_image: Option<Handle<Image>>, indices: LevelIndices) -> Self {
+        LevelMetadata { bg_image, indices }
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, TypeUuid, TypePath, Getters)]
+#[uuid = "d3190ad4-6fa4-4f47-b15b-87f92f191738"]
+pub struct ExternalLevelMetadata {
+    metadata: LevelMetadata,
+    external_handle: Handle<LdtkLevel>,
+}
+
+impl ExternalLevelMetadata {
+    pub fn new(metadata: LevelMetadata, external_handle: Handle<LdtkLevel>) -> Self {
+        ExternalLevelMetadata {
+            metadata,
+            external_handle,
+        }
+    }
+}

--- a/src/assets/level_metadata.rs
+++ b/src/assets/level_metadata.rs
@@ -47,3 +47,43 @@ impl ExternalLevelMetadata {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use bevy::render::texture::DEFAULT_IMAGE_HANDLE;
+
+    use super::*;
+
+    #[test]
+    fn level_metadata_construction() {
+        let level_metadata = LevelMetadata::new(None, LevelIndices::in_root(1));
+
+        assert_eq!(*level_metadata.bg_image(), None);
+        assert_eq!(*level_metadata.indices(), LevelIndices::in_root(1));
+
+        let level_metadata = LevelMetadata::new(
+            Some(DEFAULT_IMAGE_HANDLE.typed()),
+            LevelIndices::in_world(2, 3),
+        );
+
+        assert_eq!(
+            *level_metadata.bg_image(),
+            Some(DEFAULT_IMAGE_HANDLE.typed())
+        );
+        assert_eq!(*level_metadata.indices(), LevelIndices::in_world(2, 3));
+    }
+
+    #[test]
+    fn external_level_metadata_construction() {
+        let level_metadata = LevelMetadata::new(None, LevelIndices::in_root(1));
+
+        let external_level_metadata =
+            ExternalLevelMetadata::new(level_metadata.clone(), Handle::default());
+
+        assert_eq!(*external_level_metadata.metadata(), level_metadata);
+        assert_eq!(
+            *external_level_metadata.external_handle(),
+            Handle::default()
+        );
+    }
+}

--- a/src/assets/level_metadata_accessor.rs
+++ b/src/assets/level_metadata_accessor.rs
@@ -44,7 +44,10 @@ pub trait LevelMetadataAccessor: RawLevelAccessor {
 mod tests {
     use std::collections::HashMap;
 
-    use crate::ldtk::{raw_level_accessor::tests::sample_levels, LdtkJson, World};
+    use crate::{
+        ldtk::{raw_level_accessor::tests::sample_levels, LdtkJson, World},
+        LevelIid,
+    };
 
     use super::*;
 
@@ -70,7 +73,7 @@ mod tests {
     }
 
     impl BasicLevelMetadataAccessor {
-        fn valid() -> BasicLevelMetadataAccessor {
+        fn sample_with_root_levels() -> BasicLevelMetadataAccessor {
             let [level_a, level_b, level_c, level_d] = sample_levels();
 
             let data = LdtkJson {
@@ -89,7 +92,7 @@ mod tests {
             }
         }
 
-        fn valid_multi_world() -> BasicLevelMetadataAccessor {
+        fn sample_with_world_levels() -> BasicLevelMetadataAccessor {
             let [level_a, level_b, level_c, level_d] = sample_levels();
 
             let world_a = World {
@@ -121,49 +124,143 @@ mod tests {
 
     #[test]
     fn iid_lookup_returns_expected_root_levels() {
-        let accessor = BasicLevelMetadataAccessor::valid();
+        let accessor = BasicLevelMetadataAccessor::sample_with_root_levels();
 
         let expected_levels = sample_levels();
 
+        for i in 0..expected_levels.len() {
+            assert_eq!(
+                accessor.get_raw_level_by_iid(&expected_levels[i].iid),
+                Some(&expected_levels[i])
+            );
+        }
         assert_eq!(
-            accessor.get_raw_level_by_iid(&expected_levels[0].iid),
-            Some(&expected_levels[0])
-        );
-        assert_eq!(
-            accessor.get_raw_level_by_iid(&expected_levels[1].iid),
-            Some(&expected_levels[1])
-        );
-        assert_eq!(
-            accessor.get_raw_level_by_iid(&expected_levels[2].iid),
-            Some(&expected_levels[2])
-        );
-        assert_eq!(
-            accessor.get_raw_level_by_iid(&expected_levels[3].iid),
-            Some(&expected_levels[3])
+            accessor.get_raw_level_by_iid(&"cd51071d-5224-4628-ae0d-abbe28090521".to_string()),
+            None,
         );
     }
 
     #[test]
     fn iid_lookup_returns_expected_world_levels() {
-        let accessor = BasicLevelMetadataAccessor::valid_multi_world();
+        let accessor = BasicLevelMetadataAccessor::sample_with_world_levels();
 
         let expected_levels = sample_levels();
 
+        for i in 0..expected_levels.len() {
+            assert_eq!(
+                accessor.get_raw_level_by_iid(&expected_levels[i].iid),
+                Some(&expected_levels[i])
+            );
+        }
         assert_eq!(
-            accessor.get_raw_level_by_iid(&expected_levels[0].iid),
-            Some(&expected_levels[0])
+            accessor.get_raw_level_by_iid(&"cd51071d-5224-4628-ae0d-abbe28090521".to_string()),
+            None,
+        );
+    }
+
+    #[test]
+    fn find_by_level_selection_returns_expected_root_levels() {
+        let accessor = BasicLevelMetadataAccessor::sample_with_root_levels();
+
+        let expected_levels = sample_levels();
+
+        for i in 0..expected_levels.len() {
+            assert_eq!(
+                accessor.find_raw_level_by_level_selection(&LevelSelection::index(i)),
+                Some(&expected_levels[i])
+            );
+            assert_eq!(
+                accessor.find_raw_level_by_level_selection(&LevelSelection::Identifier(
+                    expected_levels[i].identifier.clone()
+                )),
+                Some(&expected_levels[i])
+            );
+            assert_eq!(
+                accessor.find_raw_level_by_level_selection(&LevelSelection::Iid(LevelIid::new(
+                    expected_levels[i].iid.clone()
+                ))),
+                Some(&expected_levels[i])
+            );
+            assert_eq!(
+                accessor.find_raw_level_by_level_selection(&LevelSelection::Uid(
+                    expected_levels[i].uid
+                )),
+                Some(&expected_levels[i])
+            );
+        }
+
+        assert_eq!(
+            accessor.find_raw_level_by_level_selection(&LevelSelection::index(4)),
+            None
         );
         assert_eq!(
-            accessor.get_raw_level_by_iid(&expected_levels[1].iid),
-            Some(&expected_levels[1])
+            accessor.find_raw_level_by_level_selection(&LevelSelection::Identifier(
+                "Back_Rooms".to_string()
+            )),
+            None
         );
         assert_eq!(
-            accessor.get_raw_level_by_iid(&expected_levels[2].iid),
-            Some(&expected_levels[2])
+            accessor.find_raw_level_by_level_selection(&LevelSelection::Iid(LevelIid::new(
+                "cd51071d-5224-4628-ae0d-abbe28090521".to_string()
+            ))),
+            None
         );
         assert_eq!(
-            accessor.get_raw_level_by_iid(&expected_levels[3].iid),
-            Some(&expected_levels[3])
+            accessor.find_raw_level_by_level_selection(&LevelSelection::Uid(2023)),
+            None,
+        );
+    }
+
+    #[test]
+    fn find_by_level_selection_returns_expected_world_levels() {
+        let accessor = BasicLevelMetadataAccessor::sample_with_world_levels();
+
+        let expected_levels = sample_levels();
+
+        for i in 0..expected_levels.len() {
+            assert_eq!(
+                accessor.find_raw_level_by_level_selection(&LevelSelection::indices(i / 2, i % 2)),
+                Some(&expected_levels[i])
+            );
+            assert_eq!(
+                accessor.find_raw_level_by_level_selection(&LevelSelection::Identifier(
+                    expected_levels[i].identifier.clone()
+                )),
+                Some(&expected_levels[i])
+            );
+            assert_eq!(
+                accessor.find_raw_level_by_level_selection(&LevelSelection::Iid(LevelIid::new(
+                    expected_levels[i].iid.clone()
+                ))),
+                Some(&expected_levels[i])
+            );
+            assert_eq!(
+                accessor.find_raw_level_by_level_selection(&LevelSelection::Uid(
+                    expected_levels[i].uid
+                )),
+                Some(&expected_levels[i])
+            );
+        }
+
+        assert_eq!(
+            accessor.find_raw_level_by_level_selection(&LevelSelection::index(4)),
+            None
+        );
+        assert_eq!(
+            accessor.find_raw_level_by_level_selection(&LevelSelection::Identifier(
+                "Back_Rooms".to_string()
+            )),
+            None
+        );
+        assert_eq!(
+            accessor.find_raw_level_by_level_selection(&LevelSelection::Iid(LevelIid::new(
+                "cd51071d-5224-4628-ae0d-abbe28090521".to_string()
+            ))),
+            None
+        );
+        assert_eq!(
+            accessor.find_raw_level_by_level_selection(&LevelSelection::Uid(2023)),
+            None,
         );
     }
 }

--- a/src/assets/level_metadata_accessor.rs
+++ b/src/assets/level_metadata_accessor.rs
@@ -138,10 +138,10 @@ mod tests {
 
         let expected_levels = sample_levels();
 
-        for i in 0..expected_levels.len() {
+        for expected_level in expected_levels {
             assert_eq!(
-                accessor.get_raw_level_by_iid(&expected_levels[i].iid),
-                Some(&expected_levels[i])
+                accessor.get_raw_level_by_iid(&expected_level.iid),
+                Some(&expected_level)
             );
         }
         assert_eq!(
@@ -156,10 +156,10 @@ mod tests {
 
         let expected_levels = sample_levels();
 
-        for i in 0..expected_levels.len() {
+        for expected_level in expected_levels {
             assert_eq!(
-                accessor.get_raw_level_by_iid(&expected_levels[i].iid),
-                Some(&expected_levels[i])
+                accessor.get_raw_level_by_iid(&expected_level.iid),
+                Some(&expected_level)
             );
         }
         assert_eq!(
@@ -174,28 +174,27 @@ mod tests {
 
         let expected_levels = sample_levels();
 
-        for i in 0..expected_levels.len() {
+        for (i, expected_level) in expected_levels.iter().enumerate() {
             assert_eq!(
                 accessor.find_raw_level_by_level_selection(&LevelSelection::index(i)),
-                Some(&expected_levels[i])
+                Some(expected_level)
             );
             assert_eq!(
                 accessor.find_raw_level_by_level_selection(&LevelSelection::Identifier(
-                    expected_levels[i].identifier.clone()
+                    expected_level.identifier.clone()
                 )),
-                Some(&expected_levels[i])
+                Some(expected_level)
             );
             assert_eq!(
                 accessor.find_raw_level_by_level_selection(&LevelSelection::Iid(LevelIid::new(
-                    expected_levels[i].iid.clone()
+                    expected_level.iid.clone()
                 ))),
-                Some(&expected_levels[i])
+                Some(expected_level)
             );
             assert_eq!(
-                accessor.find_raw_level_by_level_selection(&LevelSelection::Uid(
-                    expected_levels[i].uid
-                )),
-                Some(&expected_levels[i])
+                accessor
+                    .find_raw_level_by_level_selection(&LevelSelection::Uid(expected_level.uid)),
+                Some(expected_level)
             );
         }
 
@@ -227,28 +226,27 @@ mod tests {
 
         let expected_levels = sample_levels();
 
-        for i in 0..expected_levels.len() {
+        for (i, expected_level) in expected_levels.iter().enumerate() {
             assert_eq!(
                 accessor.find_raw_level_by_level_selection(&LevelSelection::indices(i / 2, i % 2)),
-                Some(&expected_levels[i])
+                Some(expected_level)
             );
             assert_eq!(
                 accessor.find_raw_level_by_level_selection(&LevelSelection::Identifier(
-                    expected_levels[i].identifier.clone()
+                    expected_level.identifier.clone()
                 )),
-                Some(&expected_levels[i])
+                Some(expected_level)
             );
             assert_eq!(
                 accessor.find_raw_level_by_level_selection(&LevelSelection::Iid(LevelIid::new(
-                    expected_levels[i].iid.clone()
+                    expected_level.iid.clone()
                 ))),
-                Some(&expected_levels[i])
+                Some(expected_level)
             );
             assert_eq!(
-                accessor.find_raw_level_by_level_selection(&LevelSelection::Uid(
-                    expected_levels[i].uid
-                )),
-                Some(&expected_levels[i])
+                accessor
+                    .find_raw_level_by_level_selection(&LevelSelection::Uid(expected_level.uid)),
+                Some(expected_level)
             );
         }
 

--- a/src/assets/level_metadata_accessor.rs
+++ b/src/assets/level_metadata_accessor.rs
@@ -1,5 +1,5 @@
 use crate::{
-    assets::{LevelIndices, LevelMetadata},
+    assets::LevelMetadata,
     ldtk::{raw_level_accessor::RawLevelAccessor, Level},
     LevelSelection,
 };
@@ -19,9 +19,12 @@ pub trait LevelMetadataAccessor: RawLevelAccessor {
         match level_selection {
             LevelSelection::Iid(iid) => self.get_raw_level_by_iid(iid.get()),
             LevelSelection::Indices(indices) => self.get_raw_level_at_indices(indices),
-            _ => self
+            LevelSelection::Identifier(selected_identifier) => self
                 .iter_raw_levels()
-                .find(|l| level_selection.is_match(&LevelIndices::default(), l)),
+                .find(|Level { identifier, .. }| identifier == selected_identifier),
+            LevelSelection::Uid(selected_uid) => self
+                .iter_raw_levels()
+                .find(|Level { uid, .. }| uid == selected_uid),
         }
     }
 }

--- a/src/assets/level_metadata_accessor.rs
+++ b/src/assets/level_metadata_accessor.rs
@@ -1,0 +1,27 @@
+use crate::{
+    assets::{LevelIndices, LevelMetadata},
+    ldtk::{raw_level_accessor::RawLevelAccessor, Level},
+    LevelSelection,
+};
+
+pub trait LevelMetadataAccessor: RawLevelAccessor {
+    fn get_level_metadata_by_iid(&self, iid: &String) -> Option<&LevelMetadata>;
+
+    fn get_raw_level_by_iid(&self, iid: &String) -> Option<&Level> {
+        self.get_level_metadata_by_iid(iid)
+            .and_then(|metadata| self.get_raw_level_at_indices(metadata.indices()))
+    }
+
+    fn find_raw_level_by_level_selection(
+        &self,
+        level_selection: &LevelSelection,
+    ) -> Option<&Level> {
+        match level_selection {
+            LevelSelection::Iid(iid) => self.get_raw_level_by_iid(iid.get()),
+            LevelSelection::Indices(indices) => self.get_raw_level_at_indices(indices),
+            _ => self
+                .iter_raw_levels()
+                .find(|l| level_selection.is_match(&LevelIndices::default(), l)),
+        }
+    }
+}

--- a/src/assets/level_metadata_accessor.rs
+++ b/src/assets/level_metadata_accessor.rs
@@ -4,14 +4,25 @@ use crate::{
     LevelSelection,
 };
 
+/// Convenience methods for types that store levels and level metadata.
 pub trait LevelMetadataAccessor: RawLevelAccessor {
+    /// Returns a reference to the level metadata corresponding to the given level iid.
     fn get_level_metadata_by_iid(&self, iid: &String) -> Option<&LevelMetadata>;
 
+    /// Immutable access to a level at the given level iid.
+    ///
+    /// Note: all levels are considered [raw](RawLevelAccessor#raw-levels).
     fn get_raw_level_by_iid(&self, iid: &String) -> Option<&Level> {
         self.get_level_metadata_by_iid(iid)
             .and_then(|metadata| self.get_raw_level_at_indices(metadata.indices()))
     }
 
+    /// Find the level matching the given the given [`LevelSelection`].
+    ///
+    /// This lookup is constant for [`LevelSelection::Iid`] and [`LevelSelection::Indices`] variants.
+    /// The other variants require iterating through the levels to find the match.
+    ///
+    /// Note: all levels are considered [raw](RawLevelAccessor#raw-levels).
     fn find_raw_level_by_level_selection(
         &self,
         level_selection: &LevelSelection,

--- a/src/assets/level_metadata_accessor.rs
+++ b/src/assets/level_metadata_accessor.rs
@@ -7,11 +7,21 @@ use crate::{
 /// Convenience methods for types that store levels and level metadata.
 pub trait LevelMetadataAccessor: RawLevelAccessor {
     /// Returns a reference to the level metadata corresponding to the given level iid.
+    // We accept an `&String` here to avoid creating a new `String`.
+    // Implementations will use this to index a `HashMap<String, _>`, which requires `&String`.
+    // So, accepting `&str` or `AsRef<str>` or `Into<String>` would all require either taking
+    // ownership or creating a new string.
+    #[allow(clippy::ptr_arg)]
     fn get_level_metadata_by_iid(&self, iid: &String) -> Option<&LevelMetadata>;
 
     /// Immutable access to a level at the given level iid.
     ///
     /// Note: all levels are considered [raw](RawLevelAccessor#raw-levels).
+    // We accept an `&String` here to avoid creating a new `String`.
+    // Implementations will use this to index a `HashMap<String, _>`, which requires `&String`.
+    // So, accepting `&str` or `AsRef<str>` or `Into<String>` would all require either taking
+    // ownership or creating a new string.
+    #[allow(clippy::ptr_arg)]
     fn get_raw_level_by_iid(&self, iid: &String) -> Option<&Level> {
         self.get_level_metadata_by_iid(iid)
             .and_then(|metadata| self.get_raw_level_at_indices(metadata.indices()))

--- a/src/assets/mod.rs
+++ b/src/assets/mod.rs
@@ -9,6 +9,9 @@ pub use ldtk_asset_plugin::LdtkAssetPlugin;
 mod level_metadata;
 pub use level_metadata::{ExternalLevelMetadata, LevelMetadata};
 
+mod level_metadata_accessor;
+pub use level_metadata_accessor::LevelMetadataAccessor;
+
 mod ldtk_level;
 pub use ldtk_level::LdtkLevel;
 

--- a/src/assets/mod.rs
+++ b/src/assets/mod.rs
@@ -6,6 +6,9 @@ use std::path::Path;
 mod ldtk_asset_plugin;
 pub use ldtk_asset_plugin::LdtkAssetPlugin;
 
+mod level_metadata;
+pub use level_metadata::{ExternalLevelMetadata, LevelMetadata};
+
 mod ldtk_level;
 pub use ldtk_level::LdtkLevel;
 

--- a/src/ldtk/raw_level_accessor.rs
+++ b/src/ldtk/raw_level_accessor.rs
@@ -154,21 +154,25 @@ pub mod tests {
 
     pub fn sample_levels() -> [Level; 4] {
         let level_a = Level {
+            iid: "e7371660-4e9b-479a-9e14-ab9fb8332619".to_string(),
             identifier: "Tutorial".to_string(),
             ..Default::default()
         };
 
         let level_b = Level {
+            iid: "3485168c-20d8-41c2-a145-a9e10bb30b3e".to_string(),
             identifier: "New_Beginnings".to_string(),
             ..Default::default()
         };
 
         let level_c = Level {
+            iid: "8dcf07d0-3382-474d-99a4-d2a27bf937c8".to_string(),
             identifier: "Turning_Point".to_string(),
             ..Default::default()
         };
 
         let level_d = Level {
+            iid: "248dafc9-75d7-4edb-97b7-44558042632d".to_string(),
             identifier: "Final_Boss".to_string(),
             ..Default::default()
         };

--- a/src/ldtk/raw_level_accessor.rs
+++ b/src/ldtk/raw_level_accessor.rs
@@ -156,24 +156,28 @@ pub mod tests {
         let level_a = Level {
             iid: "e7371660-4e9b-479a-9e14-ab9fb8332619".to_string(),
             identifier: "Tutorial".to_string(),
+            uid: 101,
             ..Default::default()
         };
 
         let level_b = Level {
             iid: "3485168c-20d8-41c2-a145-a9e10bb30b3e".to_string(),
             identifier: "New_Beginnings".to_string(),
+            uid: 103,
             ..Default::default()
         };
 
         let level_c = Level {
             iid: "8dcf07d0-3382-474d-99a4-d2a27bf937c8".to_string(),
             identifier: "Turning_Point".to_string(),
+            uid: 107,
             ..Default::default()
         };
 
         let level_d = Level {
             iid: "248dafc9-75d7-4edb-97b7-44558042632d".to_string(),
             identifier: "Final_Boss".to_string(),
+            uid: 109,
             ..Default::default()
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,7 +138,7 @@ pub mod prelude {
 
     pub use crate::{
         app::{LdtkEntity, LdtkEntityAppExt, LdtkIntCell, LdtkIntCellAppExt},
-        assets::{LdtkLevel, LdtkProject, LevelIndices},
+        assets::{LdtkLevel, LdtkProject, LevelIndices, LevelMetadataAccessor},
         components::{
             EntityIid, EntityInstance, GridCoords, IntGridCell, LayerMetadata, LdtkWorldBundle,
             LevelIid, LevelSet, Respawn, TileEnumTags, TileMetadata, Worldly,


### PR DESCRIPTION
Works towards #205.

The asset types are being redesigned a bit to clone less and provide better APIs. One design goal is to correctly handle both external level projects and internal level projects. Since we want to avoid loading level data into a separate asset in the internal level case, these two scenarios will produce different level metadata on loading. Both need to map level iids to their indices and background image handles. External level projects additionally need to produce a handle to the external level asset. This PR provides `LevelMetadata` and `ExternalLevelMetadata` types to represent the metadata produced during project loading.

Mapping iids to level indices with the help of the level metadata types allows constant-time lookup of levels by iid. This is handy since users can have access to the level iid thanks to the new `LevelIid` component, and can use it for finding level data. This also speeds up accessing levels by `LevelSelection` - two of the 4 level selection variants can now be constant-time-lookup. To aid in these two use cases, a `LevelMetadataAccessor` trait is also added in this PR. It can be implemented for types that store raw level data and a mapping of level iids to `LevelMetadata`. It provides methods for accessing raw level data by iid and by `LevelSelection`.

These types/traits have not actually been integrated into `LdtkProject` in this PR. Doing so is a pretty major change and will be a large PR. These types/traits have been given their own PR in an attempt to keep PRs small.