### PR TITLE
docs: remove README.md caveat for hot reloading external levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ base.
 ### Features
 - Support for all layer types
 - Support for loading external levels
-- Hot reloading (requires double-saving for external levels)
+- Hot reloading
 - Solutions for easily loading/unloading levels, changing levels, loading level neighbors...
 - Low-boilerplate solutions for spawning bundles for LDtk Entities and IntGrid
   tiles using derive macros (other options available)


### PR DESCRIPTION
Related to #1 

Since bevy's file changewatcher now accepts a `Duration`, running into the bug caused by level files being temporarily unavailable is either extremely unlikely or impossible with a reasonable duration. So, I think it's safe to remove this caveat from the readme saying that users need to double-save for hot-reloading to work for external levels.