### PR TITLE
test: add basic LDtk faker types and use them LevelMetadataAccessor tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ hex = "0.4"
 anyhow = "1.0"
 thiserror = "1.0"
 paste = "1.0"
+derive_more = "0.99.17"
 
 [dev-dependencies]
 bevy = "0.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ paste = "1.0"
 [dev-dependencies]
 bevy = "0.11"
 bevy_rapier2d = "0.22.0"
+fake = { version = "2.8.0", features = ["uuid"] }
 rand = "0.8"
 bevy-inspector-egui = "0.19.0"
 

--- a/src/assets/level_metadata_accessor.rs
+++ b/src/assets/level_metadata_accessor.rs
@@ -16,7 +16,7 @@ pub trait LevelMetadataAccessor: RawLevelAccessor {
 
     /// Immutable access to a level at the given level iid.
     ///
-    /// Note: all levels are considered [raw](RawLevelAccessor#raw-levels).
+    /// Note: all levels are considered [raw](crate::assets::LdtkProject#raw-vs-loaded-levels).
     // We accept an `&String` here to avoid creating a new `String`.
     // Implementations will use this to index a `HashMap<String, _>`, which requires `&String`.
     // So, accepting `&str` or `AsRef<str>` or `Into<String>` would all require either taking
@@ -27,12 +27,12 @@ pub trait LevelMetadataAccessor: RawLevelAccessor {
             .and_then(|metadata| self.get_raw_level_at_indices(metadata.indices()))
     }
 
-    /// Find the level matching the given the given [`LevelSelection`].
+    /// Find the level matching the given [`LevelSelection`].
     ///
     /// This lookup is constant for [`LevelSelection::Iid`] and [`LevelSelection::Indices`] variants.
     /// The other variants require iterating through the levels to find the match.
     ///
-    /// Note: all levels are considered [raw](RawLevelAccessor#raw-levels).
+    /// Note: all levels are considered [raw](crate::assets::LdtkProject#raw-vs-loaded-levels).
     fn find_raw_level_by_level_selection(
         &self,
         level_selection: &LevelSelection,

--- a/src/assets/level_metadata_accessor.rs
+++ b/src/assets/level_metadata_accessor.rs
@@ -51,19 +51,24 @@ pub trait LevelMetadataAccessor: RawLevelAccessor {
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use std::collections::HashMap;
 
+    use fake::Fake;
+
     use crate::{
-        ldtk::{raw_level_accessor::tests::sample_levels, LdtkJson, World},
+        ldtk::{
+            fake::{LoadedLevelsFaker, RootLevelsLdtkJsonFaker, WorldLevelsLdtkJsonFaker},
+            LdtkJson,
+        },
         LevelIid,
     };
 
     use super::*;
 
-    struct BasicLevelMetadataAccessor {
-        data: LdtkJson,
-        level_metadata: HashMap<String, LevelMetadata>,
+    pub struct BasicLevelMetadataAccessor {
+        pub data: LdtkJson,
+        pub level_metadata: HashMap<String, LevelMetadata>,
     }
 
     impl RawLevelAccessor for BasicLevelMetadataAccessor {
@@ -83,13 +88,9 @@ mod tests {
     }
 
     impl BasicLevelMetadataAccessor {
-        fn sample_with_root_levels() -> BasicLevelMetadataAccessor {
-            let [level_a, level_b, level_c, level_d] = sample_levels();
-
-            let data = LdtkJson {
-                levels: vec![level_a, level_b, level_c, level_d],
-                ..Default::default()
-            };
+        pub fn sample_with_root_levels() -> BasicLevelMetadataAccessor {
+            let data: LdtkJson =
+                RootLevelsLdtkJsonFaker::new(LoadedLevelsFaker::new(Some(4..5), None)).fake();
 
             let level_metadata = data
                 .iter_raw_levels_with_indices()
@@ -102,23 +103,10 @@ mod tests {
             }
         }
 
-        fn sample_with_world_levels() -> BasicLevelMetadataAccessor {
-            let [level_a, level_b, level_c, level_d] = sample_levels();
-
-            let world_a = World {
-                levels: vec![level_a.clone(), level_b.clone()],
-                ..Default::default()
-            };
-
-            let world_b = World {
-                levels: vec![level_c.clone(), level_d.clone()],
-                ..Default::default()
-            };
-
-            let data = LdtkJson {
-                worlds: vec![world_a, world_b],
-                ..Default::default()
-            };
+        pub fn sample_with_world_levels() -> BasicLevelMetadataAccessor {
+            let data: LdtkJson =
+                WorldLevelsLdtkJsonFaker::new(LoadedLevelsFaker::new(Some(4..5), None), 4..5)
+                    .fake();
 
             let level_metadata = data
                 .iter_raw_levels_with_indices()
@@ -136,12 +124,10 @@ mod tests {
     fn iid_lookup_returns_expected_root_levels() {
         let accessor = BasicLevelMetadataAccessor::sample_with_root_levels();
 
-        let expected_levels = sample_levels();
-
-        for expected_level in expected_levels {
+        for expected_level in &accessor.data.levels {
             assert_eq!(
                 accessor.get_raw_level_by_iid(&expected_level.iid),
-                Some(&expected_level)
+                Some(expected_level)
             );
         }
         assert_eq!(
@@ -154,12 +140,15 @@ mod tests {
     fn iid_lookup_returns_expected_world_levels() {
         let accessor = BasicLevelMetadataAccessor::sample_with_world_levels();
 
-        let expected_levels = sample_levels();
-
-        for expected_level in expected_levels {
+        for expected_level in accessor
+            .data
+            .worlds
+            .iter()
+            .flat_map(|world| world.levels.iter())
+        {
             assert_eq!(
                 accessor.get_raw_level_by_iid(&expected_level.iid),
-                Some(&expected_level)
+                Some(expected_level)
             );
         }
         assert_eq!(
@@ -172,9 +161,7 @@ mod tests {
     fn find_by_level_selection_returns_expected_root_levels() {
         let accessor = BasicLevelMetadataAccessor::sample_with_root_levels();
 
-        let expected_levels = sample_levels();
-
-        for (i, expected_level) in expected_levels.iter().enumerate() {
+        for (i, expected_level) in accessor.data.levels.iter().enumerate() {
             assert_eq!(
                 accessor.find_raw_level_by_level_selection(&LevelSelection::index(i)),
                 Some(expected_level)
@@ -224,30 +211,34 @@ mod tests {
     fn find_by_level_selection_returns_expected_world_levels() {
         let accessor = BasicLevelMetadataAccessor::sample_with_world_levels();
 
-        let expected_levels = sample_levels();
-
-        for (i, expected_level) in expected_levels.iter().enumerate() {
-            assert_eq!(
-                accessor.find_raw_level_by_level_selection(&LevelSelection::indices(i / 2, i % 2)),
-                Some(expected_level)
-            );
-            assert_eq!(
-                accessor.find_raw_level_by_level_selection(&LevelSelection::Identifier(
-                    expected_level.identifier.clone()
-                )),
-                Some(expected_level)
-            );
-            assert_eq!(
-                accessor.find_raw_level_by_level_selection(&LevelSelection::Iid(LevelIid::new(
-                    expected_level.iid.clone()
-                ))),
-                Some(expected_level)
-            );
-            assert_eq!(
-                accessor
-                    .find_raw_level_by_level_selection(&LevelSelection::Uid(expected_level.uid)),
-                Some(expected_level)
-            );
+        for (world_index, world) in accessor.data.worlds.iter().enumerate() {
+            for (level_index, expected_level) in world.levels.iter().enumerate() {
+                assert_eq!(
+                    accessor.find_raw_level_by_level_selection(&LevelSelection::indices(
+                        world_index,
+                        level_index
+                    )),
+                    Some(expected_level)
+                );
+                assert_eq!(
+                    accessor.find_raw_level_by_level_selection(&LevelSelection::Identifier(
+                        expected_level.identifier.clone()
+                    )),
+                    Some(expected_level)
+                );
+                assert_eq!(
+                    accessor.find_raw_level_by_level_selection(&LevelSelection::Iid(
+                        LevelIid::new(expected_level.iid.clone())
+                    )),
+                    Some(expected_level)
+                );
+                assert_eq!(
+                    accessor.find_raw_level_by_level_selection(&LevelSelection::Uid(
+                        expected_level.uid
+                    )),
+                    Some(expected_level)
+                );
+            }
         }
 
         assert_eq!(

--- a/src/ldtk/fake.rs
+++ b/src/ldtk/fake.rs
@@ -1,0 +1,173 @@
+use std::{any::TypeId, ops::Range};
+
+use crate::ldtk::{LayerInstance, Level, World};
+use fake::{faker::lorem::en::Words, uuid::UUIDv4, Dummy, Fake, Faker};
+use rand::Rng;
+
+use super::LdtkJson;
+
+impl Dummy<Faker> for LayerInstance {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        LayerInstance {
+            iid: UUIDv4.fake_with_rng(rng),
+            identifier: Words(2..5).fake_with_rng::<Vec<String>, R>(rng).join("_"),
+            ..Default::default()
+        }
+    }
+}
+
+#[derive(Copy, Clone, Default, Debug, PartialEq, Eq)]
+pub struct UnloadedLevelFaker;
+
+impl Dummy<UnloadedLevelFaker> for Level {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &UnloadedLevelFaker, rng: &mut R) -> Level {
+        let faker = Faker;
+        Level {
+            iid: UUIDv4.fake_with_rng(rng),
+            uid: faker.fake_with_rng(rng),
+            identifier: Words(2..5).fake_with_rng::<Vec<String>, R>(rng).join("_"),
+            ..Default::default()
+        }
+    }
+}
+
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
+pub struct UnloadedLevelsFaker(pub Range<usize>);
+
+impl Dummy<UnloadedLevelsFaker> for Vec<Level> {
+    fn dummy_with_rng<R: Rng + ?Sized>(config: &UnloadedLevelsFaker, rng: &mut R) -> Vec<Level> {
+        Fake::fake_with_rng(&(UnloadedLevelFaker, config.0.clone()), rng)
+    }
+}
+
+#[derive(Clone, Default, Debug, PartialEq)]
+pub struct LoadedLevelFaker(pub Vec<LayerInstance>);
+
+impl Dummy<LoadedLevelFaker> for Level {
+    fn dummy_with_rng<R: Rng + ?Sized>(config: &LoadedLevelFaker, rng: &mut R) -> Level {
+        Level {
+            layer_instances: Some(config.0.clone()),
+            ..UnloadedLevelFaker.fake_with_rng(rng)
+        }
+    }
+}
+
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
+pub struct LoadedLevelsFaker(pub Range<usize>);
+
+impl Dummy<LoadedLevelsFaker> for Vec<Level> {
+    fn dummy_with_rng<R: Rng + ?Sized>(config: &LoadedLevelsFaker, rng: &mut R) -> Vec<Level> {
+        let layers = Fake::fake_with_rng(&(Faker, 2..5), rng);
+        Fake::fake_with_rng(&(LoadedLevelFaker(layers), config.0.clone()), rng)
+    }
+}
+
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
+pub struct WorldFaker<L>(L)
+where
+    Vec<Level>: Dummy<L>;
+
+impl<L> Dummy<WorldFaker<L>> for World
+where
+    Vec<Level>: Dummy<L>,
+{
+    fn dummy_with_rng<R: Rng + ?Sized>(config: &WorldFaker<L>, rng: &mut R) -> Self {
+        World {
+            iid: UUIDv4.fake_with_rng(rng),
+            identifier: Words(2..5).fake_with_rng::<Vec<String>, R>(rng).join("_"),
+            levels: config.0.fake_with_rng(rng),
+            ..Default::default()
+        }
+    }
+}
+
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
+pub struct RootLevelsLdtkJsonFaker<L>(L)
+where
+    Vec<Level>: Dummy<L>;
+
+impl<L> Dummy<RootLevelsLdtkJsonFaker<L>> for LdtkJson
+where
+    Vec<Level>: Dummy<L>,
+    L: 'static,
+{
+    fn dummy_with_rng<R: Rng + ?Sized>(config: &RootLevelsLdtkJsonFaker<L>, rng: &mut R) -> Self {
+        LdtkJson {
+            iid: UUIDv4.fake_with_rng(rng),
+            levels: config.0.fake_with_rng(rng),
+            external_levels: TypeId::of::<L>() == TypeId::of::<UnloadedLevelsFaker>(),
+            ..Default::default()
+        }
+    }
+}
+
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
+pub struct WorldLevelsLdtkJsonFaker<L>(L, Range<usize>)
+where
+    Vec<Level>: Dummy<L>;
+
+impl<L> Dummy<WorldLevelsLdtkJsonFaker<L>> for LdtkJson
+where
+    Vec<Level>: Dummy<L>,
+    L: Clone + 'static,
+{
+    fn dummy_with_rng<R: Rng + ?Sized>(config: &WorldLevelsLdtkJsonFaker<L>, rng: &mut R) -> Self {
+        LdtkJson {
+            iid: UUIDv4.fake_with_rng(rng),
+            worlds: Fake::fake_with_rng(&(WorldFaker(config.0.clone()), config.1.clone()), rng),
+            external_levels: TypeId::of::<L>() == TypeId::of::<UnloadedLevelsFaker>(),
+            ..Default::default()
+        }
+    }
+}
+
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
+struct RootLevelsLdtkJsonWithExternalLevelsFaker(RootLevelsLdtkJsonFaker<LoadedLevelsFaker>);
+
+impl Dummy<RootLevelsLdtkJsonWithExternalLevelsFaker> for (LdtkJson, Vec<Level>) {
+    fn dummy_with_rng<R: Rng + ?Sized>(
+        config: &RootLevelsLdtkJsonWithExternalLevelsFaker,
+        rng: &mut R,
+    ) -> Self {
+        let mut ldtk_json: LdtkJson = config.0.fake_with_rng(rng);
+        let levels = ldtk_json.levels.clone();
+
+        ldtk_json
+            .levels
+            .iter_mut()
+            .for_each(|level| level.layer_instances = None);
+
+        ldtk_json.external_levels = true;
+
+        (ldtk_json, levels)
+    }
+}
+
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
+struct WorldLevelsLdtkJsonWithExternalLevelsFaker(WorldLevelsLdtkJsonFaker<LoadedLevelsFaker>);
+
+impl Dummy<WorldLevelsLdtkJsonWithExternalLevelsFaker> for (LdtkJson, Vec<Level>) {
+    fn dummy_with_rng<R: Rng + ?Sized>(
+        config: &WorldLevelsLdtkJsonWithExternalLevelsFaker,
+        rng: &mut R,
+    ) -> Self {
+        let mut ldtk_json: LdtkJson = config.0.fake_with_rng(rng);
+        let levels = ldtk_json
+            .worlds
+            .iter()
+            .map(|world| world.levels.iter().cloned())
+            .flatten()
+            .collect();
+
+        ldtk_json.worlds.iter_mut().for_each(|world| {
+            world
+                .levels
+                .iter_mut()
+                .for_each(|level| level.layer_instances = None)
+        });
+
+        ldtk_json.external_levels = true;
+
+        (ldtk_json, levels)
+    }
+}

--- a/src/ldtk/fake.rs
+++ b/src/ldtk/fake.rs
@@ -63,7 +63,7 @@ impl Dummy<LoadedLevelsFaker> for Vec<Level> {
 }
 
 #[derive(Clone, Default, Debug, PartialEq, Eq)]
-pub struct WorldFaker<L>(L)
+pub struct WorldFaker<L>(pub L)
 where
     Vec<Level>: Dummy<L>;
 
@@ -82,7 +82,7 @@ where
 }
 
 #[derive(Clone, Default, Debug, PartialEq, Eq)]
-pub struct RootLevelsLdtkJsonFaker<L>(L)
+pub struct RootLevelsLdtkJsonFaker<L>(pub L)
 where
     Vec<Level>: Dummy<L>;
 
@@ -102,7 +102,7 @@ where
 }
 
 #[derive(Clone, Default, Debug, PartialEq, Eq)]
-pub struct WorldLevelsLdtkJsonFaker<L>(L, Range<usize>)
+pub struct WorldLevelsLdtkJsonFaker<L>(pub L, pub Range<usize>)
 where
     Vec<Level>: Dummy<L>;
 
@@ -122,7 +122,28 @@ where
 }
 
 #[derive(Clone, Default, Debug, PartialEq, Eq)]
-struct RootLevelsLdtkJsonWithExternalLevelsFaker(RootLevelsLdtkJsonFaker<LoadedLevelsFaker>);
+pub struct MixedLevelsLdtkJsonFaker<L>(pub L, pub Range<usize>)
+where
+    Vec<Level>: Dummy<L>;
+
+impl<L> Dummy<MixedLevelsLdtkJsonFaker<L>> for LdtkJson
+where
+    Vec<Level>: Dummy<L>,
+    L: Clone + 'static,
+{
+    fn dummy_with_rng<R: Rng + ?Sized>(config: &MixedLevelsLdtkJsonFaker<L>, rng: &mut R) -> Self {
+        LdtkJson {
+            iid: UUIDv4.fake_with_rng(rng),
+            levels: config.0.fake_with_rng(rng),
+            worlds: Fake::fake_with_rng(&(WorldFaker(config.0.clone()), config.1.clone()), rng),
+            external_levels: TypeId::of::<L>() == TypeId::of::<UnloadedLevelsFaker>(),
+            ..Default::default()
+        }
+    }
+}
+
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
+struct RootLevelsLdtkJsonWithExternalLevelsFaker(pub RootLevelsLdtkJsonFaker<LoadedLevelsFaker>);
 
 impl Dummy<RootLevelsLdtkJsonWithExternalLevelsFaker> for (LdtkJson, Vec<Level>) {
     fn dummy_with_rng<R: Rng + ?Sized>(
@@ -144,7 +165,7 @@ impl Dummy<RootLevelsLdtkJsonWithExternalLevelsFaker> for (LdtkJson, Vec<Level>)
 }
 
 #[derive(Clone, Default, Debug, PartialEq, Eq)]
-struct WorldLevelsLdtkJsonWithExternalLevelsFaker(WorldLevelsLdtkJsonFaker<LoadedLevelsFaker>);
+struct WorldLevelsLdtkJsonWithExternalLevelsFaker(pub WorldLevelsLdtkJsonFaker<LoadedLevelsFaker>);
 
 impl Dummy<WorldLevelsLdtkJsonWithExternalLevelsFaker> for (LdtkJson, Vec<Level>) {
     fn dummy_with_rng<R: Rng + ?Sized>(

--- a/src/ldtk/fake.rs
+++ b/src/ldtk/fake.rs
@@ -1,19 +1,31 @@
 use std::{any::TypeId, ops::Range};
 
 use crate::ldtk::{LayerInstance, Level, World};
+use derive_more::Constructor;
 use fake::{faker::lorem::en::Words, uuid::UUIDv4, Dummy, Fake, Faker};
 use rand::Rng;
 
 use super::LdtkJson;
 
-#[derive(Clone, Default, Debug, PartialEq, Eq)]
+pub struct LdtkIdentifierFaker {
+    pub num_words: Range<usize>,
+}
+
+impl Dummy<LdtkIdentifierFaker> for String {
+    fn dummy_with_rng<R: Rng + ?Sized>(config: &LdtkIdentifierFaker, rng: &mut R) -> Self {
+        let words: Vec<String> = Words(config.num_words.clone()).fake_with_rng(rng);
+        words.join("_")
+    }
+}
+
+#[derive(Clone, Default, Debug, PartialEq, Eq, Constructor)]
 pub struct LayerFaker {
     pub identifier: String,
 }
 
 impl Dummy<Faker> for LayerFaker {
     fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
-        let identifier = Words(2..5).fake_with_rng::<Vec<String>, R>(rng).join("_");
+        let identifier = LdtkIdentifierFaker { num_words: 2..5 }.fake_with_rng(rng);
         LayerFaker { identifier }
     }
 }
@@ -35,7 +47,7 @@ impl Dummy<Faker> for LayerInstance {
     }
 }
 
-#[derive(Copy, Clone, Default, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Default, Debug, PartialEq, Eq, Constructor)]
 pub struct UnloadedLevelFaker;
 
 impl Dummy<UnloadedLevelFaker> for Level {
@@ -44,30 +56,34 @@ impl Dummy<UnloadedLevelFaker> for Level {
         Level {
             iid: UUIDv4.fake_with_rng(rng),
             uid: faker.fake_with_rng(rng),
-            identifier: Words(2..5).fake_with_rng::<Vec<String>, R>(rng).join("_"),
+            identifier: LdtkIdentifierFaker { num_words: 2..5 }.fake_with_rng(rng),
             ..Default::default()
         }
     }
 }
 
-#[derive(Clone, Default, Debug, PartialEq, Eq)]
-pub struct UnloadedLevelsFaker(pub Range<usize>);
+#[derive(Clone, Default, Debug, PartialEq, Eq, Constructor)]
+pub struct UnloadedLevelsFaker {
+    pub num_levels: Range<usize>,
+}
 
 impl Dummy<UnloadedLevelsFaker> for Vec<Level> {
     fn dummy_with_rng<R: Rng + ?Sized>(config: &UnloadedLevelsFaker, rng: &mut R) -> Vec<Level> {
-        Fake::fake_with_rng(&(UnloadedLevelFaker, config.0.clone()), rng)
+        Fake::fake_with_rng(&(UnloadedLevelFaker, config.num_levels.clone()), rng)
     }
 }
 
-#[derive(Clone, Default, Debug, PartialEq)]
-pub struct LoadedLevelFaker(pub Vec<LayerFaker>);
+#[derive(Clone, Default, Debug, PartialEq, Constructor)]
+pub struct LoadedLevelFaker {
+    pub layer_fakers: Vec<LayerFaker>,
+}
 
 impl Dummy<LoadedLevelFaker> for Level {
     fn dummy_with_rng<R: Rng + ?Sized>(config: &LoadedLevelFaker, rng: &mut R) -> Level {
         Level {
             layer_instances: Some(
                 config
-                    .0
+                    .layer_fakers
                     .iter()
                     .map(|layer_faker| layer_faker.fake_with_rng(rng))
                     .collect(),
@@ -77,20 +93,51 @@ impl Dummy<LoadedLevelFaker> for Level {
     }
 }
 
-#[derive(Clone, Default, Debug, PartialEq, Eq)]
-pub struct LoadedLevelsFaker(pub Range<usize>);
-
-impl Dummy<LoadedLevelsFaker> for Vec<Level> {
-    fn dummy_with_rng<R: Rng + ?Sized>(config: &LoadedLevelsFaker, rng: &mut R) -> Vec<Level> {
-        let layers = Fake::fake_with_rng(&(Faker, 2..5), rng);
-        Fake::fake_with_rng(&(LoadedLevelFaker(layers), config.0.clone()), rng)
+impl Dummy<Faker> for Level {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        let layer_fakers: Vec<LayerFaker> = (Faker, 2..5).fake_with_rng(rng);
+        LoadedLevelFaker { layer_fakers }.fake_with_rng(rng)
     }
 }
 
-#[derive(Clone, Default, Debug, PartialEq, Eq)]
-pub struct WorldFaker<L>(pub L)
+// Config for faking a collection of loaded levels
+//
+// Just like a real LDtk file, each level should have the same set of layers.
+// Corresponding layers between levels should have some values equal, others different.
+//
+// We cannot implement `Dummy<Faker>` for `Vec<Level>` since these are foreign types.
+// So, the fields here are optional.
+// In their absence, they will be faked or use a sensible default, like a Dummy<Faker> impl would.
+#[derive(Clone, Default, Debug, PartialEq, Eq, Constructor)]
+pub struct LoadedLevelsFaker {
+    // If None, a default range of 4..8 is used
+    pub num_levels: Option<Range<usize>>,
+    // If None, 2-5 layer fakers are faked here
+    pub layer_fakers: Option<Vec<LayerFaker>>,
+}
+
+impl Dummy<LoadedLevelsFaker> for Vec<Level> {
+    fn dummy_with_rng<R: Rng + ?Sized>(config: &LoadedLevelsFaker, rng: &mut R) -> Vec<Level> {
+        (
+            LoadedLevelFaker {
+                layer_fakers: config
+                    .layer_fakers
+                    .clone()
+                    .unwrap_or((Faker, 2..5).fake_with_rng(rng)),
+            },
+            config.num_levels.clone().unwrap_or(4..8),
+        )
+            .fake_with_rng(rng)
+    }
+}
+
+#[derive(Clone, Default, Debug, PartialEq, Eq, Constructor)]
+pub struct WorldFaker<L>
 where
-    Vec<Level>: Dummy<L>;
+    Vec<Level>: Dummy<L>,
+{
+    pub levels_faker: L,
+}
 
 impl<L> Dummy<WorldFaker<L>> for World
 where
@@ -99,17 +146,29 @@ where
     fn dummy_with_rng<R: Rng + ?Sized>(config: &WorldFaker<L>, rng: &mut R) -> Self {
         World {
             iid: UUIDv4.fake_with_rng(rng),
-            identifier: Words(2..5).fake_with_rng::<Vec<String>, R>(rng).join("_"),
-            levels: config.0.fake_with_rng(rng),
+            identifier: LdtkIdentifierFaker { num_words: 2..5 }.fake_with_rng(rng),
+            levels: config.levels_faker.fake_with_rng(rng),
             ..Default::default()
         }
     }
 }
 
-#[derive(Clone, Default, Debug, PartialEq, Eq)]
-pub struct RootLevelsLdtkJsonFaker<L>(pub L)
+impl Dummy<Faker> for World {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        WorldFaker {
+            levels_faker: LoadedLevelsFaker::default(),
+        }
+        .fake_with_rng(rng)
+    }
+}
+
+#[derive(Clone, Default, Debug, PartialEq, Eq, Constructor)]
+pub struct RootLevelsLdtkJsonFaker<L>
 where
-    Vec<Level>: Dummy<L>;
+    Vec<Level>: Dummy<L>,
+{
+    pub levels_faker: L,
+}
 
 impl<L> Dummy<RootLevelsLdtkJsonFaker<L>> for LdtkJson
 where
@@ -119,17 +178,21 @@ where
     fn dummy_with_rng<R: Rng + ?Sized>(config: &RootLevelsLdtkJsonFaker<L>, rng: &mut R) -> Self {
         LdtkJson {
             iid: UUIDv4.fake_with_rng(rng),
-            levels: config.0.fake_with_rng(rng),
+            levels: config.levels_faker.fake_with_rng(rng),
             external_levels: TypeId::of::<L>() == TypeId::of::<UnloadedLevelsFaker>(),
             ..Default::default()
         }
     }
 }
 
-#[derive(Clone, Default, Debug, PartialEq, Eq)]
-pub struct WorldLevelsLdtkJsonFaker<L>(pub L, pub Range<usize>)
+#[derive(Clone, Default, Debug, PartialEq, Eq, Constructor)]
+pub struct WorldLevelsLdtkJsonFaker<L>
 where
-    Vec<Level>: Dummy<L>;
+    Vec<Level>: Dummy<L>,
+{
+    pub levels_faker: L,
+    pub num_worlds: Range<usize>,
+}
 
 impl<L> Dummy<WorldLevelsLdtkJsonFaker<L>> for LdtkJson
 where
@@ -139,17 +202,27 @@ where
     fn dummy_with_rng<R: Rng + ?Sized>(config: &WorldLevelsLdtkJsonFaker<L>, rng: &mut R) -> Self {
         LdtkJson {
             iid: UUIDv4.fake_with_rng(rng),
-            worlds: Fake::fake_with_rng(&(WorldFaker(config.0.clone()), config.1.clone()), rng),
+            worlds: (
+                WorldFaker {
+                    levels_faker: config.levels_faker.clone(),
+                },
+                config.num_worlds.clone(),
+            )
+                .fake_with_rng(rng),
             external_levels: TypeId::of::<L>() == TypeId::of::<UnloadedLevelsFaker>(),
             ..Default::default()
         }
     }
 }
 
-#[derive(Clone, Default, Debug, PartialEq, Eq)]
-pub struct MixedLevelsLdtkJsonFaker<L>(pub L, pub Range<usize>)
+#[derive(Clone, Default, Debug, PartialEq, Eq, Constructor)]
+pub struct MixedLevelsLdtkJsonFaker<L>
 where
-    Vec<Level>: Dummy<L>;
+    Vec<Level>: Dummy<L>,
+{
+    pub levels_faker: L,
+    pub num_worlds: Range<usize>,
+}
 
 impl<L> Dummy<MixedLevelsLdtkJsonFaker<L>> for LdtkJson
 where
@@ -159,25 +232,40 @@ where
     fn dummy_with_rng<R: Rng + ?Sized>(config: &MixedLevelsLdtkJsonFaker<L>, rng: &mut R) -> Self {
         LdtkJson {
             iid: UUIDv4.fake_with_rng(rng),
-            levels: config.0.fake_with_rng(rng),
-            worlds: Fake::fake_with_rng(&(WorldFaker(config.0.clone()), config.1.clone()), rng),
+            levels: config.levels_faker.fake_with_rng(rng),
+            worlds: (
+                WorldFaker {
+                    levels_faker: config.levels_faker.clone(),
+                },
+                config.num_worlds.clone(),
+            )
+                .fake_with_rng(rng),
             external_levels: TypeId::of::<L>() == TypeId::of::<UnloadedLevelsFaker>(),
             ..Default::default()
         }
     }
 }
 
-#[derive(Clone, Default, Debug, PartialEq, Eq)]
-pub struct RootLevelsLdtkJsonWithExternalLevelsFaker(
-    pub RootLevelsLdtkJsonFaker<LoadedLevelsFaker>,
-);
+impl Dummy<Faker> for LdtkJson {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        RootLevelsLdtkJsonFaker {
+            levels_faker: LoadedLevelsFaker::default(),
+        }
+        .fake_with_rng(rng)
+    }
+}
+
+#[derive(Clone, Default, Debug, PartialEq, Eq, Constructor)]
+pub struct RootLevelsLdtkJsonWithExternalLevelsFaker {
+    pub ldtk_json_faker: RootLevelsLdtkJsonFaker<LoadedLevelsFaker>,
+}
 
 impl Dummy<RootLevelsLdtkJsonWithExternalLevelsFaker> for (LdtkJson, Vec<Level>) {
     fn dummy_with_rng<R: Rng + ?Sized>(
         config: &RootLevelsLdtkJsonWithExternalLevelsFaker,
         rng: &mut R,
     ) -> Self {
-        let mut ldtk_json: LdtkJson = config.0.fake_with_rng(rng);
+        let mut ldtk_json: LdtkJson = config.ldtk_json_faker.fake_with_rng(rng);
         let levels = ldtk_json.levels.clone();
 
         ldtk_json
@@ -191,17 +279,17 @@ impl Dummy<RootLevelsLdtkJsonWithExternalLevelsFaker> for (LdtkJson, Vec<Level>)
     }
 }
 
-#[derive(Clone, Default, Debug, PartialEq, Eq)]
-pub struct WorldLevelsLdtkJsonWithExternalLevelsFaker(
-    pub WorldLevelsLdtkJsonFaker<LoadedLevelsFaker>,
-);
+#[derive(Clone, Default, Debug, PartialEq, Eq, Constructor)]
+pub struct WorldLevelsLdtkJsonWithExternalLevelsFaker {
+    pub ldtk_json_faker: WorldLevelsLdtkJsonFaker<LoadedLevelsFaker>,
+}
 
 impl Dummy<WorldLevelsLdtkJsonWithExternalLevelsFaker> for (LdtkJson, Vec<Level>) {
     fn dummy_with_rng<R: Rng + ?Sized>(
         config: &WorldLevelsLdtkJsonWithExternalLevelsFaker,
         rng: &mut R,
     ) -> Self {
-        let mut ldtk_json: LdtkJson = config.0.fake_with_rng(rng);
+        let mut ldtk_json: LdtkJson = config.ldtk_json_faker.fake_with_rng(rng);
         let levels = ldtk_json
             .worlds
             .iter()

--- a/src/ldtk/fake.rs
+++ b/src/ldtk/fake.rs
@@ -6,13 +6,32 @@ use rand::Rng;
 
 use super::LdtkJson;
 
-impl Dummy<Faker> for LayerInstance {
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
+pub struct LayerFaker {
+    pub identifier: String,
+}
+
+impl Dummy<Faker> for LayerFaker {
     fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        let identifier = Words(2..5).fake_with_rng::<Vec<String>, R>(rng).join("_");
+        LayerFaker { identifier }
+    }
+}
+
+impl Dummy<LayerFaker> for LayerInstance {
+    fn dummy_with_rng<R: Rng + ?Sized>(config: &LayerFaker, rng: &mut R) -> Self {
         LayerInstance {
             iid: UUIDv4.fake_with_rng(rng),
-            identifier: Words(2..5).fake_with_rng::<Vec<String>, R>(rng).join("_"),
+            identifier: config.identifier.clone(),
             ..Default::default()
         }
+    }
+}
+
+impl Dummy<Faker> for LayerInstance {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        let layer_faker: LayerFaker = Faker.fake_with_rng(rng);
+        layer_faker.fake_with_rng(rng)
     }
 }
 

--- a/src/ldtk/fake.rs
+++ b/src/ldtk/fake.rs
@@ -60,12 +60,18 @@ impl Dummy<UnloadedLevelsFaker> for Vec<Level> {
 }
 
 #[derive(Clone, Default, Debug, PartialEq)]
-pub struct LoadedLevelFaker(pub Vec<LayerInstance>);
+pub struct LoadedLevelFaker(pub Vec<LayerFaker>);
 
 impl Dummy<LoadedLevelFaker> for Level {
     fn dummy_with_rng<R: Rng + ?Sized>(config: &LoadedLevelFaker, rng: &mut R) -> Level {
         Level {
-            layer_instances: Some(config.0.clone()),
+            layer_instances: Some(
+                config
+                    .0
+                    .iter()
+                    .map(|layer_faker| layer_faker.fake_with_rng(rng))
+                    .collect(),
+            ),
             ..UnloadedLevelFaker.fake_with_rng(rng)
         }
     }

--- a/src/ldtk/fake.rs
+++ b/src/ldtk/fake.rs
@@ -293,8 +293,7 @@ impl Dummy<WorldLevelsLdtkJsonWithExternalLevelsFaker> for (LdtkJson, Vec<Level>
         let levels = ldtk_json
             .worlds
             .iter()
-            .map(|world| world.levels.iter().cloned())
-            .flatten()
+            .flat_map(|world| world.levels.iter().cloned())
             .collect();
 
         ldtk_json.worlds.iter_mut().for_each(|world| {

--- a/src/ldtk/fake.rs
+++ b/src/ldtk/fake.rs
@@ -143,7 +143,9 @@ where
 }
 
 #[derive(Clone, Default, Debug, PartialEq, Eq)]
-struct RootLevelsLdtkJsonWithExternalLevelsFaker(pub RootLevelsLdtkJsonFaker<LoadedLevelsFaker>);
+pub struct RootLevelsLdtkJsonWithExternalLevelsFaker(
+    pub RootLevelsLdtkJsonFaker<LoadedLevelsFaker>,
+);
 
 impl Dummy<RootLevelsLdtkJsonWithExternalLevelsFaker> for (LdtkJson, Vec<Level>) {
     fn dummy_with_rng<R: Rng + ?Sized>(
@@ -165,7 +167,9 @@ impl Dummy<RootLevelsLdtkJsonWithExternalLevelsFaker> for (LdtkJson, Vec<Level>)
 }
 
 #[derive(Clone, Default, Debug, PartialEq, Eq)]
-struct WorldLevelsLdtkJsonWithExternalLevelsFaker(pub WorldLevelsLdtkJsonFaker<LoadedLevelsFaker>);
+pub struct WorldLevelsLdtkJsonWithExternalLevelsFaker(
+    pub WorldLevelsLdtkJsonFaker<LoadedLevelsFaker>,
+);
 
 impl Dummy<WorldLevelsLdtkJsonWithExternalLevelsFaker> for (LdtkJson, Vec<Level>) {
     fn dummy_with_rng<R: Rng + ?Sized>(

--- a/src/ldtk/mod.rs
+++ b/src/ldtk/mod.rs
@@ -42,7 +42,7 @@ use crate::prelude::LdtkEntity;
 pub mod all_some_iter;
 mod color;
 #[cfg(test)]
-mod fake;
+pub mod fake;
 mod field_instance;
 mod impl_definitions;
 pub mod ldtk_fields;

--- a/src/ldtk/mod.rs
+++ b/src/ldtk/mod.rs
@@ -41,6 +41,8 @@ use crate::prelude::LdtkEntity;
 
 pub mod all_some_iter;
 mod color;
+#[cfg(test)]
+mod fake;
 mod field_instance;
 mod impl_definitions;
 pub mod ldtk_fields;


### PR DESCRIPTION
I would like to have more comprehensive tests, but one obstacle in that respect has always been that the LDtk json types were very difficult to construct for tests. They are quite complicated and massive, so writing custom test data is very time consuming and difficult to maintain. This seems to me like a good use case for a faker library, so that is what this PR implements.

You may notice that these faker types are not very sophisticated, and only edit a few fields. My thoughts are that, as tests need to fake more fields of these types, they are welcome to improve the fakers. The sorts of things that are faked here are those that are used in tests for the new asset types. These fakers are also pretty careful about making the faked data a little bit realistic.. in particular, all faked levels will have the "same" set of layers with some per-instance variation much like a real LDtk file. At the highest level, there are also fakers for creating an LdtkJson with unloaded levels, and a separate list of loaded levels, which can be added to an asset store for testing of accessing external level data in the future.

I wasn't too careful about documenting these new types for now, since they are all behind `#[cfg(test)]` and do not appear in the library. If contributors find these types confusing, it may be worth documenting them in a future PR.