### PR TITLE
feat!: redesign LdtkProject with better level data accessors and correct modeling of internal/external levels

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ derive_more = "0.99.17"
 [dev-dependencies]
 bevy = "0.11"
 bevy_rapier2d = "0.22.0"
+fake = { version = "2.8.0", features = ["uuid"] }
 rand = "0.8"
 bevy-inspector-egui = "0.19.0"
 

--- a/src/assets/ldtk_external_level.rs
+++ b/src/assets/ldtk_external_level.rs
@@ -22,6 +22,11 @@ pub struct LdtkExternalLevel {
 }
 
 impl LdtkExternalLevel {
+    #[cfg(test)]
+    pub fn new(data: Level) -> LdtkExternalLevel {
+        LdtkExternalLevel { data }
+    }
+
     pub fn data(&self) -> LoadedLevel {
         LoadedLevel::try_from(&self.data)
             .expect("construction of LdtkExternalLevel should guarantee that the level is loaded.")

--- a/src/assets/ldtk_external_level.rs
+++ b/src/assets/ldtk_external_level.rs
@@ -17,28 +17,36 @@ use thiserror::Error;
 #[derive(Clone, Debug, PartialEq, TypeUuid, Reflect)]
 #[uuid = "5448469b-2134-44f5-a86c-a7b829f70a0c"]
 pub struct LdtkExternalLevel {
-    /// Raw ldtk level data.
+    /// Raw LDtk level data.
     data: Level,
 }
 
 impl LdtkExternalLevel {
+    /// Construct a new [`LdtkExternalLevel`].
+    ///
+    /// Only available for testing.
+    /// This type should only be constructed via the bevy asset system under normal use.
     #[cfg(test)]
     pub fn new(data: Level) -> LdtkExternalLevel {
         LdtkExternalLevel { data }
     }
 
+    /// Internal LDtk level data as a [`LoadedLevel`].
     pub fn data(&self) -> LoadedLevel {
         LoadedLevel::try_from(&self.data)
             .expect("construction of LdtkExternalLevel should guarantee that the level is loaded.")
     }
 }
 
+/// Errors that can occur when loading an [`LdtkExternalLevel`] asset.
 #[derive(Debug, Error)]
 pub enum LdtkExternalLevelLoaderError {
-    #[error("external LDtk level should contain all level data, but the level's layers is null")]
+    /// External LDtk level should contain all level data, but some level has null layers.
+    #[error("external LDtk level should contain all level data, but some level has null layers")]
     NullLayers,
 }
 
+/// AssetLoader for [`LdtkExternalLevel`]
 #[derive(Default)]
 pub struct LdtkExternalLevelLoader;
 

--- a/src/assets/ldtk_external_level.rs
+++ b/src/assets/ldtk_external_level.rs
@@ -76,3 +76,32 @@ impl AssetLoader for LdtkExternalLevelLoader {
         &["ldtkl"]
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use fake::{Fake, Faker};
+
+    use crate::ldtk::fake::UnloadedLevelFaker;
+
+    use super::*;
+
+    #[test]
+    fn data_accessor_for_loaded_level_succeeds() {
+        // default level faker creates a loaded level
+        let level: Level = Faker.fake();
+
+        let ldtk_external_level = LdtkExternalLevel::new(level.clone());
+
+        assert_eq!(ldtk_external_level.data().raw(), &level);
+    }
+
+    #[test]
+    #[should_panic]
+    fn data_accessor_for_unloaded_level_panics() {
+        let level: Level = UnloadedLevelFaker.fake();
+
+        let ldtk_external_level = LdtkExternalLevel::new(level.clone());
+
+        let _should_panic = ldtk_external_level.data();
+    }
+}

--- a/src/assets/ldtk_external_level.rs
+++ b/src/assets/ldtk_external_level.rs
@@ -31,10 +31,6 @@ impl LdtkExternalLevel {
         LoadedLevel::try_from(&self.data)
             .expect("construction of LdtkExternalLevel should guarantee that the level is loaded.")
     }
-
-    pub fn background_image(&self) -> &Option<Handle<Image>> {
-        &None
-    }
 }
 
 #[derive(Debug, Error)]

--- a/src/assets/ldtk_json_with_metadata.rs
+++ b/src/assets/ldtk_json_with_metadata.rs
@@ -7,7 +7,6 @@ use crate::{
 };
 use bevy::reflect::Reflect;
 use derive_getters::Getters;
-use derive_more::Constructor;
 use std::collections::HashMap;
 
 #[cfg(feature = "internal_levels")]
@@ -36,7 +35,7 @@ fn expect_level_loaded(level: &Level) -> LoadedLevel {
 /// - [external-levels](LdtkJsonWithMetadata#impl-LdtkJsonWithMetadata<ExternalLevels>)
 ///
 /// [`LdtkProject`]: crate::assets::LdtkProject
-#[derive(Clone, Debug, PartialEq, Constructor, Getters, Reflect)]
+#[derive(Clone, Debug, PartialEq, Getters, Reflect)]
 pub struct LdtkJsonWithMetadata<L>
 where
     L: LevelLocale,
@@ -45,6 +44,24 @@ where
     json_data: LdtkJson,
     /// Map from level iids to level metadata.
     level_map: HashMap<String, L::Metadata>,
+}
+
+impl<L> LdtkJsonWithMetadata<L>
+where
+    L: LevelLocale,
+{
+    /// Construct a new [`LdtkJsonWithMetadata`].
+    ///
+    /// Only public to the crate to preserve type guarantees about loaded levels.
+    pub(crate) fn new(
+        json_data: LdtkJson,
+        level_map: HashMap<String, L::Metadata>,
+    ) -> LdtkJsonWithMetadata<L> {
+        LdtkJsonWithMetadata {
+            json_data,
+            level_map,
+        }
+    }
 }
 
 impl<L> RawLevelAccessor for LdtkJsonWithMetadata<L>
@@ -205,6 +222,7 @@ impl LdtkJsonWithMetadata<ExternalLevels> {
 #[cfg(test)]
 pub mod tests {
     use super::*;
+    use derive_more::Constructor;
     use fake::Dummy;
 
     #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Constructor)]

--- a/src/assets/ldtk_json_with_metadata.rs
+++ b/src/assets/ldtk_json_with_metadata.rs
@@ -257,15 +257,14 @@ pub mod tests {
 
         impl Dummy<Faker> for LdtkJsonWithMetadata<InternalLevels> {
             fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
-                LdtkJsonWithMetadataFaker(RootLevelsLdtkJsonFaker(LoadedLevelsFaker(4..8)))
-                    .fake_with_rng(rng)
+                LdtkJsonWithMetadataFaker::new(Faker).fake_with_rng(rng)
             }
         }
 
         #[test]
         fn raw_level_accessor_implementation_is_transparent() {
-            let project: LdtkJsonWithMetadata<InternalLevels> = LdtkJsonWithMetadataFaker(
-                MixedLevelsLdtkJsonFaker(UnloadedLevelsFaker(4..8), 4..8),
+            let project: LdtkJsonWithMetadata<InternalLevels> = LdtkJsonWithMetadataFaker::new(
+                MixedLevelsLdtkJsonFaker::new(LoadedLevelsFaker::default(), 4..8),
             )
             .fake();
 
@@ -471,8 +470,10 @@ pub mod tests {
 
         impl Dummy<Faker> for LdtkJsonWithMetadata<ExternalLevels> {
             fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
-                LdtkJsonWithMetadataFaker(RootLevelsLdtkJsonFaker(LoadedLevelsFaker(4..8)))
-                    .fake_with_rng(rng)
+                LdtkJsonWithMetadataFaker::new(RootLevelsLdtkJsonFaker::new(
+                    UnloadedLevelsFaker::new(4..8),
+                ))
+                .fake_with_rng(rng)
             }
         }
 
@@ -488,8 +489,8 @@ pub mod tests {
             app: &mut App,
         ) -> LdtkJsonWithMetadata<ExternalLevels> {
             let (json_data, levels): (LdtkJson, Vec<Level>) =
-                RootLevelsLdtkJsonWithExternalLevelsFaker(RootLevelsLdtkJsonFaker(
-                    LoadedLevelsFaker(4..8),
+                RootLevelsLdtkJsonWithExternalLevelsFaker::new(RootLevelsLdtkJsonFaker::new(
+                    LoadedLevelsFaker::default(),
                 ))
                 .fake();
 
@@ -520,8 +521,8 @@ pub mod tests {
 
         #[test]
         fn raw_level_accessor_implementation_is_transparent() {
-            let project: LdtkJsonWithMetadata<ExternalLevels> = LdtkJsonWithMetadataFaker(
-                MixedLevelsLdtkJsonFaker(UnloadedLevelsFaker(4..8), 4..8),
+            let project: LdtkJsonWithMetadata<ExternalLevels> = LdtkJsonWithMetadataFaker::new(
+                MixedLevelsLdtkJsonFaker::new(LoadedLevelsFaker::default(), 4..8),
             )
             .fake();
 

--- a/src/assets/ldtk_json_with_metadata.rs
+++ b/src/assets/ldtk_json_with_metadata.rs
@@ -26,14 +26,14 @@ fn expect_level_loaded(level: &Level) -> LoadedLevel {
 
 /// LDtk json data and level metadata produced when loading an [`LdtkProject`] asset.
 ///
-/// Generic over the level metadata type, `L`.
+/// Generic over a level-locale marker type, `L`.
 /// This helps differentiate between internal- and external-level projects.
-/// In practice, `L` will only ever be either [`LevelMetadata`] or [`ExternalLevelMetadata`].
+/// `L` will can only be either [`InternalLevels`] or [`ExternalLevels`].
 /// This provides some abstraction over the two cases, but they are ultimately different types.
 /// Some methods are exclusive to each case, especially for obtaining [`LoadedLevel`]s.
 /// See the [`LoadedLevel`]-accessing methods in the following impls:
-/// - [internal-levels](LdtkJsonWithMetadata#impl-LdtkJsonWithMetadata<LevelMetadata>)
-/// - [external-levels](LdtkJsonWithMetadata#impl-LdtkJsonWithMetadata<ExternalLevelMetadata>)
+/// - [internal-levels](LdtkJsonWithMetadata#impl-LdtkJsonWithMetadata<InternalLevels>)
+/// - [external-levels](LdtkJsonWithMetadata#impl-LdtkJsonWithMetadata<ExternalLevels>)
 ///
 /// [`LdtkProject`]: crate::assets::LdtkProject
 #[derive(Clone, Debug, PartialEq, Constructor, Getters, Reflect)]

--- a/src/assets/ldtk_json_with_metadata.rs
+++ b/src/assets/ldtk_json_with_metadata.rs
@@ -5,6 +5,7 @@ use crate::{
     },
     resources::LevelSelection,
 };
+use bevy::reflect::Reflect;
 use derive_getters::Getters;
 use derive_more::Constructor;
 use std::collections::HashMap;
@@ -31,7 +32,7 @@ fn expect_level_loaded(level: &Level) -> LoadedLevel {
 /// - [external-levels](LdtkJsonWithMetadata#impl-LdtkJsonWithMetadata<ExternalLevelMetadata>)
 ///
 /// [`LdtkProject`]: crate::assets::LdtkProject
-#[derive(Clone, Debug, PartialEq, Constructor, Getters)]
+#[derive(Clone, Debug, PartialEq, Constructor, Getters, Reflect)]
 pub struct LdtkJsonWithMetadata<L> {
     /// Raw ldtk json data.
     json_data: LdtkJson,

--- a/src/assets/ldtk_json_with_metadata.rs
+++ b/src/assets/ldtk_json_with_metadata.rs
@@ -203,7 +203,7 @@ impl LdtkJsonWithMetadata<ExternalLevels> {
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use super::*;
     use fake::Dummy;
 
@@ -212,7 +212,7 @@ mod tests {
         LdtkJson: Dummy<F>;
 
     #[cfg(feature = "internal_levels")]
-    pub mod internal_levels {
+    mod internal_levels {
         use fake::{Fake, Faker};
 
         use crate::{
@@ -435,7 +435,7 @@ mod tests {
             LevelIid,
         };
         use bevy::asset::HandleId;
-        use fake::Fake;
+        use fake::{Fake, Faker};
 
         impl<F> Dummy<LdtkJsonWithMetadataFaker<F>> for LdtkJsonWithMetadata<ExternalLevels>
         where
@@ -465,6 +465,13 @@ mod tests {
                     json_data,
                     level_map,
                 }
+            }
+        }
+
+        impl Dummy<Faker> for LdtkJsonWithMetadata<ExternalLevels> {
+            fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+                LdtkJsonWithMetadataFaker(RootLevelsLdtkJsonFaker(LoadedLevelsFaker(4..8)))
+                    .fake_with_rng(rng)
             }
         }
 
@@ -512,15 +519,13 @@ mod tests {
 
         #[test]
         fn raw_level_accessor_implementation_is_transparent() {
-            let data: LdtkJson = MixedLevelsLdtkJsonFaker(UnloadedLevelsFaker(4..8), 4..8).fake();
+            let project: LdtkJsonWithMetadata<ExternalLevels> = LdtkJsonWithMetadataFaker(
+                MixedLevelsLdtkJsonFaker(UnloadedLevelsFaker(4..8), 4..8),
+            )
+            .fake();
 
-            let project = LdtkJsonWithMetadata::<ExternalLevels> {
-                json_data: data.clone(),
-                level_map: HashMap::default(),
-            };
-
-            assert_eq!(project.root_levels(), data.root_levels());
-            assert_eq!(project.worlds(), data.worlds());
+            assert_eq!(project.root_levels(), project.json_data().root_levels());
+            assert_eq!(project.worlds(), project.json_data().worlds());
         }
 
         #[test]

--- a/src/assets/ldtk_json_with_metadata.rs
+++ b/src/assets/ldtk_json_with_metadata.rs
@@ -83,7 +83,7 @@ impl LdtkJsonWithMetadata<InternalLevels> {
     ///
     /// These levels are "loaded", meaning that they are type-guaranteed to have complete data.
     /// See [`LoadedLevel`] for more details.
-    pub fn get_loaded_level_by_indices(&self, indices: &LevelIndices) -> Option<LoadedLevel> {
+    pub fn get_loaded_level_at_indices(&self, indices: &LevelIndices) -> Option<LoadedLevel> {
         self.get_raw_level_at_indices(indices)
             .map(expect_level_loaded)
     }
@@ -141,7 +141,7 @@ impl LdtkJsonWithMetadata<ExternalLevels> {
     ///
     /// These levels are "loaded", meaning that they are type-guaranteed to have complete data.
     /// See [`LoadedLevel`] for more details.
-    pub fn get_external_level_by_indices<'a>(
+    pub fn get_external_level_at_indices<'a>(
         &'a self,
         external_level_assets: &'a Assets<LdtkExternalLevel>,
         indices: &LevelIndices,
@@ -184,7 +184,7 @@ impl LdtkJsonWithMetadata<ExternalLevels> {
                 self.get_external_level_by_iid(external_level_assets, iid.get())
             }
             LevelSelection::Indices(indices) => {
-                self.get_external_level_by_indices(external_level_assets, indices)
+                self.get_external_level_at_indices(external_level_assets, indices)
             }
             _ => self.get_external_level_by_iid(
                 external_level_assets,
@@ -297,7 +297,7 @@ mod tests {
             for (i, expected_level) in project.json_data.levels.iter().enumerate() {
                 assert_eq!(
                     project
-                        .get_loaded_level_by_indices(&LevelIndices::in_root(i))
+                        .get_loaded_level_at_indices(&LevelIndices::in_root(i))
                         .unwrap()
                         .raw(),
                     expected_level
@@ -305,11 +305,11 @@ mod tests {
             }
 
             assert_eq!(
-                project.get_raw_level_at_indices(&LevelIndices::in_root(10)),
+                project.get_loaded_level_at_indices(&LevelIndices::in_root(10)),
                 None
             );
             assert_eq!(
-                project.get_raw_level_at_indices(&LevelIndices::in_world(0, 0)),
+                project.get_loaded_level_at_indices(&LevelIndices::in_world(0, 0)),
                 None
             );
         }

--- a/src/assets/ldtk_json_with_metadata.rs
+++ b/src/assets/ldtk_json_with_metadata.rs
@@ -73,16 +73,18 @@ impl LdtkJsonWithMetadata<InternalLevels> {
     ///
     /// This first iterates through [root levels, then world levels](RawLevelAccessor#root-vs-world-levels).
     ///
-    /// These levels are "loaded", meaning that they are type-guaranteed to have complete data.
-    /// See [`LoadedLevel`] for more details.
+    /// These levels are [loaded], meaning that they are type-guaranteed to have complete data.
+    ///
+    /// [loaded]: crate::assets::LdtkProject#raw-vs-loaded-levels
     pub fn iter_loaded_levels(&self) -> impl Iterator<Item = LoadedLevel> {
         self.iter_raw_levels().map(expect_level_loaded)
     }
 
     /// Immutable access to a loaded level at the given [`LevelIndices`].
     ///
-    /// These levels are "loaded", meaning that they are type-guaranteed to have complete data.
-    /// See [`LoadedLevel`] for more details.
+    /// These levels are [loaded], meaning that they are type-guaranteed to have complete data.
+    ///
+    /// [loaded]: crate::assets::LdtkProject#raw-vs-loaded-levels
     pub fn get_loaded_level_at_indices(&self, indices: &LevelIndices) -> Option<LoadedLevel> {
         self.get_raw_level_at_indices(indices)
             .map(expect_level_loaded)
@@ -90,8 +92,9 @@ impl LdtkJsonWithMetadata<InternalLevels> {
 
     /// Returns a reference to the loaded level metadata corresponding to the given level iid.
     ///
-    /// These levels are "loaded", meaning that they are type-guaranteed to have complete data.
-    /// See [`LoadedLevel`] for more details.
+    /// These levels are [loaded], meaning that they are type-guaranteed to have complete data.
+    ///
+    /// [loaded]: crate::assets::LdtkProject#raw-vs-loaded-levels
     pub fn get_loaded_level_by_iid(&self, iid: &String) -> Option<LoadedLevel> {
         self.get_raw_level_by_iid(iid).map(expect_level_loaded)
     }
@@ -101,8 +104,9 @@ impl LdtkJsonWithMetadata<InternalLevels> {
     /// This lookup is constant for [`LevelSelection::Iid`] and [`LevelSelection::Indices`] variants.
     /// The other variants require iterating through the levels to find the match.
     ///
-    /// These levels are "loaded", meaning that they are type-guaranteed to have complete data.
-    /// See [`LoadedLevel`] for more details.
+    /// These levels are [loaded], meaning that they are type-guaranteed to have complete data.
+    ///
+    /// [loaded]: crate::assets::LdtkProject#raw-vs-loaded-levels
     pub fn find_loaded_level_by_level_selection(
         &self,
         level_selection: &LevelSelection,
@@ -125,8 +129,9 @@ impl LdtkJsonWithMetadata<ExternalLevels> {
     ///
     /// This first iterates through [root levels, then world levels](RawLevelAccessor#root-vs-world-levels).
     ///
-    /// These levels are "loaded", meaning that they are type-guaranteed to have complete data.
-    /// See [`LoadedLevel`] for more details.
+    /// These levels are [loaded], meaning that they are type-guaranteed to have complete data.
+    ///
+    /// [loaded]: crate::assets::LdtkProject#raw-vs-loaded-levels
     pub fn iter_external_levels<'a>(
         &'a self,
         external_level_assets: &'a Assets<LdtkExternalLevel>,
@@ -139,8 +144,9 @@ impl LdtkJsonWithMetadata<ExternalLevels> {
 
     /// Immutable access to an external level at the given [`LevelIndices`].
     ///
-    /// These levels are "loaded", meaning that they are type-guaranteed to have complete data.
-    /// See [`LoadedLevel`] for more details.
+    /// These levels are [loaded], meaning that they are type-guaranteed to have complete data.
+    ///
+    /// [loaded]: crate::assets::LdtkProject#raw-vs-loaded-levels
     pub fn get_external_level_at_indices<'a>(
         &'a self,
         external_level_assets: &'a Assets<LdtkExternalLevel>,
@@ -154,8 +160,9 @@ impl LdtkJsonWithMetadata<ExternalLevels> {
 
     /// Returns a reference to the external level metadata corresponding to the given level iid.
     ///
-    /// These levels are "loaded", meaning that they are type-guaranteed to have complete data.
-    /// See [`LoadedLevel`] for more details.
+    /// These levels are [loaded], meaning that they are type-guaranteed to have complete data.
+    ///
+    /// [loaded]: crate::assets::LdtkProject#raw-vs-loaded-levels
     pub fn get_external_level_by_iid<'a>(
         &'a self,
         external_level_assets: &'a Assets<LdtkExternalLevel>,
@@ -172,8 +179,9 @@ impl LdtkJsonWithMetadata<ExternalLevels> {
     /// This lookup is constant for [`LevelSelection::Iid`] and [`LevelSelection::Indices`] variants.
     /// The other variants require iterating through the levels to find the match.
     ///
-    /// These levels are "loaded", meaning that they are type-guaranteed to have complete data.
-    /// See [`LoadedLevel`] for more details.
+    /// These levels are [loaded], meaning that they are type-guaranteed to have complete data.
+    ///
+    /// [loaded]: crate::assets::LdtkProject#raw-vs-loaded-levels
     pub fn find_external_level_by_level_selection<'a>(
         &'a self,
         external_level_assets: &'a Assets<LdtkExternalLevel>,

--- a/src/assets/ldtk_json_with_metadata.rs
+++ b/src/assets/ldtk_json_with_metadata.rs
@@ -50,12 +50,14 @@ impl<L> RawLevelAccessor for LdtkJsonWithMetadata<L> {
     }
 }
 
+#[cfg(feature = "internal_levels")]
 impl LevelMetadataAccessor for LdtkJsonWithMetadata<LevelMetadata> {
     fn get_level_metadata_by_iid(&self, iid: &String) -> Option<&LevelMetadata> {
         self.level_map.get(iid)
     }
 }
 
+#[cfg(feature = "internal_levels")]
 impl LdtkJsonWithMetadata<LevelMetadata> {
     /// Iterate through this project's loaded levels.
     ///

--- a/src/assets/ldtk_json_with_metadata.rs
+++ b/src/assets/ldtk_json_with_metadata.rs
@@ -200,14 +200,42 @@ mod tests {
         assets::level_metadata_accessor::tests::BasicLevelMetadataAccessor,
         ldtk::fake::{MixedLevelsLdtkJsonFaker, UnloadedLevelsFaker},
     };
-    use fake::Fake;
+    use fake::{Dummy, Fake, Faker};
 
     use super::*;
 
     #[cfg(feature = "internal_levels")]
     mod internal_levels {
 
+        use crate::{
+            ldtk::fake::{LoadedLevelsFaker, RootLevelsLdtkJsonFaker},
+            LevelIid,
+        };
+
         use super::*;
+
+        impl Dummy<Faker> for LdtkJsonWithMetadata<InternalLevels> {
+            fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+                let json_data: LdtkJson =
+                    RootLevelsLdtkJsonFaker(LoadedLevelsFaker(4..8)).fake_with_rng(rng);
+                let level_map = json_data
+                    .levels
+                    .iter()
+                    .enumerate()
+                    .map(|(i, level)| {
+                        (
+                            level.iid.clone(),
+                            LevelMetadata::new(None, LevelIndices::in_root(i)),
+                        )
+                    })
+                    .collect();
+
+                LdtkJsonWithMetadata {
+                    json_data,
+                    level_map,
+                }
+            }
+        }
 
         #[test]
         fn raw_level_accessor_implementation_is_transparent() {

--- a/src/assets/ldtk_json_with_metadata.rs
+++ b/src/assets/ldtk_json_with_metadata.rs
@@ -198,34 +198,20 @@ impl LdtkJsonWithMetadata<ExternalLevels> {
 mod tests {
     use crate::{
         assets::level_metadata_accessor::tests::BasicLevelMetadataAccessor,
-        ldtk::{raw_level_accessor::tests::sample_levels, World},
+        ldtk::fake::{MixedLevelsLdtkJsonFaker, UnloadedLevelsFaker},
     };
+    use fake::Fake;
 
     use super::*;
 
     #[cfg(feature = "internal_levels")]
     mod internal_levels {
+
         use super::*;
 
         #[test]
         fn raw_level_accessor_implementation_is_transparent() {
-            let [level_a, level_b, level_c, level_d] = sample_levels();
-
-            let world_a = World {
-                levels: vec![level_c.clone()],
-                ..Default::default()
-            };
-
-            let world_b = World {
-                levels: vec![level_d.clone()],
-                ..Default::default()
-            };
-
-            let data = LdtkJson {
-                worlds: vec![world_a, world_b],
-                levels: vec![level_a.clone(), level_b.clone()],
-                ..Default::default()
-            };
+            let data: LdtkJson = MixedLevelsLdtkJsonFaker(UnloadedLevelsFaker(4..8), 4..8).fake();
 
             let project = LdtkJsonWithMetadata::<InternalLevels> {
                 json_data: data.clone(),
@@ -245,9 +231,7 @@ mod tests {
                 level_map: basic.level_metadata.clone(),
             };
 
-            let expected_levels = sample_levels();
-
-            for level in expected_levels {
+            for level in &basic.data.levels {
                 assert_eq!(
                     ldtk_json_with_metadata.get_level_metadata_by_iid(&level.iid),
                     basic.get_level_metadata_by_iid(&level.iid),
@@ -269,23 +253,7 @@ mod tests {
 
         #[test]
         fn raw_level_accessor_implementation_is_transparent() {
-            let [level_a, level_b, level_c, level_d] = sample_levels();
-
-            let world_a = World {
-                levels: vec![level_c.clone()],
-                ..Default::default()
-            };
-
-            let world_b = World {
-                levels: vec![level_d.clone()],
-                ..Default::default()
-            };
-
-            let data = LdtkJson {
-                worlds: vec![world_a, world_b],
-                levels: vec![level_a.clone(), level_b.clone()],
-                ..Default::default()
-            };
+            let data: LdtkJson = MixedLevelsLdtkJsonFaker(UnloadedLevelsFaker(4..8), 4..8).fake();
 
             let project = LdtkJsonWithMetadata::<ExternalLevels> {
                 json_data: data.clone(),
@@ -315,9 +283,7 @@ mod tests {
                     .collect(),
             };
 
-            let expected_levels = sample_levels();
-
-            for level in expected_levels {
+            for level in &basic.data.levels {
                 assert_eq!(
                     ldtk_json_with_metadata.get_level_metadata_by_iid(&level.iid),
                     basic.get_level_metadata_by_iid(&level.iid),

--- a/src/assets/ldtk_json_with_metadata.rs
+++ b/src/assets/ldtk_json_with_metadata.rs
@@ -498,5 +498,168 @@ mod tests {
                 None
             );
         }
+
+        #[test]
+        fn external_level_iteration() {
+            let mut app = app_setup();
+            let project = fake_and_load_ldtk_json_with_metadata(&mut app);
+
+            assert_eq!(
+                project
+                    .iter_external_levels(
+                        app.world
+                            .get_resource::<Assets<LdtkExternalLevel>>()
+                            .unwrap()
+                    )
+                    .count(),
+                project.json_data.levels.len()
+            );
+
+            for (external_level, expected_level) in project
+                .iter_external_levels(
+                    app.world
+                        .get_resource::<Assets<LdtkExternalLevel>>()
+                        .unwrap(),
+                )
+                .zip(project.json_data.levels.iter())
+            {
+                assert_eq!(external_level.iid(), &expected_level.iid)
+            }
+        }
+
+        #[test]
+        fn indices_lookup_returns_expected_external_levels() {
+            let mut app = app_setup();
+            let project = fake_and_load_ldtk_json_with_metadata(&mut app);
+
+            let assets = app
+                .world
+                .get_resource::<Assets<LdtkExternalLevel>>()
+                .unwrap();
+
+            for (i, expected_level) in project.json_data.levels.iter().enumerate() {
+                assert_eq!(
+                    project
+                        .get_external_level_at_indices(assets, &LevelIndices::in_root(i))
+                        .unwrap()
+                        .iid(),
+                    &expected_level.iid
+                );
+            }
+
+            assert_eq!(
+                project.get_external_level_at_indices(assets, &LevelIndices::in_root(10)),
+                None
+            );
+            assert_eq!(
+                project.get_external_level_at_indices(assets, &LevelIndices::in_world(0, 0)),
+                None
+            );
+        }
+
+        #[test]
+        fn iid_lookup_returns_expected_external_levels() {
+            let mut app = app_setup();
+            let project = fake_and_load_ldtk_json_with_metadata(&mut app);
+
+            let assets = app
+                .world
+                .get_resource::<Assets<LdtkExternalLevel>>()
+                .unwrap();
+
+            for expected_level in &project.json_data.levels {
+                assert_eq!(
+                    project
+                        .get_external_level_by_iid(assets, &expected_level.iid)
+                        .unwrap()
+                        .iid(),
+                    &expected_level.iid
+                );
+            }
+
+            assert_eq!(
+                project.get_external_level_by_iid(
+                    assets,
+                    &"cd51071d-5224-4628-ae0d-abbe28090521".to_string()
+                ),
+                None
+            )
+        }
+
+        #[test]
+        fn find_by_level_selection_returns_expected_external_levels() {
+            let mut app = app_setup();
+            let project = fake_and_load_ldtk_json_with_metadata(&mut app);
+
+            let assets = app
+                .world
+                .get_resource::<Assets<LdtkExternalLevel>>()
+                .unwrap();
+
+            for (i, expected_level) in project.json_data.levels.iter().enumerate() {
+                assert_eq!(
+                    project
+                        .find_external_level_by_level_selection(assets, &LevelSelection::index(i))
+                        .unwrap()
+                        .iid(),
+                    &expected_level.iid
+                );
+                assert_eq!(
+                    project
+                        .find_external_level_by_level_selection(
+                            assets,
+                            &LevelSelection::Identifier(expected_level.identifier.clone())
+                        )
+                        .unwrap()
+                        .iid(),
+                    &expected_level.iid
+                );
+                assert_eq!(
+                    project
+                        .find_external_level_by_level_selection(
+                            assets,
+                            &LevelSelection::Iid(LevelIid::new(expected_level.iid.clone()))
+                        )
+                        .unwrap()
+                        .iid(),
+                    &expected_level.iid
+                );
+                assert_eq!(
+                    project
+                        .find_external_level_by_level_selection(
+                            assets,
+                            &LevelSelection::Uid(expected_level.uid)
+                        )
+                        .unwrap()
+                        .iid(),
+                    &expected_level.iid
+                );
+            }
+
+            assert_eq!(
+                project.find_external_level_by_level_selection(assets, &LevelSelection::index(10)),
+                None
+            );
+            assert_eq!(
+                project.find_external_level_by_level_selection(
+                    assets,
+                    &LevelSelection::Identifier("Back_Rooms".to_string())
+                ),
+                None
+            );
+            assert_eq!(
+                project.find_external_level_by_level_selection(
+                    assets,
+                    &LevelSelection::Iid(LevelIid::new(
+                        "cd51071d-5224-4628-ae0d-abbe28090521".to_string()
+                    ))
+                ),
+                None
+            );
+            assert_eq!(
+                project.find_external_level_by_level_selection(assets, &LevelSelection::Uid(2023)),
+                None,
+            );
+        }
     }
 }

--- a/src/assets/ldtk_json_with_metadata.rs
+++ b/src/assets/ldtk_json_with_metadata.rs
@@ -203,94 +203,132 @@ mod tests {
 
     use super::*;
 
-    #[test]
-    fn raw_level_accessor_implementation_is_transparent() {
-        let [level_a, level_b, level_c, level_d] = sample_levels();
-
-        let world_a = World {
-            levels: vec![level_c.clone()],
-            ..Default::default()
-        };
-
-        let world_b = World {
-            levels: vec![level_d.clone()],
-            ..Default::default()
-        };
-
-        let data = LdtkJson {
-            worlds: vec![world_a, world_b],
-            levels: vec![level_a.clone(), level_b.clone()],
-            ..Default::default()
-        };
-
-        let project = LdtkJsonWithMetadata::<()> {
-            json_data: data.clone(),
-            level_map: HashMap::default(),
-        };
-
-        assert_eq!(project.root_levels(), data.root_levels());
-        assert_eq!(project.worlds(), data.worlds());
-    }
-
-    #[test]
     #[cfg(feature = "internal_levels")]
-    fn level_metadata_accessor_implementation_is_transparent() {
-        let basic = BasicLevelMetadataAccessor::sample_with_root_levels();
+    mod internal_levels {
+        use super::*;
 
-        let ldtk_json_with_metadata = LdtkJsonWithMetadata {
-            json_data: basic.data.clone(),
-            level_map: basic.level_metadata.clone(),
-        };
+        #[test]
+        fn raw_level_accessor_implementation_is_transparent() {
+            let [level_a, level_b, level_c, level_d] = sample_levels();
 
-        let expected_levels = sample_levels();
+            let world_a = World {
+                levels: vec![level_c.clone()],
+                ..Default::default()
+            };
 
-        for level in expected_levels {
-            assert_eq!(
-                ldtk_json_with_metadata.get_level_metadata_by_iid(&level.iid),
-                basic.get_level_metadata_by_iid(&level.iid),
-            );
+            let world_b = World {
+                levels: vec![level_d.clone()],
+                ..Default::default()
+            };
+
+            let data = LdtkJson {
+                worlds: vec![world_a, world_b],
+                levels: vec![level_a.clone(), level_b.clone()],
+                ..Default::default()
+            };
+
+            let project = LdtkJsonWithMetadata::<InternalLevels> {
+                json_data: data.clone(),
+                level_map: HashMap::default(),
+            };
+
+            assert_eq!(project.root_levels(), data.root_levels());
+            assert_eq!(project.worlds(), data.worlds());
         }
 
-        assert_eq!(
-            ldtk_json_with_metadata
-                .get_level_metadata_by_iid(&"This_level_doesnt_exist".to_string()),
-            None
-        );
+        #[test]
+        fn level_metadata_accessor_implementation_is_transparent() {
+            let basic = BasicLevelMetadataAccessor::sample_with_root_levels();
+
+            let ldtk_json_with_metadata = LdtkJsonWithMetadata::<InternalLevels> {
+                json_data: basic.data.clone(),
+                level_map: basic.level_metadata.clone(),
+            };
+
+            let expected_levels = sample_levels();
+
+            for level in expected_levels {
+                assert_eq!(
+                    ldtk_json_with_metadata.get_level_metadata_by_iid(&level.iid),
+                    basic.get_level_metadata_by_iid(&level.iid),
+                );
+            }
+
+            assert_eq!(
+                ldtk_json_with_metadata
+                    .get_level_metadata_by_iid(&"This_level_doesnt_exist".to_string()),
+                None
+            );
+        }
     }
 
-    #[test]
     #[cfg(feature = "external_levels")]
-    fn external_level_metadata_accessor_is_transparent() {
-        let basic = BasicLevelMetadataAccessor::sample_with_root_levels();
+    mod external_levels {
+        use super::*;
+        use crate::assets::ExternalLevelMetadata;
 
-        let ldtk_json_with_metadata = LdtkJsonWithMetadata {
-            json_data: basic.data.clone(),
-            level_map: basic
-                .level_metadata
-                .clone()
-                .into_iter()
-                .map(|(iid, level_metadata)| {
-                    (
-                        iid,
-                        ExternalLevelMetadata::new(level_metadata, Handle::default()),
-                    )
-                })
-                .collect(),
-        };
+        #[test]
+        fn raw_level_accessor_implementation_is_transparent() {
+            let [level_a, level_b, level_c, level_d] = sample_levels();
 
-        let expected_levels = sample_levels();
+            let world_a = World {
+                levels: vec![level_c.clone()],
+                ..Default::default()
+            };
 
-        for level in expected_levels {
-            assert_eq!(
-                ldtk_json_with_metadata.get_level_metadata_by_iid(&level.iid),
-                basic.get_level_metadata_by_iid(&level.iid),
-            );
+            let world_b = World {
+                levels: vec![level_d.clone()],
+                ..Default::default()
+            };
+
+            let data = LdtkJson {
+                worlds: vec![world_a, world_b],
+                levels: vec![level_a.clone(), level_b.clone()],
+                ..Default::default()
+            };
+
+            let project = LdtkJsonWithMetadata::<ExternalLevels> {
+                json_data: data.clone(),
+                level_map: HashMap::default(),
+            };
+
+            assert_eq!(project.root_levels(), data.root_levels());
+            assert_eq!(project.worlds(), data.worlds());
         }
 
-        assert_eq!(
-            ldtk_json_with_metadata
-                .get_level_metadata_by_iid(&"This_level_doesnt_exist".to_string()),
-            None
-        );
+        #[test]
+        fn external_level_metadata_accessor_is_transparent() {
+            let basic = BasicLevelMetadataAccessor::sample_with_root_levels();
+
+            let ldtk_json_with_metadata = LdtkJsonWithMetadata::<ExternalLevels> {
+                json_data: basic.data.clone(),
+                level_map: basic
+                    .level_metadata
+                    .clone()
+                    .into_iter()
+                    .map(|(iid, level_metadata)| {
+                        (
+                            iid,
+                            ExternalLevelMetadata::new(level_metadata, Handle::default()),
+                        )
+                    })
+                    .collect(),
+            };
+
+            let expected_levels = sample_levels();
+
+            for level in expected_levels {
+                assert_eq!(
+                    ldtk_json_with_metadata.get_level_metadata_by_iid(&level.iid),
+                    basic.get_level_metadata_by_iid(&level.iid),
+                );
+            }
+
+            assert_eq!(
+                ldtk_json_with_metadata
+                    .get_level_metadata_by_iid(&"This_level_doesnt_exist".to_string()),
+                None
+            );
+        }
     }
 }

--- a/src/assets/ldtk_json_with_metadata.rs
+++ b/src/assets/ldtk_json_with_metadata.rs
@@ -207,9 +207,13 @@ pub mod tests {
     use super::*;
     use fake::Dummy;
 
-    pub struct LdtkJsonWithMetadataFaker<F>(pub F)
+    #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Constructor)]
+    pub struct LdtkJsonWithMetadataFaker<F>
     where
-        LdtkJson: Dummy<F>;
+        LdtkJson: Dummy<F>,
+    {
+        pub ldtk_json_faker: F,
+    }
 
     #[cfg(feature = "internal_levels")]
     mod internal_levels {
@@ -217,10 +221,7 @@ pub mod tests {
 
         use crate::{
             assets::level_metadata_accessor::tests::BasicLevelMetadataAccessor,
-            ldtk::fake::{
-                LoadedLevelsFaker, MixedLevelsLdtkJsonFaker, RootLevelsLdtkJsonFaker,
-                UnloadedLevelsFaker,
-            },
+            ldtk::fake::{LoadedLevelsFaker, MixedLevelsLdtkJsonFaker},
             LevelIid,
         };
 
@@ -234,7 +235,7 @@ pub mod tests {
                 config: &LdtkJsonWithMetadataFaker<F>,
                 rng: &mut R,
             ) -> Self {
-                let json_data: LdtkJson = config.0.fake_with_rng(rng);
+                let json_data: LdtkJson = config.ldtk_json_faker.fake_with_rng(rng);
                 let level_map = json_data
                     .levels
                     .iter()
@@ -445,7 +446,7 @@ pub mod tests {
                 config: &LdtkJsonWithMetadataFaker<F>,
                 rng: &mut R,
             ) -> Self {
-                let json_data: LdtkJson = config.0.fake_with_rng(rng);
+                let json_data: LdtkJson = config.ldtk_json_faker.fake_with_rng(rng);
                 let level_map = json_data
                     .levels
                     .iter()

--- a/src/assets/ldtk_json_with_metadata.rs
+++ b/src/assets/ldtk_json_with_metadata.rs
@@ -207,14 +207,13 @@ impl LdtkJsonWithMetadata<ExternalLevels> {
 mod internal_level_tests {
     use crate::{
         assets::level_metadata_accessor::tests::BasicLevelMetadataAccessor,
-        ldtk::fake::{MixedLevelsLdtkJsonFaker, UnloadedLevelsFaker},
-    };
-    use fake::{Dummy, Fake, Faker};
-
-    use crate::{
-        ldtk::fake::{LoadedLevelsFaker, RootLevelsLdtkJsonFaker},
+        ldtk::fake::{
+            LoadedLevelsFaker, MixedLevelsLdtkJsonFaker, RootLevelsLdtkJsonFaker,
+            UnloadedLevelsFaker,
+        },
         LevelIid,
     };
+    use fake::{Dummy, Fake, Faker};
 
     use super::*;
 
@@ -405,13 +404,12 @@ mod internal_level_tests {
 mod external_level_tests {
     use super::*;
     use crate::{
-        assets::level_metadata_accessor::tests::BasicLevelMetadataAccessor,
-        ldtk::fake::{MixedLevelsLdtkJsonFaker, UnloadedLevelsFaker},
-    };
-    use crate::{
-        assets::ExternalLevelMetadata,
+        assets::{
+            level_metadata_accessor::tests::BasicLevelMetadataAccessor, ExternalLevelMetadata,
+        },
         ldtk::fake::{
-            LoadedLevelsFaker, RootLevelsLdtkJsonFaker, RootLevelsLdtkJsonWithExternalLevelsFaker,
+            LoadedLevelsFaker, MixedLevelsLdtkJsonFaker, RootLevelsLdtkJsonFaker,
+            RootLevelsLdtkJsonWithExternalLevelsFaker, UnloadedLevelsFaker,
         },
         LevelIid,
     };

--- a/src/assets/ldtk_json_with_metadata.rs
+++ b/src/assets/ldtk_json_with_metadata.rs
@@ -131,8 +131,8 @@ impl LdtkJsonWithMetadata<ExternalLevels> {
         &'a self,
         external_level_assets: &'a Assets<LdtkExternalLevel>,
     ) -> impl Iterator<Item = LoadedLevel<'a>> {
-        self.level_map()
-            .values()
+        self.iter_raw_levels()
+            .filter_map(|level| self.level_map.get(&level.iid))
             .filter_map(|metadata| external_level_assets.get(metadata.external_handle()))
             .map(LdtkExternalLevel::data)
     }

--- a/src/assets/ldtk_json_with_metadata.rs
+++ b/src/assets/ldtk_json_with_metadata.rs
@@ -204,7 +204,7 @@ impl LdtkJsonWithMetadata<ExternalLevels> {
 
 #[cfg(feature = "internal_levels")]
 #[cfg(test)]
-mod internal_level_tests {
+pub mod internal_level_tests {
     use crate::{
         assets::level_metadata_accessor::tests::BasicLevelMetadataAccessor,
         ldtk::fake::{
@@ -217,10 +217,19 @@ mod internal_level_tests {
 
     use super::*;
 
-    impl Dummy<Faker> for LdtkJsonWithMetadata<InternalLevels> {
-        fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
-            let json_data: LdtkJson =
-                RootLevelsLdtkJsonFaker(LoadedLevelsFaker(4..8)).fake_with_rng(rng);
+    pub struct LdtkJsonWithMetadataFaker<F>(pub F)
+    where
+        LdtkJson: Dummy<F>;
+
+    impl<F> Dummy<LdtkJsonWithMetadataFaker<F>> for LdtkJsonWithMetadata<InternalLevels>
+    where
+        LdtkJson: Dummy<F>,
+    {
+        fn dummy_with_rng<R: rand::Rng + ?Sized>(
+            config: &LdtkJsonWithMetadataFaker<F>,
+            rng: &mut R,
+        ) -> Self {
+            let json_data: LdtkJson = config.0.fake_with_rng(rng);
             let level_map = json_data
                 .levels
                 .iter()
@@ -237,6 +246,13 @@ mod internal_level_tests {
                 json_data,
                 level_map,
             }
+        }
+    }
+
+    impl Dummy<Faker> for LdtkJsonWithMetadata<InternalLevels> {
+        fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+            LdtkJsonWithMetadataFaker(RootLevelsLdtkJsonFaker(LoadedLevelsFaker(4..8)))
+                .fake_with_rng(rng)
         }
     }
 

--- a/src/assets/ldtk_json_with_metadata.rs
+++ b/src/assets/ldtk_json_with_metadata.rs
@@ -272,6 +272,131 @@ mod tests {
                 None
             );
         }
+
+        #[test]
+        fn loaded_level_iteration() {
+            let project: LdtkJsonWithMetadata<InternalLevels> = Faker.fake();
+
+            assert_eq!(
+                project.iter_loaded_levels().count(),
+                project.json_data.levels.len()
+            );
+
+            for (loaded_level, expected_level) in project
+                .iter_loaded_levels()
+                .zip(project.json_data.levels.iter())
+            {
+                assert_eq!(loaded_level.raw(), expected_level)
+            }
+        }
+
+        #[test]
+        fn indices_lookup_returns_expected_loaded_levels() {
+            let project: LdtkJsonWithMetadata<InternalLevels> = Faker.fake();
+
+            for (i, expected_level) in project.json_data.levels.iter().enumerate() {
+                assert_eq!(
+                    project
+                        .get_loaded_level_by_indices(&LevelIndices::in_root(i))
+                        .unwrap()
+                        .raw(),
+                    expected_level
+                );
+            }
+
+            assert_eq!(
+                project.get_raw_level_at_indices(&LevelIndices::in_root(10)),
+                None
+            );
+            assert_eq!(
+                project.get_raw_level_at_indices(&LevelIndices::in_world(0, 0)),
+                None
+            );
+        }
+
+        #[test]
+        fn iid_lookup_returns_expected_loaded_levels() {
+            let project: LdtkJsonWithMetadata<InternalLevels> = Faker.fake();
+
+            for expected_level in &project.json_data.levels {
+                assert_eq!(
+                    project
+                        .get_loaded_level_by_iid(&expected_level.iid)
+                        .unwrap()
+                        .raw(),
+                    expected_level
+                );
+            }
+
+            assert_eq!(
+                project
+                    .get_loaded_level_by_iid(&"cd51071d-5224-4628-ae0d-abbe28090521".to_string()),
+                None
+            )
+        }
+
+        #[test]
+        fn find_by_level_selection_returns_expected_loaded_levels() {
+            let project: LdtkJsonWithMetadata<InternalLevels> = Faker.fake();
+
+            for (i, expected_level) in project.json_data.levels.iter().enumerate() {
+                assert_eq!(
+                    project
+                        .find_loaded_level_by_level_selection(&LevelSelection::index(i))
+                        .unwrap()
+                        .raw(),
+                    expected_level
+                );
+                assert_eq!(
+                    project
+                        .find_loaded_level_by_level_selection(&LevelSelection::Identifier(
+                            expected_level.identifier.clone()
+                        ))
+                        .unwrap()
+                        .raw(),
+                    expected_level
+                );
+                assert_eq!(
+                    project
+                        .find_loaded_level_by_level_selection(&LevelSelection::Iid(LevelIid::new(
+                            expected_level.iid.clone()
+                        )))
+                        .unwrap()
+                        .raw(),
+                    expected_level
+                );
+                assert_eq!(
+                    project
+                        .find_loaded_level_by_level_selection(&LevelSelection::Uid(
+                            expected_level.uid
+                        ))
+                        .unwrap()
+                        .raw(),
+                    expected_level
+                );
+            }
+
+            assert_eq!(
+                project.find_loaded_level_by_level_selection(&LevelSelection::index(10)),
+                None
+            );
+            assert_eq!(
+                project.find_loaded_level_by_level_selection(&LevelSelection::Identifier(
+                    "Back_Rooms".to_string()
+                )),
+                None
+            );
+            assert_eq!(
+                project.find_loaded_level_by_level_selection(&LevelSelection::Iid(LevelIid::new(
+                    "cd51071d-5224-4628-ae0d-abbe28090521".to_string()
+                ))),
+                None
+            );
+            assert_eq!(
+                project.find_loaded_level_by_level_selection(&LevelSelection::Uid(2023)),
+                None,
+            );
+        }
     }
 
     #[cfg(feature = "external_levels")]

--- a/src/assets/ldtk_project.rs
+++ b/src/assets/ldtk_project.rs
@@ -68,8 +68,8 @@ fn ldtk_path_to_asset_path<'b>(ldtk_path: &Path, rel_path: &str) -> AssetPath<'b
 ///
 /// [`LoadedLevel`]: crate::ldtk::loaded_level::LoadedLevel
 /// [`LdtkExternalLevel`]: crate::assets::LdtkExternalLevel
-/// [`loaded_level` accessors]: LdtkJsonWithMetadata#impl-LdtkJsonWithMetadata<LevelMetadata>
-/// [`external_level` accessors]: LdtkJsonWithMetadata#impl-LdtkJsonWithMetadata<ExternalLevelMetadata>
+/// [`loaded_level` accessors]: LdtkJsonWithMetadata#impl-LdtkJsonWithMetadata<InternalLevels>
+/// [`external_level` accessors]: LdtkJsonWithMetadata#impl-LdtkJsonWithMetadata<ExternalLevels>
 #[derive(Clone, Debug, PartialEq, From, TypeUuid, Getters, Constructor, Reflect)]
 #[uuid = "43571891-8570-4416-903f-582efe3426ac"]
 pub struct LdtkProject {
@@ -87,28 +87,28 @@ impl LdtkProject {
         self.data.json_data()
     }
 
-    /// Unwrap as a [`LdtkJsonWithMetadata<LevelMetadata>`].
+    /// Unwrap as a [`LdtkJsonWithMetadata<InternalLevels>`].
     /// For use on internal-levels ldtk projects only.
     ///
     /// # Panics
     /// Panics if `self.data()` is not [`LdtkProjectData::Standalone`].
     /// This shouldn't occur if the project uses internal levels.
     ///
-    /// [`LdtkJsonWithMetadata<LevelMetadata>`]: LdtkJsonWithMetadata
+    /// [`LdtkJsonWithMetadata<InternalLevels>`]: LdtkJsonWithMetadata
     /// [`LoadedLevel`]: crate::assets::loaded_level::LoadedLevel
     #[cfg(feature = "internal_levels")]
     pub fn as_standalone(&self) -> &LdtkJsonWithMetadata<InternalLevels> {
         self.data.as_standalone()
     }
 
-    /// Unwrap as a [`LdtkJsonWithMetadata<ExternalLevelMetadata>`].
+    /// Unwrap as a [`LdtkJsonWithMetadata<ExternalLevels>`].
     /// For use on external-levels ldtk projects only.
     ///
     /// # Panics
     /// Panics if `self.data()` is not [`LdtkProjectData::Parent`].
     /// This shouldn't occur if the project uses external levels.
     ///
-    /// [`LdtkJsonWithMetadata<ExternalLevelMetadata>`]: LdtkJsonWithMetadata
+    /// [`LdtkJsonWithMetadata<ExternalLevels>`]: LdtkJsonWithMetadata
     /// [`LoadedLevel`]: crate::assets::loaded_level::LoadedLevel
     #[cfg(feature = "external_levels")]
     pub fn as_parent(&self) -> &LdtkJsonWithMetadata<ExternalLevels> {

--- a/src/assets/ldtk_project.rs
+++ b/src/assets/ldtk_project.rs
@@ -411,6 +411,14 @@ mod tests {
 
     #[cfg(feature = "external_levels")]
     mod external_levels {
+        use crate::{
+            assets::{
+                ldtk_json_with_metadata::tests::LdtkJsonWithMetadataFaker,
+                ldtk_project_data::external_level_tests::ParentLdtkProjectDataFaker,
+            },
+            ldtk::fake::{LoadedLevelsFaker, MixedLevelsLdtkJsonFaker},
+        };
+
         use super::*;
 
         impl Dummy<ExternalLevels> for LdtkProject {
@@ -420,6 +428,44 @@ mod tests {
                 }
                 .fake_with_rng(rng)
             }
+        }
+
+        #[test]
+        fn json_data_accessor_is_transparent() {
+            let project: LdtkProject = ExternalLevels.fake();
+
+            assert_eq!(project.json_data(), project.data().json_data());
+        }
+
+        #[test]
+        fn raw_level_accessor_implementation_is_transparent() {
+            let project: LdtkProject = LdtkProjectFaker::new(ParentLdtkProjectDataFaker::new(
+                LdtkJsonWithMetadataFaker::new(MixedLevelsLdtkJsonFaker::new(
+                    LoadedLevelsFaker::default(),
+                    4..8,
+                )),
+            ))
+            .fake();
+
+            assert_eq!(project.root_levels(), project.json_data().root_levels());
+            assert_eq!(project.worlds(), project.json_data().worlds());
+        }
+
+        #[test]
+        fn level_metadata_accessor_implementation_is_transparent() {
+            let project: LdtkProject = ExternalLevels.fake();
+
+            for level in &project.json_data().levels {
+                assert_eq!(
+                    project.get_level_metadata_by_iid(&level.iid),
+                    project.data().get_level_metadata_by_iid(&level.iid),
+                );
+            }
+
+            assert_eq!(
+                project.get_level_metadata_by_iid(&"This_level_doesnt_exist".to_string()),
+                None
+            );
         }
     }
 }

--- a/src/assets/ldtk_project.rs
+++ b/src/assets/ldtk_project.rs
@@ -351,6 +351,14 @@ mod tests {
 
     #[cfg(feature = "internal_levels")]
     mod internal_levels {
+        use crate::{
+            assets::{
+                ldtk_json_with_metadata::tests::LdtkJsonWithMetadataFaker,
+                ldtk_project_data::internal_level_tests::StandaloneLdtkProjectDataFaker,
+            },
+            ldtk::fake::{LoadedLevelsFaker, MixedLevelsLdtkJsonFaker},
+        };
+
         use super::*;
 
         impl Dummy<InternalLevels> for LdtkProject {
@@ -360,6 +368,44 @@ mod tests {
                 }
                 .fake_with_rng(rng)
             }
+        }
+
+        #[test]
+        fn json_data_accessor_is_transparent() {
+            let project: LdtkProject = InternalLevels.fake();
+
+            assert_eq!(project.json_data(), project.data().json_data());
+        }
+
+        #[test]
+        fn raw_level_accessor_implementation_is_transparent() {
+            let project: LdtkProject = LdtkProjectFaker::new(StandaloneLdtkProjectDataFaker::new(
+                LdtkJsonWithMetadataFaker::new(MixedLevelsLdtkJsonFaker::new(
+                    LoadedLevelsFaker::default(),
+                    4..8,
+                )),
+            ))
+            .fake();
+
+            assert_eq!(project.root_levels(), project.json_data().root_levels());
+            assert_eq!(project.worlds(), project.json_data().worlds());
+        }
+
+        #[test]
+        fn level_metadata_accessor_implementation_is_transparent() {
+            let project: LdtkProject = InternalLevels.fake();
+
+            for level in &project.json_data().levels {
+                assert_eq!(
+                    project.get_level_metadata_by_iid(&level.iid),
+                    project.data().get_level_metadata_by_iid(&level.iid),
+                );
+            }
+
+            assert_eq!(
+                project.get_level_metadata_by_iid(&"This_level_doesnt_exist".to_string()),
+                None
+            );
         }
     }
 

--- a/src/assets/ldtk_project.rs
+++ b/src/assets/ldtk_project.rs
@@ -9,7 +9,7 @@ use crate::{
 use bevy::{
     asset::{AssetLoader, AssetPath, LoadContext, LoadedAsset},
     prelude::*,
-    reflect::{TypePath, TypeUuid},
+    reflect::{Reflect, TypeUuid},
     utils::BoxedFuture,
 };
 use derive_getters::Getters;
@@ -67,7 +67,7 @@ fn ldtk_path_to_asset_path<'b>(ldtk_path: &Path, rel_path: &str) -> AssetPath<'b
 /// [`LdtkExternalLevel`]: crate::assets::LdtkExternalLevel
 /// [`loaded_level` accessors]: LdtkJsonWithMetadata#impl-LdtkJsonWithMetadata<LevelMetadata>
 /// [`external_level` accessors]: LdtkJsonWithMetadata#impl-LdtkJsonWithMetadata<ExternalLevelMetadata>
-#[derive(Clone, Debug, PartialEq, From, TypeUuid, TypePath, Getters, Constructor)]
+#[derive(Clone, Debug, PartialEq, From, TypeUuid, Getters, Constructor, Reflect)]
 #[uuid = "43571891-8570-4416-903f-582efe3426ac"]
 pub struct LdtkProject {
     /// LDtk json data and level metadata.

--- a/src/assets/ldtk_project.rs
+++ b/src/assets/ldtk_project.rs
@@ -95,7 +95,6 @@ impl LdtkProject {
     /// This shouldn't occur if the project uses internal levels.
     ///
     /// [`LdtkJsonWithMetadata<InternalLevels>`]: LdtkJsonWithMetadata
-    /// [`LoadedLevel`]: crate::assets::loaded_level::LoadedLevel
     #[cfg(feature = "internal_levels")]
     pub fn as_standalone(&self) -> &LdtkJsonWithMetadata<InternalLevels> {
         self.data.as_standalone()
@@ -109,7 +108,6 @@ impl LdtkProject {
     /// This shouldn't occur if the project uses external levels.
     ///
     /// [`LdtkJsonWithMetadata<ExternalLevels>`]: LdtkJsonWithMetadata
-    /// [`LoadedLevel`]: crate::assets::loaded_level::LoadedLevel
     #[cfg(feature = "external_levels")]
     pub fn as_parent(&self) -> &LdtkJsonWithMetadata<ExternalLevels> {
         self.data.as_parent()

--- a/src/assets/ldtk_project.rs
+++ b/src/assets/ldtk_project.rs
@@ -13,7 +13,7 @@ use bevy::{
     utils::BoxedFuture,
 };
 use derive_getters::Getters;
-use derive_more::{Constructor, From};
+use derive_more::From;
 use std::collections::HashMap;
 use thiserror::Error;
 
@@ -70,7 +70,7 @@ fn ldtk_path_to_asset_path<'b>(ldtk_path: &Path, rel_path: &str) -> AssetPath<'b
 /// [`LdtkExternalLevel`]: crate::assets::LdtkExternalLevel
 /// [`loaded_level` accessors]: LdtkJsonWithMetadata#impl-LdtkJsonWithMetadata<InternalLevels>
 /// [`external_level` accessors]: LdtkJsonWithMetadata#impl-LdtkJsonWithMetadata<ExternalLevels>
-#[derive(Clone, Debug, PartialEq, From, TypeUuid, Getters, Constructor, Reflect)]
+#[derive(Clone, Debug, PartialEq, From, TypeUuid, Getters, Reflect)]
 #[uuid = "43571891-8570-4416-903f-582efe3426ac"]
 pub struct LdtkProject {
     /// LDtk json data and level metadata.
@@ -82,6 +82,21 @@ pub struct LdtkProject {
 }
 
 impl LdtkProject {
+    /// Construct a new [`LdtkProject`].
+    ///
+    /// Private to preserve type guarantees about loaded levels.
+    fn new(
+        data: LdtkProjectData,
+        tileset_map: HashMap<i32, Handle<Image>>,
+        int_grid_image_handle: Option<Handle<Image>>,
+    ) -> LdtkProject {
+        LdtkProject {
+            data,
+            tileset_map,
+            int_grid_image_handle,
+        }
+    }
+
     /// Raw ldtk json data.
     pub fn json_data(&self) -> &LdtkJson {
         self.data.json_data()
@@ -316,6 +331,7 @@ impl AssetLoader for LdtkProjectLoader {
 mod tests {
     use super::*;
     use bevy::asset::HandleId;
+    use derive_more::Constructor;
     use fake::{Dummy, Fake};
     use rand::Rng;
 

--- a/src/assets/ldtk_project.rs
+++ b/src/assets/ldtk_project.rs
@@ -17,8 +17,11 @@ use derive_more::{Constructor, From};
 use std::collections::HashMap;
 use thiserror::Error;
 
+#[cfg(feature = "internal_levels")]
+use crate::assets::InternalLevels;
+
 #[cfg(feature = "external_levels")]
-use crate::assets::ExternalLevelMetadata;
+use crate::assets::{ExternalLevelMetadata, ExternalLevels};
 
 fn ldtk_path_to_asset_path<'b>(ldtk_path: &Path, rel_path: &str) -> AssetPath<'b> {
     ldtk_path.parent().unwrap().join(Path::new(rel_path)).into()
@@ -94,7 +97,7 @@ impl LdtkProject {
     /// [`LdtkJsonWithMetadata<LevelMetadata>`]: LdtkJsonWithMetadata
     /// [`LoadedLevel`]: crate::assets::loaded_level::LoadedLevel
     #[cfg(feature = "internal_levels")]
-    pub fn as_standalone(&self) -> &LdtkJsonWithMetadata<LevelMetadata> {
+    pub fn as_standalone(&self) -> &LdtkJsonWithMetadata<InternalLevels> {
         self.data.as_standalone()
     }
 
@@ -108,7 +111,7 @@ impl LdtkProject {
     /// [`LdtkJsonWithMetadata<ExternalLevelMetadata>`]: LdtkJsonWithMetadata
     /// [`LoadedLevel`]: crate::assets::loaded_level::LoadedLevel
     #[cfg(feature = "external_levels")]
-    pub fn as_parent(&self) -> &LdtkJsonWithMetadata<ExternalLevelMetadata> {
+    pub fn as_parent(&self) -> &LdtkJsonWithMetadata<ExternalLevels> {
         self.data.as_parent()
     }
 }

--- a/src/assets/ldtk_project_data.rs
+++ b/src/assets/ldtk_project_data.rs
@@ -106,15 +106,20 @@ impl LevelMetadataAccessor for LdtkProjectData {
 mod internal_level_tests {
     use crate::{
         assets::ldtk_json_with_metadata::tests::LdtkJsonWithMetadataFaker,
-        ldtk::fake::{MixedLevelsLdtkJsonFaker, UnloadedLevelsFaker},
+        ldtk::fake::{LoadedLevelsFaker, MixedLevelsLdtkJsonFaker},
     };
+    use derive_more::Constructor;
 
     use super::*;
     use fake::{Dummy, Fake, Faker};
 
-    pub struct StandaloneLdtkProjectDataFaker<F>(pub F)
+    #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Constructor)]
+    pub struct StandaloneLdtkProjectDataFaker<F>
     where
-        LdtkJsonWithMetadata<InternalLevels>: Dummy<F>;
+        LdtkJsonWithMetadata<InternalLevels>: Dummy<F>,
+    {
+        pub ldtk_json_with_metadata_faker: F,
+    }
 
     impl<F> Dummy<StandaloneLdtkProjectDataFaker<F>> for LdtkProjectData
     where
@@ -124,7 +129,7 @@ mod internal_level_tests {
             config: &StandaloneLdtkProjectDataFaker<F>,
             rng: &mut R,
         ) -> Self {
-            LdtkProjectData::Standalone(config.0.fake_with_rng(rng))
+            LdtkProjectData::Standalone(config.ldtk_json_with_metadata_faker.fake_with_rng(rng))
         }
     }
 
@@ -186,15 +191,20 @@ mod internal_level_tests {
 mod external_level_tests {
     use crate::{
         assets::ldtk_json_with_metadata::tests::LdtkJsonWithMetadataFaker,
-        ldtk::fake::{MixedLevelsLdtkJsonFaker, UnloadedLevelsFaker},
+        ldtk::fake::{LoadedLevelsFaker, MixedLevelsLdtkJsonFaker},
     };
+    use derive_more::Constructor;
 
     use super::*;
     use fake::{Dummy, Fake, Faker};
 
-    pub struct ParentLdtkProjectDataFaker<F>(pub F)
+    #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Constructor)]
+    pub struct ParentLdtkProjectDataFaker<F>
     where
-        LdtkJsonWithMetadata<ExternalLevels>: Dummy<F>;
+        LdtkJsonWithMetadata<ExternalLevels>: Dummy<F>,
+    {
+        pub ldtk_json_with_metadata_faker: F,
+    }
 
     impl<F> Dummy<ParentLdtkProjectDataFaker<F>> for LdtkProjectData
     where
@@ -204,7 +214,7 @@ mod external_level_tests {
             config: &ParentLdtkProjectDataFaker<F>,
             rng: &mut R,
         ) -> Self {
-            LdtkProjectData::Parent(config.0.fake_with_rng(rng))
+            LdtkProjectData::Parent(config.ldtk_json_with_metadata_faker.fake_with_rng(rng))
         }
     }
 

--- a/src/assets/ldtk_project_data.rs
+++ b/src/assets/ldtk_project_data.rs
@@ -61,7 +61,6 @@ impl LdtkProjectData {
     /// This shouldn't occur if the project uses internal levels.
     ///
     /// [`LdtkJsonWithMetadata<InternalLevels>`]: LdtkJsonWithMetadata
-    /// [`LoadedLevel`]: crate::assets::loaded_level::LoadedLevel
     #[cfg(feature = "internal_levels")]
     pub fn as_standalone(&self) -> &LdtkJsonWithMetadata<InternalLevels> {
         self.try_into().unwrap()
@@ -75,7 +74,6 @@ impl LdtkProjectData {
     /// This shouldn't occur if the project uses external levels.
     ///
     /// [`LdtkJsonWithMetadata<ExternalLevels>`]: LdtkJsonWithMetadata
-    /// [`LoadedLevel`]: crate::assets::loaded_level::LoadedLevel
     #[cfg(feature = "external_levels")]
     pub fn as_parent(&self) -> &LdtkJsonWithMetadata<ExternalLevels> {
         self.try_into().unwrap()

--- a/src/assets/ldtk_project_data.rs
+++ b/src/assets/ldtk_project_data.rs
@@ -148,10 +148,11 @@ mod internal_level_tests {
 
     #[test]
     fn raw_level_accessor_implementation_is_transparent() {
-        let project: LdtkProjectData = StandaloneLdtkProjectDataFaker(LdtkJsonWithMetadataFaker(
-            MixedLevelsLdtkJsonFaker(UnloadedLevelsFaker(4..8), 4..8),
-        ))
-        .fake();
+        let project: LdtkProjectData =
+            StandaloneLdtkProjectDataFaker::new(LdtkJsonWithMetadataFaker::new(
+                MixedLevelsLdtkJsonFaker::new(LoadedLevelsFaker::default(), 4..8),
+            ))
+            .fake();
 
         assert_eq!(project.root_levels(), project.json_data().root_levels());
         assert_eq!(project.worlds(), project.json_data().worlds());
@@ -233,10 +234,11 @@ mod external_level_tests {
 
     #[test]
     fn raw_level_accessor_implementation_is_transparent() {
-        let project: LdtkProjectData = ParentLdtkProjectDataFaker(LdtkJsonWithMetadataFaker(
-            MixedLevelsLdtkJsonFaker(UnloadedLevelsFaker(4..8), 4..8),
-        ))
-        .fake();
+        let project: LdtkProjectData =
+            ParentLdtkProjectDataFaker::new(LdtkJsonWithMetadataFaker::new(
+                MixedLevelsLdtkJsonFaker::new(LoadedLevelsFaker::default(), 4..8),
+            ))
+            .fake();
 
         assert_eq!(project.root_levels(), project.json_data().root_levels());
         assert_eq!(project.worlds(), project.json_data().worlds());

--- a/src/assets/ldtk_project_data.rs
+++ b/src/assets/ldtk_project_data.rs
@@ -143,15 +143,32 @@ mod internal_level_tests {
 
     #[test]
     fn raw_level_accessor_implementation_is_transparent() {
-        let data: LdtkJson = MixedLevelsLdtkJsonFaker(UnloadedLevelsFaker(4..8), 4..8).fake();
+        let project: LdtkProjectData = StandaloneLdtkProjectDataFaker(LdtkJsonWithMetadataFaker(
+            MixedLevelsLdtkJsonFaker(UnloadedLevelsFaker(4..8), 4..8),
+        ))
+        .fake();
 
-        let project = LdtkProjectData::Standalone(LdtkJsonWithMetadata {
-            json_data: data.clone(),
-            level_map: HashMap::default(),
-        });
+        assert_eq!(project.root_levels(), project.json_data().root_levels());
+        assert_eq!(project.worlds(), project.json_data().worlds());
+    }
 
-        assert_eq!(project.root_levels(), data.root_levels());
-        assert_eq!(project.worlds(), data.worlds());
+    #[test]
+    fn level_metadata_accessor_implementation_is_transparent() {
+        let project: LdtkProjectData = InternalLevels.fake();
+
+        for level in &project.json_data().levels {
+            assert_eq!(
+                project.get_level_metadata_by_iid(&level.iid),
+                project
+                    .as_standalone()
+                    .get_level_metadata_by_iid(&level.iid),
+            );
+        }
+
+        assert_eq!(
+            project.get_level_metadata_by_iid(&"This_level_doesnt_exist".to_string()),
+            None
+        );
     }
 }
 

--- a/src/assets/ldtk_project_data.rs
+++ b/src/assets/ldtk_project_data.rs
@@ -170,6 +170,15 @@ mod internal_level_tests {
             None
         );
     }
+
+    #[cfg(feature = "external_levels")]
+    #[test]
+    #[should_panic]
+    fn standalone_project_as_parent_panics() {
+        let project: LdtkProjectData = InternalLevels.fake();
+
+        let _should_panic = project.as_parent();
+    }
 }
 
 #[cfg(test)]
@@ -238,5 +247,14 @@ mod external_level_tests {
             project.get_level_metadata_by_iid(&"This_level_doesnt_exist".to_string()),
             None
         );
+    }
+
+    #[cfg(feature = "internal_levels")]
+    #[test]
+    #[should_panic]
+    fn parent_project_as_standalone_panics() {
+        let project: LdtkProjectData = ExternalLevels.fake();
+
+        let _should_panic = project.as_standalone();
     }
 }

--- a/src/assets/ldtk_project_data.rs
+++ b/src/assets/ldtk_project_data.rs
@@ -6,8 +6,11 @@ use crate::{
 use bevy::reflect::Reflect;
 use derive_more::{From, TryInto};
 
+#[cfg(feature = "internal_levels")]
+use crate::assets::InternalLevels;
+
 #[cfg(feature = "external_levels")]
-use crate::assets::ExternalLevelMetadata;
+use crate::assets::ExternalLevels;
 
 /// LDtk json data and level metadata for both internal- and external-level projects.
 ///
@@ -31,12 +34,12 @@ pub enum LdtkProjectData {
     ///
     /// This is only available under the `internal_levels` feature.
     #[cfg(feature = "internal_levels")]
-    Standalone(LdtkJsonWithMetadata<LevelMetadata>),
+    Standalone(LdtkJsonWithMetadata<InternalLevels>),
     /// LDtk data for a parent project (uses external levels).
     ///
     /// This is only available under the `external_levels` feature.
     #[cfg(feature = "external_levels")]
-    Parent(LdtkJsonWithMetadata<ExternalLevelMetadata>),
+    Parent(LdtkJsonWithMetadata<ExternalLevels>),
 }
 
 impl LdtkProjectData {
@@ -60,7 +63,7 @@ impl LdtkProjectData {
     /// [`LdtkJsonWithMetadata<LevelMetadata>`]: LdtkJsonWithMetadata
     /// [`LoadedLevel`]: crate::assets::loaded_level::LoadedLevel
     #[cfg(feature = "internal_levels")]
-    pub fn as_standalone(&self) -> &LdtkJsonWithMetadata<LevelMetadata> {
+    pub fn as_standalone(&self) -> &LdtkJsonWithMetadata<InternalLevels> {
         self.try_into().unwrap()
     }
 
@@ -74,7 +77,7 @@ impl LdtkProjectData {
     /// [`LdtkJsonWithMetadata<ExternalLevelMetadata>`]: LdtkJsonWithMetadata
     /// [`LoadedLevel`]: crate::assets::loaded_level::LoadedLevel
     #[cfg(feature = "external_levels")]
-    pub fn as_parent(&self) -> &LdtkJsonWithMetadata<ExternalLevelMetadata> {
+    pub fn as_parent(&self) -> &LdtkJsonWithMetadata<ExternalLevels> {
         self.try_into().unwrap()
     }
 }

--- a/src/assets/ldtk_project_data.rs
+++ b/src/assets/ldtk_project_data.rs
@@ -103,7 +103,7 @@ impl LevelMetadataAccessor for LdtkProjectData {
 
 #[cfg(test)]
 #[cfg(feature = "internal_levels")]
-mod internal_level_tests {
+pub mod internal_level_tests {
     use crate::{
         assets::ldtk_json_with_metadata::tests::LdtkJsonWithMetadataFaker,
         ldtk::fake::{LoadedLevelsFaker, MixedLevelsLdtkJsonFaker},
@@ -189,7 +189,7 @@ mod internal_level_tests {
 
 #[cfg(test)]
 #[cfg(feature = "external_levels")]
-mod external_level_tests {
+pub mod external_level_tests {
     use crate::{
         assets::ldtk_json_with_metadata::tests::LdtkJsonWithMetadataFaker,
         ldtk::fake::{LoadedLevelsFaker, MixedLevelsLdtkJsonFaker},

--- a/src/assets/ldtk_project_data.rs
+++ b/src/assets/ldtk_project_data.rs
@@ -104,10 +104,29 @@ impl LevelMetadataAccessor for LdtkProjectData {
 #[cfg(test)]
 #[cfg(feature = "internal_levels")]
 mod internal_level_tests {
-    use crate::ldtk::fake::{MixedLevelsLdtkJsonFaker, UnloadedLevelsFaker};
+    use crate::{
+        assets::ldtk_json_with_metadata::internal_level_tests::LdtkJsonWithMetadataFaker,
+        ldtk::fake::{MixedLevelsLdtkJsonFaker, UnloadedLevelsFaker},
+    };
 
     use super::*;
     use fake::{Dummy, Fake, Faker};
+
+    pub struct StandaloneLdtkProjectDataFaker<F>(pub F)
+    where
+        LdtkJsonWithMetadata<InternalLevels>: Dummy<F>;
+
+    impl<F> Dummy<StandaloneLdtkProjectDataFaker<F>> for LdtkProjectData
+    where
+        LdtkJsonWithMetadata<InternalLevels>: Dummy<F>,
+    {
+        fn dummy_with_rng<R: rand::Rng + ?Sized>(
+            config: &StandaloneLdtkProjectDataFaker<F>,
+            rng: &mut R,
+        ) -> Self {
+            LdtkProjectData::Standalone(config.0.fake_with_rng(rng))
+        }
+    }
 
     impl Dummy<InternalLevels> for LdtkProjectData {
         fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &InternalLevels, rng: &mut R) -> Self {

--- a/src/assets/ldtk_project_data.rs
+++ b/src/assets/ldtk_project_data.rs
@@ -19,8 +19,8 @@ use crate::assets::ExternalLevels;
 /// However, methods exclusive to each case require accessing the internal type.
 /// These include methods for obtaining [`LoadedLevel`]s.
 /// See the [`LoadedLevel`]-accessing methods in the following impls:
-/// - [standalone projects](LdtkJsonWithMetadata#impl-LdtkJsonWithMetadata<LevelMetadata>)
-/// - [parent projects](LdtkJsonWithMetadata#impl-LdtkJsonWithMetadata<ExternalLevelMetadata>)
+/// - [standalone projects](LdtkJsonWithMetadata#impl-LdtkJsonWithMetadata<InternalLevels>)
+/// - [parent projects](LdtkJsonWithMetadata#impl-LdtkJsonWithMetadata<ExternalLevels>)
 ///
 /// Note that this type's variants are under different feature flags.
 /// At least one of these feature flags needs to be enabled for the plugin to compile.
@@ -53,28 +53,28 @@ impl LdtkProjectData {
         }
     }
 
-    /// Unwrap as a [`LdtkJsonWithMetadata<LevelMetadata>`].
+    /// Unwrap as a [`LdtkJsonWithMetadata<InternalLevels>`].
     /// For use on internal-levels ldtk projects only.
     ///
     /// # Panics
     /// Panics if this is not [`LdtkProjectData::Standalone`].
     /// This shouldn't occur if the project uses internal levels.
     ///
-    /// [`LdtkJsonWithMetadata<LevelMetadata>`]: LdtkJsonWithMetadata
+    /// [`LdtkJsonWithMetadata<InternalLevels>`]: LdtkJsonWithMetadata
     /// [`LoadedLevel`]: crate::assets::loaded_level::LoadedLevel
     #[cfg(feature = "internal_levels")]
     pub fn as_standalone(&self) -> &LdtkJsonWithMetadata<InternalLevels> {
         self.try_into().unwrap()
     }
 
-    /// Unwrap as a [`LdtkJsonWithMetadata<ExternalLevelMetadata>`].
+    /// Unwrap as a [`LdtkJsonWithMetadata<ExternalLevels>`].
     /// For use on external-levels ldtk projects only.
     ///
     /// # Panics
     /// Panics if this is not [`LdtkProjectData::Parent`].
     /// This shouldn't occur if the project uses external levels.
     ///
-    /// [`LdtkJsonWithMetadata<ExternalLevelMetadata>`]: LdtkJsonWithMetadata
+    /// [`LdtkJsonWithMetadata<ExternalLevels>`]: LdtkJsonWithMetadata
     /// [`LoadedLevel`]: crate::assets::loaded_level::LoadedLevel
     #[cfg(feature = "external_levels")]
     pub fn as_parent(&self) -> &LdtkJsonWithMetadata<ExternalLevels> {

--- a/src/assets/ldtk_project_data.rs
+++ b/src/assets/ldtk_project_data.rs
@@ -100,3 +100,44 @@ impl LevelMetadataAccessor for LdtkProjectData {
         }
     }
 }
+
+#[cfg(test)]
+#[cfg(feature = "internal_levels")]
+mod internal_level_tests {
+    use crate::ldtk::fake::{MixedLevelsLdtkJsonFaker, UnloadedLevelsFaker};
+
+    use super::*;
+    use fake::{Dummy, Fake, Faker};
+
+    impl Dummy<InternalLevels> for LdtkProjectData {
+        fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &InternalLevels, rng: &mut R) -> Self {
+            LdtkProjectData::Standalone(Faker.fake_with_rng(rng))
+        }
+    }
+
+    #[test]
+    fn json_data_accessor_is_transparent() {
+        let project: LdtkProjectData = InternalLevels.fake();
+
+        assert_eq!(project.json_data(), project.as_standalone().json_data());
+    }
+
+    #[test]
+    fn raw_level_accessor_implementation_is_transparent() {
+        let data: LdtkJson = MixedLevelsLdtkJsonFaker(UnloadedLevelsFaker(4..8), 4..8).fake();
+
+        let project = LdtkProjectData::Standalone(LdtkJsonWithMetadata {
+            json_data: data.clone(),
+            level_map: HashMap::default(),
+        });
+
+        assert_eq!(project.root_levels(), data.root_levels());
+        assert_eq!(project.worlds(), data.worlds());
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "external_levels")]
+mod external_level_tests {
+    use super::*;
+}

--- a/src/assets/ldtk_project_data.rs
+++ b/src/assets/ldtk_project_data.rs
@@ -3,6 +3,7 @@ use crate::{
     ldtk::{LdtkJson, Level},
     prelude::RawLevelAccessor,
 };
+use bevy::reflect::Reflect;
 use derive_more::{From, TryInto};
 
 #[cfg(feature = "external_levels")]
@@ -23,7 +24,7 @@ use crate::assets::ExternalLevelMetadata;
 ///
 /// [`LdtkProject`]: crate::assets::LdtkProject
 /// [`LoadedLevel`]: crate::ldtk::loaded_level::LoadedLevel
-#[derive(Clone, Debug, PartialEq, From, TryInto)]
+#[derive(Clone, Debug, PartialEq, From, TryInto, Reflect)]
 #[try_into(owned, ref)]
 pub enum LdtkProjectData {
     /// LDtk data for a standalone project (uses internal levels).

--- a/src/assets/level_indices.rs
+++ b/src/assets/level_indices.rs
@@ -1,3 +1,5 @@
+use bevy::reflect::Reflect;
+
 /// Indices pointing to the location of a level in an [`LdtkProject`] or [`LdtkJson`].
 ///
 /// This type supports multi-world projects by storing an optional `world` index.
@@ -6,7 +8,7 @@
 ///
 /// [`LdtkProject`]: crate::assets::LdtkProject
 /// [`LdtkJson`]: crate::ldtk::LdtkJson
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Reflect)]
 pub struct LevelIndices {
     /// The index of the world the level belongs to, if the project is multi-world.
     pub world: Option<usize>,

--- a/src/assets/level_locale.rs
+++ b/src/assets/level_locale.rs
@@ -1,0 +1,29 @@
+use bevy::reflect::Reflect;
+
+#[cfg(feature = "internal_levels")]
+use crate::assets::LevelMetadata;
+
+#[cfg(feature = "external_levels")]
+use crate::assets::ExternalLevelMetadata;
+
+pub trait LevelLocale {
+    type Metadata;
+}
+
+#[cfg(feature = "internal_levels")]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Reflect)]
+pub struct InternalLevels;
+
+#[cfg(feature = "internal_levels")]
+impl LevelLocale for InternalLevels {
+    type Metadata = LevelMetadata;
+}
+
+#[cfg(feature = "external_levels")]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Reflect)]
+pub struct ExternalLevels;
+
+#[cfg(feature = "external_levels")]
+impl LevelLocale for ExternalLevels {
+    type Metadata = ExternalLevelMetadata;
+}

--- a/src/assets/level_locale.rs
+++ b/src/assets/level_locale.rs
@@ -6,15 +6,30 @@ use crate::assets::LevelMetadata;
 #[cfg(feature = "external_levels")]
 use crate::assets::ExternalLevelMetadata;
 
+/// Trait for marker types describing the location of levels.
+///
+/// Used as a trait bound to parameterize [`LdtkJsonWithMetadata`].
+/// Also provides an associated type defining the level metadata type for the locale.
+///
+/// Only implemented by [`InternalLevels`] and [`ExternalLevels`].
+///
+/// [`LdtkJsonWithMetadata`]: crate::assets::LdtkJsonWithMetadata
 pub trait LevelLocale {
+    /// Level metadata type used for this locale.
     type Metadata;
 }
 
 #[cfg(feature = "internal_levels")]
+/// Marker type for indicating an internal-levels LDtk project.
+///
+/// Used to parameterize [`LdtkJsonWithMetadata`].
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Reflect)]
 pub struct InternalLevels;
 
 #[cfg(feature = "internal_levels")]
+/// Marker type for indicating an external-levels LDtk projects.
+///
+/// Used to parameterize [`LdtkJsonWithMetadata`].
 impl LevelLocale for InternalLevels {
     type Metadata = LevelMetadata;
 }

--- a/src/assets/level_locale.rs
+++ b/src/assets/level_locale.rs
@@ -23,18 +23,22 @@ pub trait LevelLocale {
 /// Marker type for indicating an internal-levels LDtk project.
 ///
 /// Used to parameterize [`LdtkJsonWithMetadata`].
+///
+/// [`LdtkJsonWithMetadata`]: crate::assets::LdtkJsonWithMetadata
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Reflect)]
 pub struct InternalLevels;
 
 #[cfg(feature = "internal_levels")]
-/// Marker type for indicating an external-levels LDtk projects.
-///
-/// Used to parameterize [`LdtkJsonWithMetadata`].
 impl LevelLocale for InternalLevels {
     type Metadata = LevelMetadata;
 }
 
 #[cfg(feature = "external_levels")]
+/// Marker type for indicating an external-levels LDtk projects.
+///
+/// Used to parameterize [`LdtkJsonWithMetadata`].
+///
+/// [`LdtkJsonWithMetadata`]: crate::assets::LdtkJsonWithMetadata
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Reflect)]
 pub struct ExternalLevels;
 

--- a/src/assets/level_metadata.rs
+++ b/src/assets/level_metadata.rs
@@ -1,5 +1,5 @@
 use crate::assets::LevelIndices;
-use bevy::prelude::*;
+use bevy::{prelude::*, reflect::Reflect};
 use derive_getters::Getters;
 
 #[cfg(feature = "external_levels")]
@@ -8,7 +8,7 @@ use crate::assets::LdtkExternalLevel;
 /// Metadata produced for every level during [`LdtkProject`] loading.
 ///
 /// [`LdtkProject`]: crate::assets::LdtkProject
-#[derive(Clone, Debug, Default, Eq, PartialEq, Getters)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Getters, Reflect)]
 pub struct LevelMetadata {
     /// Image handle for the background image of this level, if it has one.
     bg_image: Option<Handle<Image>>,
@@ -27,7 +27,7 @@ impl LevelMetadata {
 /// Metadata produced for every level during [`LdtkProject`] loading for external-levels projects.
 ///
 /// [`LdtkProject`]: crate::assets::LdtkProject
-#[derive(Clone, Debug, Default, Eq, PartialEq, Getters)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Getters, Reflect)]
 pub struct ExternalLevelMetadata {
     /// Common metadata for this level.
     metadata: LevelMetadata,

--- a/src/assets/level_metadata_accessor.rs
+++ b/src/assets/level_metadata_accessor.rs
@@ -58,7 +58,7 @@ pub mod tests {
 
     use crate::{
         ldtk::{
-            fake::{RootLevelsLdtkJsonFaker, UnloadedLevelsFaker, WorldLevelsLdtkJsonFaker},
+            fake::{LoadedLevelsFaker, RootLevelsLdtkJsonFaker, WorldLevelsLdtkJsonFaker},
             LdtkJson,
         },
         LevelIid,
@@ -89,7 +89,8 @@ pub mod tests {
 
     impl BasicLevelMetadataAccessor {
         pub fn sample_with_root_levels() -> BasicLevelMetadataAccessor {
-            let data: LdtkJson = RootLevelsLdtkJsonFaker(UnloadedLevelsFaker(4..5)).fake();
+            let data: LdtkJson =
+                RootLevelsLdtkJsonFaker::new(LoadedLevelsFaker::new(Some(4..5), None)).fake();
 
             let level_metadata = data
                 .iter_raw_levels_with_indices()
@@ -103,7 +104,9 @@ pub mod tests {
         }
 
         pub fn sample_with_world_levels() -> BasicLevelMetadataAccessor {
-            let data: LdtkJson = WorldLevelsLdtkJsonFaker(UnloadedLevelsFaker(4..5), 4..5).fake();
+            let data: LdtkJson =
+                WorldLevelsLdtkJsonFaker::new(LoadedLevelsFaker::new(Some(4..5), None), 4..5)
+                    .fake();
 
             let level_metadata = data
                 .iter_raw_levels_with_indices()

--- a/src/assets/level_metadata_accessor.rs
+++ b/src/assets/level_metadata_accessor.rs
@@ -51,7 +51,7 @@ pub trait LevelMetadataAccessor: RawLevelAccessor {
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use std::collections::HashMap;
 
     use crate::{
@@ -61,9 +61,9 @@ mod tests {
 
     use super::*;
 
-    struct BasicLevelMetadataAccessor {
-        data: LdtkJson,
-        level_metadata: HashMap<String, LevelMetadata>,
+    pub struct BasicLevelMetadataAccessor {
+        pub data: LdtkJson,
+        pub level_metadata: HashMap<String, LevelMetadata>,
     }
 
     impl RawLevelAccessor for BasicLevelMetadataAccessor {
@@ -83,7 +83,7 @@ mod tests {
     }
 
     impl BasicLevelMetadataAccessor {
-        fn sample_with_root_levels() -> BasicLevelMetadataAccessor {
+        pub fn sample_with_root_levels() -> BasicLevelMetadataAccessor {
             let [level_a, level_b, level_c, level_d] = sample_levels();
 
             let data = LdtkJson {
@@ -102,7 +102,7 @@ mod tests {
             }
         }
 
-        fn sample_with_world_levels() -> BasicLevelMetadataAccessor {
+        pub fn sample_with_world_levels() -> BasicLevelMetadataAccessor {
             let [level_a, level_b, level_c, level_d] = sample_levels();
 
             let world_a = World {

--- a/src/assets/mod.rs
+++ b/src/assets/mod.rs
@@ -8,6 +8,14 @@ mod level_metadata;
 #[cfg(feature = "external_levels")]
 pub use level_metadata::ExternalLevelMetadata;
 
+mod level_locale;
+
+#[cfg(feature = "internal_levels")]
+pub use level_locale::InternalLevels;
+
+#[cfg(feature = "external_levels")]
+pub use level_locale::ExternalLevels;
+
 pub use level_metadata::LevelMetadata;
 
 mod level_metadata_accessor;

--- a/src/assets/mod.rs
+++ b/src/assets/mod.rs
@@ -1,4 +1,4 @@
-//! Assets for loading ldtk files.
+//! Assets and related items for loading LDtk files.
 
 mod ldtk_asset_plugin;
 pub use ldtk_asset_plugin::LdtkAssetPlugin;

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -307,10 +307,12 @@ impl From<&LayerInstance> for LayerMetadata {
 
 /// [Component] that indicates that an LDtk level or world should respawn.
 ///
-/// Inserting this component on an entity with either `Handle<LdtkProject>` or `Handle<LdtkExternalLevel>`
+/// Inserting this component on an entity with either [`Handle<LdtkProject>`] or [`LevelIid`]
 /// components will cause it to respawn.
 /// This can be used to implement a simple level-restart feature.
 /// Internally, this is used to support the entire level spawning process
+///
+/// [`Handle<LdtkProject>`]: crate::assets::LdtkProject
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Default, Hash, Component, Reflect)]
 #[reflect(Component)]
 pub struct Respawn;

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -333,20 +333,20 @@ pub(crate) struct EntityInstanceBundle {
     pub entity_instance: EntityInstance,
 }
 
-/// [Bundle] for spawning LDtk worlds and their levels. The main bundle for using this plugin.
+/// `Bundle` for spawning LDtk worlds and their levels. The main bundle for using this plugin.
 ///
-/// After the ldtk file is done loading, the levels you've chosen with [LevelSelection] or
-/// [LevelSet] will begin to spawn.
-/// Each level is its own entity, with the [LdtkWorldBundle] as its parent.
-/// Each level has a `Handle<LdtkExternalLevel>` component.
+/// After the ldtk file is done loading, the levels you've chosen with [`LevelSelection`] or
+/// [`LevelSet`] will begin to spawn.
+/// Each level is its own entity, with the [`LdtkWorldBundle`] as its parent.
+/// Each level has a [`LevelIid`] component.
 ///
 /// All non-Entity layers (IntGrid, Tile, and AutoTile) will also spawn as their own entities.
 /// Each layer's parent will be the level entity.
-/// Each layer will have a [LayerMetadata] component, and are [bevy_ecs_tilemap::TilemapBundle]s.
+/// Each layer will have a [`LayerMetadata`] component, and are bevy_ecs_tilemap TileMaps.
 /// Each tile in these layers will have the layer entity as its parent.
 ///
 /// For Entity layers, all LDtk entities in the level are spawned as children to the level entity,
-/// unless marked by a [Worldly] component.
+/// unless marked by a [`Worldly`] component.
 #[derive(Clone, Default, Bundle)]
 pub struct LdtkWorldBundle {
     pub ldtk_handle: Handle<LdtkProject>,

--- a/src/ldtk/fake.rs
+++ b/src/ldtk/fake.rs
@@ -1,0 +1,173 @@
+use std::{any::TypeId, ops::Range};
+
+use crate::ldtk::{LayerInstance, Level, World};
+use fake::{faker::lorem::en::Words, uuid::UUIDv4, Dummy, Fake, Faker};
+use rand::Rng;
+
+use super::LdtkJson;
+
+impl Dummy<Faker> for LayerInstance {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        LayerInstance {
+            iid: UUIDv4.fake_with_rng(rng),
+            identifier: Words(2..5).fake_with_rng::<Vec<String>, R>(rng).join("_"),
+            ..Default::default()
+        }
+    }
+}
+
+#[derive(Copy, Clone, Default, Debug, PartialEq, Eq)]
+pub struct UnloadedLevelFaker;
+
+impl Dummy<UnloadedLevelFaker> for Level {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &UnloadedLevelFaker, rng: &mut R) -> Level {
+        let faker = Faker;
+        Level {
+            iid: UUIDv4.fake_with_rng(rng),
+            uid: faker.fake_with_rng(rng),
+            identifier: Words(2..5).fake_with_rng::<Vec<String>, R>(rng).join("_"),
+            ..Default::default()
+        }
+    }
+}
+
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
+pub struct UnloadedLevelsFaker(pub Range<usize>);
+
+impl Dummy<UnloadedLevelsFaker> for Vec<Level> {
+    fn dummy_with_rng<R: Rng + ?Sized>(config: &UnloadedLevelsFaker, rng: &mut R) -> Vec<Level> {
+        Fake::fake_with_rng(&(UnloadedLevelFaker, config.0.clone()), rng)
+    }
+}
+
+#[derive(Clone, Default, Debug, PartialEq)]
+pub struct LoadedLevelFaker(pub Vec<LayerInstance>);
+
+impl Dummy<LoadedLevelFaker> for Level {
+    fn dummy_with_rng<R: Rng + ?Sized>(config: &LoadedLevelFaker, rng: &mut R) -> Level {
+        Level {
+            layer_instances: Some(config.0.clone()),
+            ..UnloadedLevelFaker.fake_with_rng(rng)
+        }
+    }
+}
+
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
+pub struct LoadedLevelsFaker(pub Range<usize>);
+
+impl Dummy<LoadedLevelsFaker> for Vec<Level> {
+    fn dummy_with_rng<R: Rng + ?Sized>(config: &LoadedLevelsFaker, rng: &mut R) -> Vec<Level> {
+        let layers = Fake::fake_with_rng(&(Faker, 2..5), rng);
+        Fake::fake_with_rng(&(LoadedLevelFaker(layers), config.0.clone()), rng)
+    }
+}
+
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
+pub struct WorldFaker<L>(L)
+where
+    Vec<Level>: Dummy<L>;
+
+impl<L> Dummy<WorldFaker<L>> for World
+where
+    Vec<Level>: Dummy<L>,
+{
+    fn dummy_with_rng<R: Rng + ?Sized>(config: &WorldFaker<L>, rng: &mut R) -> Self {
+        World {
+            iid: UUIDv4.fake_with_rng(rng),
+            identifier: Words(2..5).fake_with_rng::<Vec<String>, R>(rng).join("_"),
+            levels: config.0.fake_with_rng(rng),
+            ..Default::default()
+        }
+    }
+}
+
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
+pub struct RootLevelsLdtkJsonFaker<L>(L)
+where
+    Vec<Level>: Dummy<L>;
+
+impl<L> Dummy<RootLevelsLdtkJsonFaker<L>> for LdtkJson
+where
+    Vec<Level>: Dummy<L>,
+    L: 'static,
+{
+    fn dummy_with_rng<R: Rng + ?Sized>(config: &RootLevelsLdtkJsonFaker<L>, rng: &mut R) -> Self {
+        LdtkJson {
+            iid: UUIDv4.fake_with_rng(rng),
+            levels: config.0.fake_with_rng(rng),
+            external_levels: TypeId::of::<L>() == TypeId::of::<UnloadedLevelsFaker>(),
+            ..Default::default()
+        }
+    }
+}
+
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
+pub struct WorldLevelsLdtkJsonFaker<L>(L, Range<usize>)
+where
+    Vec<Level>: Dummy<L>;
+
+impl<L> Dummy<WorldLevelsLdtkJsonFaker<L>> for LdtkJson
+where
+    Vec<Level>: Dummy<L>,
+    L: Clone + 'static,
+{
+    fn dummy_with_rng<R: Rng + ?Sized>(config: &WorldLevelsLdtkJsonFaker<L>, rng: &mut R) -> Self {
+        LdtkJson {
+            iid: UUIDv4.fake_with_rng(rng),
+            worlds: Fake::fake_with_rng(&(WorldFaker(config.0.clone()), config.1.clone()), rng),
+            external_levels: TypeId::of::<L>() == TypeId::of::<UnloadedLevelsFaker>(),
+            ..Default::default()
+        }
+    }
+}
+
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
+struct RootLevelsLdtkJsonWithExternalLevelsFaker(RootLevelsLdtkJsonFaker<LoadedLevelsFaker>);
+
+impl Dummy<RootLevelsLdtkJsonWithExternalLevelsFaker> for (LdtkJson, Vec<Level>) {
+    fn dummy_with_rng<R: Rng + ?Sized>(
+        config: &RootLevelsLdtkJsonWithExternalLevelsFaker,
+        rng: &mut R,
+    ) -> Self {
+        let mut ldtk_json: LdtkJson = config.0.fake_with_rng(rng);
+        let levels = ldtk_json.levels.clone();
+
+        ldtk_json
+            .levels
+            .iter_mut()
+            .for_each(|level| level.layer_instances = None);
+
+        ldtk_json.external_levels = true;
+
+        (ldtk_json, levels)
+    }
+}
+
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
+struct WorldLevelsLdtkJsonWithExternalLevelsFaker(WorldLevelsLdtkJsonFaker<LoadedLevelsFaker>);
+
+impl Dummy<WorldLevelsLdtkJsonWithExternalLevelsFaker> for (LdtkJson, Vec<Level>) {
+    fn dummy_with_rng<R: Rng + ?Sized>(
+        config: &WorldLevelsLdtkJsonWithExternalLevelsFaker,
+        rng: &mut R,
+    ) -> Self {
+        let mut ldtk_json: LdtkJson = config.0.fake_with_rng(rng);
+        let levels = ldtk_json
+            .worlds
+            .iter()
+            .map(|world| world.levels.iter().cloned())
+            .flatten()
+            .collect();
+
+        ldtk_json.worlds.iter_mut().for_each(|world| {
+            world
+                .levels
+                .iter_mut()
+                .for_each(|level| level.layer_instances = None)
+        });
+
+        ldtk_json.external_levels = true;
+
+        (ldtk_json, levels)
+    }
+}

--- a/src/ldtk/fake.rs
+++ b/src/ldtk/fake.rs
@@ -63,7 +63,7 @@ impl Dummy<LoadedLevelsFaker> for Vec<Level> {
 }
 
 #[derive(Clone, Default, Debug, PartialEq, Eq)]
-pub struct WorldFaker<L>(L)
+pub struct WorldFaker<L>(pub L)
 where
     Vec<Level>: Dummy<L>;
 
@@ -82,7 +82,7 @@ where
 }
 
 #[derive(Clone, Default, Debug, PartialEq, Eq)]
-pub struct RootLevelsLdtkJsonFaker<L>(L)
+pub struct RootLevelsLdtkJsonFaker<L>(pub L)
 where
     Vec<Level>: Dummy<L>;
 
@@ -102,7 +102,7 @@ where
 }
 
 #[derive(Clone, Default, Debug, PartialEq, Eq)]
-pub struct WorldLevelsLdtkJsonFaker<L>(L, Range<usize>)
+pub struct WorldLevelsLdtkJsonFaker<L>(pub L, pub Range<usize>)
 where
     Vec<Level>: Dummy<L>;
 
@@ -122,7 +122,28 @@ where
 }
 
 #[derive(Clone, Default, Debug, PartialEq, Eq)]
-struct RootLevelsLdtkJsonWithExternalLevelsFaker(RootLevelsLdtkJsonFaker<LoadedLevelsFaker>);
+pub struct MixedLevelsLdtkJsonFaker<L>(pub L, pub Range<usize>)
+where
+    Vec<Level>: Dummy<L>;
+
+impl<L> Dummy<MixedLevelsLdtkJsonFaker<L>> for LdtkJson
+where
+    Vec<Level>: Dummy<L>,
+    L: Clone + 'static,
+{
+    fn dummy_with_rng<R: Rng + ?Sized>(config: &MixedLevelsLdtkJsonFaker<L>, rng: &mut R) -> Self {
+        LdtkJson {
+            iid: UUIDv4.fake_with_rng(rng),
+            levels: config.0.fake_with_rng(rng),
+            worlds: Fake::fake_with_rng(&(WorldFaker(config.0.clone()), config.1.clone()), rng),
+            external_levels: TypeId::of::<L>() == TypeId::of::<UnloadedLevelsFaker>(),
+            ..Default::default()
+        }
+    }
+}
+
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
+struct RootLevelsLdtkJsonWithExternalLevelsFaker(pub RootLevelsLdtkJsonFaker<LoadedLevelsFaker>);
 
 impl Dummy<RootLevelsLdtkJsonWithExternalLevelsFaker> for (LdtkJson, Vec<Level>) {
     fn dummy_with_rng<R: Rng + ?Sized>(
@@ -144,7 +165,7 @@ impl Dummy<RootLevelsLdtkJsonWithExternalLevelsFaker> for (LdtkJson, Vec<Level>)
 }
 
 #[derive(Clone, Default, Debug, PartialEq, Eq)]
-struct WorldLevelsLdtkJsonWithExternalLevelsFaker(WorldLevelsLdtkJsonFaker<LoadedLevelsFaker>);
+struct WorldLevelsLdtkJsonWithExternalLevelsFaker(pub WorldLevelsLdtkJsonFaker<LoadedLevelsFaker>);
 
 impl Dummy<WorldLevelsLdtkJsonWithExternalLevelsFaker> for (LdtkJson, Vec<Level>) {
     fn dummy_with_rng<R: Rng + ?Sized>(

--- a/src/ldtk/fake.rs
+++ b/src/ldtk/fake.rs
@@ -1,19 +1,31 @@
 use std::{any::TypeId, ops::Range};
 
 use crate::ldtk::{LayerInstance, Level, World};
+use derive_more::Constructor;
 use fake::{faker::lorem::en::Words, uuid::UUIDv4, Dummy, Fake, Faker};
 use rand::Rng;
 
 use super::LdtkJson;
 
-#[derive(Clone, Default, Debug, PartialEq, Eq)]
+pub struct LdtkIdentifierFaker {
+    pub num_words: Range<usize>,
+}
+
+impl Dummy<LdtkIdentifierFaker> for String {
+    fn dummy_with_rng<R: Rng + ?Sized>(config: &LdtkIdentifierFaker, rng: &mut R) -> Self {
+        let words: Vec<String> = Words(config.num_words.clone()).fake_with_rng(rng);
+        words.join("_")
+    }
+}
+
+#[derive(Clone, Default, Debug, PartialEq, Eq, Constructor)]
 pub struct LayerFaker {
     pub identifier: String,
 }
 
 impl Dummy<Faker> for LayerFaker {
     fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
-        let identifier = Words(2..5).fake_with_rng::<Vec<String>, R>(rng).join("_");
+        let identifier = LdtkIdentifierFaker { num_words: 2..5 }.fake_with_rng(rng);
         LayerFaker { identifier }
     }
 }
@@ -35,7 +47,7 @@ impl Dummy<Faker> for LayerInstance {
     }
 }
 
-#[derive(Copy, Clone, Default, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Default, Debug, PartialEq, Eq, Constructor)]
 pub struct UnloadedLevelFaker;
 
 impl Dummy<UnloadedLevelFaker> for Level {
@@ -44,30 +56,34 @@ impl Dummy<UnloadedLevelFaker> for Level {
         Level {
             iid: UUIDv4.fake_with_rng(rng),
             uid: faker.fake_with_rng(rng),
-            identifier: Words(2..5).fake_with_rng::<Vec<String>, R>(rng).join("_"),
+            identifier: LdtkIdentifierFaker { num_words: 2..5 }.fake_with_rng(rng),
             ..Default::default()
         }
     }
 }
 
-#[derive(Clone, Default, Debug, PartialEq, Eq)]
-pub struct UnloadedLevelsFaker(pub Range<usize>);
+#[derive(Clone, Default, Debug, PartialEq, Eq, Constructor)]
+pub struct UnloadedLevelsFaker {
+    pub num_levels: Range<usize>,
+}
 
 impl Dummy<UnloadedLevelsFaker> for Vec<Level> {
     fn dummy_with_rng<R: Rng + ?Sized>(config: &UnloadedLevelsFaker, rng: &mut R) -> Vec<Level> {
-        Fake::fake_with_rng(&(UnloadedLevelFaker, config.0.clone()), rng)
+        Fake::fake_with_rng(&(UnloadedLevelFaker, config.num_levels.clone()), rng)
     }
 }
 
-#[derive(Clone, Default, Debug, PartialEq)]
-pub struct LoadedLevelFaker(pub Vec<LayerFaker>);
+#[derive(Clone, Default, Debug, PartialEq, Constructor)]
+pub struct LoadedLevelFaker {
+    pub layer_fakers: Vec<LayerFaker>,
+}
 
 impl Dummy<LoadedLevelFaker> for Level {
     fn dummy_with_rng<R: Rng + ?Sized>(config: &LoadedLevelFaker, rng: &mut R) -> Level {
         Level {
             layer_instances: Some(
                 config
-                    .0
+                    .layer_fakers
                     .iter()
                     .map(|layer_faker| layer_faker.fake_with_rng(rng))
                     .collect(),
@@ -77,20 +93,51 @@ impl Dummy<LoadedLevelFaker> for Level {
     }
 }
 
-#[derive(Clone, Default, Debug, PartialEq, Eq)]
-pub struct LoadedLevelsFaker(pub Range<usize>);
-
-impl Dummy<LoadedLevelsFaker> for Vec<Level> {
-    fn dummy_with_rng<R: Rng + ?Sized>(config: &LoadedLevelsFaker, rng: &mut R) -> Vec<Level> {
-        let layers = Fake::fake_with_rng(&(Faker, 2..5), rng);
-        Fake::fake_with_rng(&(LoadedLevelFaker(layers), config.0.clone()), rng)
+impl Dummy<Faker> for Level {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        let layer_fakers: Vec<LayerFaker> = (Faker, 2..5).fake_with_rng(rng);
+        LoadedLevelFaker { layer_fakers }.fake_with_rng(rng)
     }
 }
 
-#[derive(Clone, Default, Debug, PartialEq, Eq)]
-pub struct WorldFaker<L>(pub L)
+// Config for faking a collection of loaded levels
+//
+// Just like a real LDtk file, each level should have the same set of layers.
+// Corresponding layers between levels should have some values equal, others different.
+//
+// We cannot implement `Dummy<Faker>` for `Vec<Level>` since these are foreign types.
+// So, the fields here are optional.
+// In their absence, they will be faked or use a sensible default, like a Dummy<Faker> impl would.
+#[derive(Clone, Default, Debug, PartialEq, Eq, Constructor)]
+pub struct LoadedLevelsFaker {
+    // If None, a default range of 4..8 is used
+    pub num_levels: Option<Range<usize>>,
+    // If None, 2-5 layer fakers are faked here
+    pub layer_fakers: Option<Vec<LayerFaker>>,
+}
+
+impl Dummy<LoadedLevelsFaker> for Vec<Level> {
+    fn dummy_with_rng<R: Rng + ?Sized>(config: &LoadedLevelsFaker, rng: &mut R) -> Vec<Level> {
+        (
+            LoadedLevelFaker {
+                layer_fakers: config
+                    .layer_fakers
+                    .clone()
+                    .unwrap_or((Faker, 2..5).fake_with_rng(rng)),
+            },
+            config.num_levels.clone().unwrap_or(4..8),
+        )
+            .fake_with_rng(rng)
+    }
+}
+
+#[derive(Clone, Default, Debug, PartialEq, Eq, Constructor)]
+pub struct WorldFaker<L>
 where
-    Vec<Level>: Dummy<L>;
+    Vec<Level>: Dummy<L>,
+{
+    pub levels_faker: L,
+}
 
 impl<L> Dummy<WorldFaker<L>> for World
 where
@@ -99,17 +146,29 @@ where
     fn dummy_with_rng<R: Rng + ?Sized>(config: &WorldFaker<L>, rng: &mut R) -> Self {
         World {
             iid: UUIDv4.fake_with_rng(rng),
-            identifier: Words(2..5).fake_with_rng::<Vec<String>, R>(rng).join("_"),
-            levels: config.0.fake_with_rng(rng),
+            identifier: LdtkIdentifierFaker { num_words: 2..5 }.fake_with_rng(rng),
+            levels: config.levels_faker.fake_with_rng(rng),
             ..Default::default()
         }
     }
 }
 
-#[derive(Clone, Default, Debug, PartialEq, Eq)]
-pub struct RootLevelsLdtkJsonFaker<L>(pub L)
+impl Dummy<Faker> for World {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        WorldFaker {
+            levels_faker: LoadedLevelsFaker::default(),
+        }
+        .fake_with_rng(rng)
+    }
+}
+
+#[derive(Clone, Default, Debug, PartialEq, Eq, Constructor)]
+pub struct RootLevelsLdtkJsonFaker<L>
 where
-    Vec<Level>: Dummy<L>;
+    Vec<Level>: Dummy<L>,
+{
+    pub levels_faker: L,
+}
 
 impl<L> Dummy<RootLevelsLdtkJsonFaker<L>> for LdtkJson
 where
@@ -119,17 +178,21 @@ where
     fn dummy_with_rng<R: Rng + ?Sized>(config: &RootLevelsLdtkJsonFaker<L>, rng: &mut R) -> Self {
         LdtkJson {
             iid: UUIDv4.fake_with_rng(rng),
-            levels: config.0.fake_with_rng(rng),
+            levels: config.levels_faker.fake_with_rng(rng),
             external_levels: TypeId::of::<L>() == TypeId::of::<UnloadedLevelsFaker>(),
             ..Default::default()
         }
     }
 }
 
-#[derive(Clone, Default, Debug, PartialEq, Eq)]
-pub struct WorldLevelsLdtkJsonFaker<L>(pub L, pub Range<usize>)
+#[derive(Clone, Default, Debug, PartialEq, Eq, Constructor)]
+pub struct WorldLevelsLdtkJsonFaker<L>
 where
-    Vec<Level>: Dummy<L>;
+    Vec<Level>: Dummy<L>,
+{
+    pub levels_faker: L,
+    pub num_worlds: Range<usize>,
+}
 
 impl<L> Dummy<WorldLevelsLdtkJsonFaker<L>> for LdtkJson
 where
@@ -139,17 +202,27 @@ where
     fn dummy_with_rng<R: Rng + ?Sized>(config: &WorldLevelsLdtkJsonFaker<L>, rng: &mut R) -> Self {
         LdtkJson {
             iid: UUIDv4.fake_with_rng(rng),
-            worlds: Fake::fake_with_rng(&(WorldFaker(config.0.clone()), config.1.clone()), rng),
+            worlds: (
+                WorldFaker {
+                    levels_faker: config.levels_faker.clone(),
+                },
+                config.num_worlds.clone(),
+            )
+                .fake_with_rng(rng),
             external_levels: TypeId::of::<L>() == TypeId::of::<UnloadedLevelsFaker>(),
             ..Default::default()
         }
     }
 }
 
-#[derive(Clone, Default, Debug, PartialEq, Eq)]
-pub struct MixedLevelsLdtkJsonFaker<L>(pub L, pub Range<usize>)
+#[derive(Clone, Default, Debug, PartialEq, Eq, Constructor)]
+pub struct MixedLevelsLdtkJsonFaker<L>
 where
-    Vec<Level>: Dummy<L>;
+    Vec<Level>: Dummy<L>,
+{
+    pub levels_faker: L,
+    pub num_worlds: Range<usize>,
+}
 
 impl<L> Dummy<MixedLevelsLdtkJsonFaker<L>> for LdtkJson
 where
@@ -159,25 +232,40 @@ where
     fn dummy_with_rng<R: Rng + ?Sized>(config: &MixedLevelsLdtkJsonFaker<L>, rng: &mut R) -> Self {
         LdtkJson {
             iid: UUIDv4.fake_with_rng(rng),
-            levels: config.0.fake_with_rng(rng),
-            worlds: Fake::fake_with_rng(&(WorldFaker(config.0.clone()), config.1.clone()), rng),
+            levels: config.levels_faker.fake_with_rng(rng),
+            worlds: (
+                WorldFaker {
+                    levels_faker: config.levels_faker.clone(),
+                },
+                config.num_worlds.clone(),
+            )
+                .fake_with_rng(rng),
             external_levels: TypeId::of::<L>() == TypeId::of::<UnloadedLevelsFaker>(),
             ..Default::default()
         }
     }
 }
 
-#[derive(Clone, Default, Debug, PartialEq, Eq)]
-pub struct RootLevelsLdtkJsonWithExternalLevelsFaker(
-    pub RootLevelsLdtkJsonFaker<LoadedLevelsFaker>,
-);
+impl Dummy<Faker> for LdtkJson {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        RootLevelsLdtkJsonFaker {
+            levels_faker: LoadedLevelsFaker::default(),
+        }
+        .fake_with_rng(rng)
+    }
+}
+
+#[derive(Clone, Default, Debug, PartialEq, Eq, Constructor)]
+pub struct RootLevelsLdtkJsonWithExternalLevelsFaker {
+    pub ldtk_json_faker: RootLevelsLdtkJsonFaker<LoadedLevelsFaker>,
+}
 
 impl Dummy<RootLevelsLdtkJsonWithExternalLevelsFaker> for (LdtkJson, Vec<Level>) {
     fn dummy_with_rng<R: Rng + ?Sized>(
         config: &RootLevelsLdtkJsonWithExternalLevelsFaker,
         rng: &mut R,
     ) -> Self {
-        let mut ldtk_json: LdtkJson = config.0.fake_with_rng(rng);
+        let mut ldtk_json: LdtkJson = config.ldtk_json_faker.fake_with_rng(rng);
         let levels = ldtk_json.levels.clone();
 
         ldtk_json
@@ -191,17 +279,17 @@ impl Dummy<RootLevelsLdtkJsonWithExternalLevelsFaker> for (LdtkJson, Vec<Level>)
     }
 }
 
-#[derive(Clone, Default, Debug, PartialEq, Eq)]
-pub struct WorldLevelsLdtkJsonWithExternalLevelsFaker(
-    pub WorldLevelsLdtkJsonFaker<LoadedLevelsFaker>,
-);
+#[derive(Clone, Default, Debug, PartialEq, Eq, Constructor)]
+pub struct WorldLevelsLdtkJsonWithExternalLevelsFaker {
+    pub ldtk_json_faker: WorldLevelsLdtkJsonFaker<LoadedLevelsFaker>,
+}
 
 impl Dummy<WorldLevelsLdtkJsonWithExternalLevelsFaker> for (LdtkJson, Vec<Level>) {
     fn dummy_with_rng<R: Rng + ?Sized>(
         config: &WorldLevelsLdtkJsonWithExternalLevelsFaker,
         rng: &mut R,
     ) -> Self {
-        let mut ldtk_json: LdtkJson = config.0.fake_with_rng(rng);
+        let mut ldtk_json: LdtkJson = config.ldtk_json_faker.fake_with_rng(rng);
         let levels = ldtk_json
             .worlds
             .iter()

--- a/src/ldtk/fake.rs
+++ b/src/ldtk/fake.rs
@@ -6,13 +6,32 @@ use rand::Rng;
 
 use super::LdtkJson;
 
-impl Dummy<Faker> for LayerInstance {
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
+pub struct LayerFaker {
+    pub identifier: String,
+}
+
+impl Dummy<Faker> for LayerFaker {
     fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        let identifier = Words(2..5).fake_with_rng::<Vec<String>, R>(rng).join("_");
+        LayerFaker { identifier }
+    }
+}
+
+impl Dummy<LayerFaker> for LayerInstance {
+    fn dummy_with_rng<R: Rng + ?Sized>(config: &LayerFaker, rng: &mut R) -> Self {
         LayerInstance {
             iid: UUIDv4.fake_with_rng(rng),
-            identifier: Words(2..5).fake_with_rng::<Vec<String>, R>(rng).join("_"),
+            identifier: config.identifier.clone(),
             ..Default::default()
         }
+    }
+}
+
+impl Dummy<Faker> for LayerInstance {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        let layer_faker: LayerFaker = Faker.fake_with_rng(rng);
+        layer_faker.fake_with_rng(rng)
     }
 }
 

--- a/src/ldtk/fake.rs
+++ b/src/ldtk/fake.rs
@@ -60,12 +60,18 @@ impl Dummy<UnloadedLevelsFaker> for Vec<Level> {
 }
 
 #[derive(Clone, Default, Debug, PartialEq)]
-pub struct LoadedLevelFaker(pub Vec<LayerInstance>);
+pub struct LoadedLevelFaker(pub Vec<LayerFaker>);
 
 impl Dummy<LoadedLevelFaker> for Level {
     fn dummy_with_rng<R: Rng + ?Sized>(config: &LoadedLevelFaker, rng: &mut R) -> Level {
         Level {
-            layer_instances: Some(config.0.clone()),
+            layer_instances: Some(
+                config
+                    .0
+                    .iter()
+                    .map(|layer_faker| layer_faker.fake_with_rng(rng))
+                    .collect(),
+            ),
             ..UnloadedLevelFaker.fake_with_rng(rng)
         }
     }

--- a/src/ldtk/fake.rs
+++ b/src/ldtk/fake.rs
@@ -293,8 +293,7 @@ impl Dummy<WorldLevelsLdtkJsonWithExternalLevelsFaker> for (LdtkJson, Vec<Level>
         let levels = ldtk_json
             .worlds
             .iter()
-            .map(|world| world.levels.iter().cloned())
-            .flatten()
+            .flat_map(|world| world.levels.iter().cloned())
             .collect();
 
         ldtk_json.worlds.iter_mut().for_each(|world| {

--- a/src/ldtk/fake.rs
+++ b/src/ldtk/fake.rs
@@ -143,7 +143,9 @@ where
 }
 
 #[derive(Clone, Default, Debug, PartialEq, Eq)]
-struct RootLevelsLdtkJsonWithExternalLevelsFaker(pub RootLevelsLdtkJsonFaker<LoadedLevelsFaker>);
+pub struct RootLevelsLdtkJsonWithExternalLevelsFaker(
+    pub RootLevelsLdtkJsonFaker<LoadedLevelsFaker>,
+);
 
 impl Dummy<RootLevelsLdtkJsonWithExternalLevelsFaker> for (LdtkJson, Vec<Level>) {
     fn dummy_with_rng<R: Rng + ?Sized>(
@@ -165,7 +167,9 @@ impl Dummy<RootLevelsLdtkJsonWithExternalLevelsFaker> for (LdtkJson, Vec<Level>)
 }
 
 #[derive(Clone, Default, Debug, PartialEq, Eq)]
-struct WorldLevelsLdtkJsonWithExternalLevelsFaker(pub WorldLevelsLdtkJsonFaker<LoadedLevelsFaker>);
+pub struct WorldLevelsLdtkJsonWithExternalLevelsFaker(
+    pub WorldLevelsLdtkJsonFaker<LoadedLevelsFaker>,
+);
 
 impl Dummy<WorldLevelsLdtkJsonWithExternalLevelsFaker> for (LdtkJson, Vec<Level>) {
     fn dummy_with_rng<R: Rng + ?Sized>(

--- a/src/ldtk/mod.rs
+++ b/src/ldtk/mod.rs
@@ -42,7 +42,7 @@ use crate::prelude::LdtkEntity;
 pub mod all_some_iter;
 mod color;
 #[cfg(test)]
-mod fake;
+pub mod fake;
 mod field_instance;
 mod impl_definitions;
 pub mod ldtk_fields;

--- a/src/ldtk/mod.rs
+++ b/src/ldtk/mod.rs
@@ -41,6 +41,8 @@ use crate::prelude::LdtkEntity;
 
 pub mod all_some_iter;
 mod color;
+#[cfg(test)]
+mod fake;
 mod field_instance;
 mod impl_definitions;
 pub mod ldtk_fields;

--- a/src/ldtk/raw_level_accessor.rs
+++ b/src/ldtk/raw_level_accessor.rs
@@ -140,7 +140,7 @@ impl RawLevelAccessor for LdtkJson {
 
 #[cfg(test)]
 pub mod tests {
-    use fake::Fake;
+    use fake::{Fake, Faker};
 
     use crate::ldtk::fake::{
         MixedLevelsLdtkJsonFaker, RootLevelsLdtkJsonFaker, UnloadedLevelsFaker,
@@ -151,7 +151,7 @@ pub mod tests {
 
     #[test]
     fn iter_levels_in_root() {
-        let project: LdtkJson = RootLevelsLdtkJsonFaker(UnloadedLevelsFaker(4..8)).fake();
+        let project: LdtkJson = Faker.fake();
 
         let iter_raw_levels_with_indices =
             project.iter_raw_levels_with_indices().collect::<Vec<_>>();
@@ -188,7 +188,8 @@ pub mod tests {
 
     #[test]
     fn iter_levels_in_worlds() {
-        let project: LdtkJson = WorldLevelsLdtkJsonFaker(UnloadedLevelsFaker(4..5), 4..5).fake();
+        let project: LdtkJson =
+            WorldLevelsLdtkJsonFaker::new(UnloadedLevelsFaker::new(4..5), 4..5).fake();
 
         let iter_raw_levels_with_indices =
             project.iter_raw_levels_with_indices().collect::<Vec<_>>();
@@ -225,7 +226,8 @@ pub mod tests {
 
     #[test]
     fn iter_raw_levels_iterates_through_root_levels_first() {
-        let project: LdtkJson = MixedLevelsLdtkJsonFaker(UnloadedLevelsFaker(4..5), 4..5).fake();
+        let project: LdtkJson =
+            MixedLevelsLdtkJsonFaker::new(UnloadedLevelsFaker::new(4..5), 4..5).fake();
 
         let iter_raw_levels_with_indices =
             project.iter_raw_levels_with_indices().collect::<Vec<_>>();
@@ -283,7 +285,7 @@ pub mod tests {
 
     #[test]
     fn get_root_levels_by_indices() {
-        let project: LdtkJson = RootLevelsLdtkJsonFaker(UnloadedLevelsFaker(4..5)).fake();
+        let project: LdtkJson = RootLevelsLdtkJsonFaker::new(UnloadedLevelsFaker::new(4..5)).fake();
 
         for (i, level) in project.levels.iter().enumerate() {
             assert_eq!(
@@ -305,7 +307,8 @@ pub mod tests {
 
     #[test]
     fn get_world_levels_by_indices() {
-        let project: LdtkJson = WorldLevelsLdtkJsonFaker(UnloadedLevelsFaker(4..5), 4..5).fake();
+        let project: LdtkJson =
+            WorldLevelsLdtkJsonFaker::new(UnloadedLevelsFaker::new(4..5), 4..5).fake();
 
         for (world_index, world) in project.worlds.iter().enumerate() {
             for (level_index, level) in world.levels.iter().enumerate() {

--- a/src/ldtk/raw_level_accessor.rs
+++ b/src/ldtk/raw_level_accessor.rs
@@ -149,38 +149,6 @@ pub mod tests {
 
     use super::*;
 
-    pub fn sample_levels() -> [Level; 4] {
-        let level_a = Level {
-            iid: "e7371660-4e9b-479a-9e14-ab9fb8332619".to_string(),
-            identifier: "Tutorial".to_string(),
-            uid: 101,
-            ..Default::default()
-        };
-
-        let level_b = Level {
-            iid: "3485168c-20d8-41c2-a145-a9e10bb30b3e".to_string(),
-            identifier: "New_Beginnings".to_string(),
-            uid: 103,
-            ..Default::default()
-        };
-
-        let level_c = Level {
-            iid: "8dcf07d0-3382-474d-99a4-d2a27bf937c8".to_string(),
-            identifier: "Turning_Point".to_string(),
-            uid: 107,
-            ..Default::default()
-        };
-
-        let level_d = Level {
-            iid: "248dafc9-75d7-4edb-97b7-44558042632d".to_string(),
-            identifier: "Final_Boss".to_string(),
-            uid: 109,
-            ..Default::default()
-        };
-
-        [level_a, level_b, level_c, level_d]
-    }
-
     #[test]
     fn iter_levels_in_root() {
         let project: LdtkJson = RootLevelsLdtkJsonFaker(UnloadedLevelsFaker(4..8)).fake();

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -268,7 +268,7 @@ pub fn process_ldtk_levels(
                             .get(level_iid.get())
                             .and_then(|level_metadata| {
                                 let loaded_level = project
-                                    .get_loaded_level_by_indices(level_metadata.indices())?;
+                                    .get_loaded_level_at_indices(level_metadata.indices())?;
 
                                 Some((level_metadata, loaded_level))
                             }),
@@ -277,7 +277,7 @@ pub fn process_ldtk_levels(
                             .level_map()
                             .get(level_iid.get())
                             .and_then(|level_metadata| {
-                                let loaded_level = project.get_external_level_by_indices(
+                                let loaded_level = project.get_external_level_at_indices(
                                     &level_assets,
                                     level_metadata.metadata().indices(),
                                 )?;

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -35,18 +35,18 @@ pub fn process_ldtk_assets(
         match event {
             AssetEvent::Created { handle } => {
                 debug!("LDtk asset creation detected.");
-                ldtk_handles_for_clear_color.insert(handle.clone());
+                ldtk_handles_for_clear_color.insert(handle);
             }
             AssetEvent::Modified { handle } => {
                 info!("LDtk asset modification detected.");
-                ldtk_handles_to_respawn.insert(handle.clone());
-                ldtk_handles_for_clear_color.insert(handle.clone());
+                ldtk_handles_to_respawn.insert(handle);
+                ldtk_handles_for_clear_color.insert(handle);
             }
             AssetEvent::Removed { handle } => {
                 info!("LDtk asset removal detected.");
                 // if mesh was modified and removed in the same update, ignore the modification
                 // events are ordered so future modification events are ok
-                ldtk_handles_to_respawn.retain(|changed_handle| changed_handle != handle);
+                ldtk_handles_to_respawn.retain(|changed_handle| *changed_handle != handle);
             }
         }
     }

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -200,8 +200,8 @@ fn pre_spawn_level(commands: &mut Commands, level: &Level, ldtk_settings: &LdtkS
         .id()
 }
 
-/// Performs all the spawning of levels, layers, chunks, bundles, entities, tiles, etc. when an
-/// LdtkLevelBundle is added.
+/// Performs all the spawning of levels, layers, chunks, bundles, entities, tiles, etc. when a
+/// LevelIid is added or respawned.
 #[allow(clippy::too_many_arguments, clippy::type_complexity)]
 pub fn process_ldtk_levels(
     mut commands: Commands,


### PR DESCRIPTION
Closes #205

This is the final PR for redesigning the asset types. The main improvements of this redesign are that the type provides better APIs for accessing raw or loaded level data, and internal/external levels are modeled more correctly.

The `LdtkProject` type is still the asset type and stores most metadata applicable to either level locale, along with `LdtkProjectData`.

`LdtkProjectData` is a enum whose variants store the actual ldtk json data, with a variant for each level locality. The internal types of the variants are `LdtkJsonWithMetadata<L: LevelLocale>`, with either `InternalLevels` or `ExternalLevels` as `L`.

`LdtkJsonWithMetadata<L>` is a generic type storing the actual ldtk json data + level metadata, with either `InternalLevels` or `ExternalLevels` as `L`.

Splitting these up like this allows us to define some methods that are exclusive to each level locality. This is important because accessing loaded level data is a very different operation memory-wise for each case (indexing the `LdtkJson` for internal-levels, or accessing the `Assets<LdtkLevel>` asset store for external levels). But other methods can be provided for either case, either with a generic implementation at the lowest level, or exposing transparent implementations in the higher-level types.

An important point about this new design is that `LdtkLevel` assets are no longer used in the internal-levels case. Level entities will only ever have a `LevelIid` component, no longer a `Handle<LdtkLevel>`. The handle for the asset in the external-levels case is only stored inside the `LdtkProject`. To help make this change clear, `LdtkLevel` has been renamed `LdtkExternalLevel`. Doing things this way actually fixes an egregious clone of all level data that is in all previous versions of this plugin.

See the documentation of `LdtkProject` to learn about the best ways to access loaded level data now.

feat!: LdtkLevel renamed to LdtkExternalLevel and is no longer used as a component (#244)