### PR TITLE
test: use faker types instead of sample_levels helper in RawLevelAccessor and LdtkProject tests

### DIFF
--- a/src/assets/ldtk_project.rs
+++ b/src/assets/ldtk_project.rs
@@ -141,29 +141,16 @@ impl AssetLoader for LdtkProjectLoader {
 
 #[cfg(test)]
 mod tests {
-    use crate::ldtk::{raw_level_accessor::tests::sample_levels, World};
+    use fake::Fake;
+
+    use crate::ldtk::fake::{LoadedLevelsFaker, MixedLevelsLdtkJsonFaker};
 
     use super::*;
 
     #[test]
     fn raw_level_accessor_implementation_is_transparent() {
-        let [level_a, level_b, level_c, level_d] = sample_levels();
-
-        let world_a = World {
-            levels: vec![level_c.clone()],
-            ..Default::default()
-        };
-
-        let world_b = World {
-            levels: vec![level_d.clone()],
-            ..Default::default()
-        };
-
-        let data = LdtkJson {
-            worlds: vec![world_a, world_b],
-            levels: vec![level_a.clone(), level_b.clone()],
-            ..Default::default()
-        };
+        let data: LdtkJson =
+            MixedLevelsLdtkJsonFaker::new(LoadedLevelsFaker::default(), 4..8).fake();
 
         let project = LdtkProject {
             data: data.clone(),

--- a/src/ldtk/raw_level_accessor.rs
+++ b/src/ldtk/raw_level_accessor.rs
@@ -140,7 +140,7 @@ impl RawLevelAccessor for LdtkJson {
 
 #[cfg(test)]
 pub mod tests {
-    use fake::Fake;
+    use fake::{Fake, Faker};
 
     use crate::ldtk::fake::{
         MixedLevelsLdtkJsonFaker, RootLevelsLdtkJsonFaker, UnloadedLevelsFaker,
@@ -151,7 +151,7 @@ pub mod tests {
 
     #[test]
     fn iter_levels_in_root() {
-        let project: LdtkJson = RootLevelsLdtkJsonFaker(UnloadedLevelsFaker(4..8)).fake();
+        let project: LdtkJson = Faker.fake();
 
         let iter_raw_levels_with_indices =
             project.iter_raw_levels_with_indices().collect::<Vec<_>>();
@@ -188,7 +188,8 @@ pub mod tests {
 
     #[test]
     fn iter_levels_in_worlds() {
-        let project: LdtkJson = WorldLevelsLdtkJsonFaker(UnloadedLevelsFaker(4..5), 4..5).fake();
+        let project: LdtkJson =
+            WorldLevelsLdtkJsonFaker::new(UnloadedLevelsFaker::new(4..5), 4..5).fake();
 
         let iter_raw_levels_with_indices =
             project.iter_raw_levels_with_indices().collect::<Vec<_>>();
@@ -225,7 +226,8 @@ pub mod tests {
 
     #[test]
     fn iter_raw_levels_iterates_through_root_levels_first() {
-        let project: LdtkJson = MixedLevelsLdtkJsonFaker(UnloadedLevelsFaker(4..5), 4..5).fake();
+        let project: LdtkJson =
+            MixedLevelsLdtkJsonFaker::new(UnloadedLevelsFaker::new(4..5), 4..5).fake();
 
         let iter_raw_levels_with_indices =
             project.iter_raw_levels_with_indices().collect::<Vec<_>>();
@@ -283,7 +285,7 @@ pub mod tests {
 
     #[test]
     fn get_root_levels_by_indices() {
-        let project: LdtkJson = RootLevelsLdtkJsonFaker(UnloadedLevelsFaker(4..5)).fake();
+        let project: LdtkJson = RootLevelsLdtkJsonFaker::new(UnloadedLevelsFaker::new(4..5)).fake();
 
         for (i, level) in project.levels.iter().enumerate() {
             assert_eq!(
@@ -305,7 +307,8 @@ pub mod tests {
 
     #[test]
     fn get_world_levels_by_indices() {
-        let project: LdtkJson = WorldLevelsLdtkJsonFaker(UnloadedLevelsFaker(4..5), 4..5).fake();
+        let project: LdtkJson =
+            WorldLevelsLdtkJsonFaker::new(UnloadedLevelsFaker::new(4..5), 4..5).fake();
 
         for (world_index, world) in project.worlds.iter().enumerate() {
             for (level_index, level) in world.levels.iter().enumerate() {

--- a/src/ldtk/raw_level_accessor.rs
+++ b/src/ldtk/raw_level_accessor.rs
@@ -49,14 +49,6 @@ pub type IterLevelsWithIndices<'a> =
 /// This sort of data stores levels both in the "root" of the project, and in each [`World`].
 /// The former is referred to in trait methods as `root_levels`, and the latter as `world_levels`.
 /// Root levels may be removed in the future after LDtk's multi-worlds update.
-///
-/// # Raw levels
-/// All levels that these methods can retrieve are considered "raw".
-/// Raw levels do not have any type guarantee that the level data is complete.
-/// Level data may be incomplete and contain no layer instances if external levels are enabled.
-/// Other methods to retrieve a [`LoadedLevel`] can be used to guarantee level data completion.
-///
-/// [`LoadedLevel`]: crate::ldtk::loaded_level::LoadedLevel
 pub trait RawLevelAccessor {
     /// Slice to this project's collection of [root levels](RawLevelAccessor#root-vs-world-levels).
     fn root_levels(&self) -> &[Level];
@@ -66,14 +58,14 @@ pub trait RawLevelAccessor {
 
     /// Iterate through this project's [root levels](RawLevelAccessor#root-vs-world-levels).
     ///
-    /// Note: all levels are considered [raw](RawLevelAccessor#raw-levels).
+    /// Note: all levels are considered [raw](crate::assets::LdtkProject#raw-vs-loaded-levels).
     fn iter_root_levels(&self) -> IterRootLevels {
         self.root_levels().iter()
     }
 
     /// Iterate through this project's [world levels](RawLevelAccessor#root-vs-world-levels).
     ///
-    /// Note: all levels are considered [raw](RawLevelAccessor#raw-levels).
+    /// Note: all levels are considered [raw](crate::assets::LdtkProject#raw-vs-loaded-levels).
     fn iter_world_levels(&self) -> IterWorldLevels {
         self.worlds().iter().flat_map(|world| world.levels.iter())
     }
@@ -82,7 +74,7 @@ pub trait RawLevelAccessor {
     ///
     /// This first iterates through [root levels, then world levels](RawLevelAccessor#root-vs-world-levels).
     ///
-    /// Note: all levels are considered [raw](RawLevelAccessor#raw-levels).
+    /// Note: all levels are considered [raw](crate::assets::LdtkProject#raw-vs-loaded-levels).
     fn iter_raw_levels(&self) -> IterLevels {
         self.iter_root_levels().chain(self.iter_world_levels())
     }
@@ -90,7 +82,7 @@ pub trait RawLevelAccessor {
     /// Iterate through this project's [root levels](RawLevelAccessor#root-vs-world-levels)
     /// enumerated with their [`LevelIndices`].
     ///
-    /// Note: all levels are considered [raw](RawLevelAccessor#raw-levels).
+    /// Note: all levels are considered [raw](crate::assets::LdtkProject#raw-vs-loaded-levels).
     fn iter_root_levels_with_indices(&self) -> IterRootLevelsWithIndices {
         self.root_levels()
             .iter()
@@ -101,7 +93,7 @@ pub trait RawLevelAccessor {
     /// Iterate through this project's [world levels](RawLevelAccessor#root-vs-world-levels)
     /// enumerated with their [`LevelIndices`].
     ///
-    /// Note: all levels are considered [raw](RawLevelAccessor#raw-levels).
+    /// Note: all levels are considered [raw](crate::assets::LdtkProject#raw-vs-loaded-levels).
     fn iter_world_levels_with_indices(&self) -> IterWorldLevelsWithIndices {
         self.worlds()
             .iter()
@@ -119,7 +111,7 @@ pub trait RawLevelAccessor {
     ///
     /// This first iterates through [root levels, then world levels](RawLevelAccessor#root-vs-world-levels).
     ///
-    /// Note: all levels are considered [raw](RawLevelAccessor#raw-levels).
+    /// Note: all levels are considered [raw](crate::assets::LdtkProject#raw-vs-loaded-levels).
     fn iter_raw_levels_with_indices(&self) -> IterLevelsWithIndices {
         self.iter_root_levels_with_indices()
             .chain(self.iter_world_levels_with_indices())
@@ -127,7 +119,7 @@ pub trait RawLevelAccessor {
 
     /// Immutable access to a level at the given [`LevelIndices`].
     ///
-    /// Note: all levels are considered [raw](RawLevelAccessor#raw-levels).
+    /// Note: all levels are considered [raw](crate::assets::LdtkProject#raw-vs-loaded-levels).
     fn get_raw_level_at_indices(&self, indices: &LevelIndices) -> Option<&Level> {
         match indices.world {
             Some(world_index) => self.worlds().get(world_index)?.levels.get(indices.level),

--- a/src/ldtk/raw_level_accessor.rs
+++ b/src/ldtk/raw_level_accessor.rs
@@ -149,38 +149,6 @@ pub mod tests {
 
     use super::*;
 
-    pub fn sample_levels() -> [Level; 4] {
-        let level_a = Level {
-            iid: "e7371660-4e9b-479a-9e14-ab9fb8332619".to_string(),
-            identifier: "Tutorial".to_string(),
-            uid: 101,
-            ..Default::default()
-        };
-
-        let level_b = Level {
-            iid: "3485168c-20d8-41c2-a145-a9e10bb30b3e".to_string(),
-            identifier: "New_Beginnings".to_string(),
-            uid: 103,
-            ..Default::default()
-        };
-
-        let level_c = Level {
-            iid: "8dcf07d0-3382-474d-99a4-d2a27bf937c8".to_string(),
-            identifier: "Turning_Point".to_string(),
-            uid: 107,
-            ..Default::default()
-        };
-
-        let level_d = Level {
-            iid: "248dafc9-75d7-4edb-97b7-44558042632d".to_string(),
-            identifier: "Final_Boss".to_string(),
-            uid: 109,
-            ..Default::default()
-        };
-
-        [level_a, level_b, level_c, level_d]
-    }
-
     #[test]
     fn iter_levels_in_root() {
         let project: LdtkJson = RootLevelsLdtkJsonFaker(UnloadedLevelsFaker(4..8)).fake();


### PR DESCRIPTION
A recent PR added fakers for the LDtk types. `LevelMetadataAccessor` tests were updated to use these faker types, but I mistakenly forgot to add the updates to the `RawLevelAccessor` tests. This PR adds those update, which allows us to delete `RawLevelAccessor::tests::sample_levels`. 

The `LdtkProject` test also is updated for this, even though it won't really be exist in this form for very long.

(Ignore broken doc-links here, they will no longer be broken in future PRs)