### PR TITLE
docs: document all-features in docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,9 @@ render = ["bevy_ecs_tilemap/render"]
 internal_levels = []
 external_levels = []
 
+[package.metadata.docs.rs]
+all-features = true
+
 [[example]]
 name = "platformer"
 path = "examples/platformer/main.rs"


### PR DESCRIPTION
Closes #246 

Now that entire types are being hidden behind features, it's important that we enable this option so that they are visible in doc.rs. I also looked into enabling other common features like `--generate-link-to-definition`, but this seems to be only relevant if we're publishing the docs ourselves instead of relying on docs.rs, so I left that out for now.