### PR TITLE
Normalize resolved asset paths using `path_clean`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ anyhow = "1.0"
 thiserror = "1.0"
 paste = "1.0"
 derive_more = "0.99.17"
+path-clean = "1.0.1"
 
 [dev-dependencies]
 bevy = "0.11"

--- a/src/assets/ldtk_project.rs
+++ b/src/assets/ldtk_project.rs
@@ -393,6 +393,7 @@ mod tests {
     }
 
     #[cfg(target_os = "windows")]
+    #[test]
     fn normalizes_windows_asset_paths() {
         let resolve_path = |project_path, rel_path| {
             let asset_path = ldtk_path_to_asset_path(Path::new(project_path), rel_path);

--- a/src/assets/ldtk_project.rs
+++ b/src/assets/ldtk_project.rs
@@ -14,8 +14,8 @@ use bevy::{
 };
 use derive_getters::Getters;
 use derive_more::From;
-use std::collections::HashMap;
 use path_clean::PathClean;
+use std::collections::HashMap;
 use thiserror::Error;
 
 #[cfg(feature = "internal_levels")]
@@ -380,16 +380,37 @@ mod tests {
 
         assert_eq!(
             resolve_path("project.ldtk", "images/tiles.png"),
-            Path::new("images/tiles.png"));
+            Path::new("images/tiles.png")
+        );
+        assert_eq!(
+            resolve_path("projects/sub/project.ldtk", "../images/tiles.png"),
+            Path::new("projects/images/tiles.png")
+        );
+        assert_eq!(
+            resolve_path("projects/sub/project.ldtk", "../../tiles.png"),
+            Path::new("tiles.png")
+        );
+    }
+
+    #[cfg(target_os = "windows")]
+    fn normalizes_windows_asset_paths() {
+        let resolve_path = |project_path, rel_path| {
+            let asset_path = ldtk_path_to_asset_path(Path::new(project_path), rel_path);
+            asset_path.path().to_owned()
+        };
+
         assert_eq!(
             resolve_path("projects\\sub/project.ldtk", "../images/tiles.png"),
-            Path::new("projects/images/tiles.png"));
+            Path::new("projects/images/tiles.png")
+        );
         assert_eq!(
             resolve_path("projects\\sub/project.ldtk", "../../images/tiles.png"),
-            Path::new("images/tiles.png"));
+            Path::new("images/tiles.png")
+        );
         assert_eq!(
             resolve_path("projects/sub\\project.ldtk", "../../tiles.png"),
-            Path::new("tiles.png"));
+            Path::new("tiles.png")
+        );
     }
 
     #[cfg(feature = "internal_levels")]


### PR DESCRIPTION
Makes all paths relative to the `assets` root. Ensures that LDtk-linked assets are shared with assets loaded by `AssetServer`, [bevy_asset_loader](https://github.com/NiklasEi/bevy_asset_loader) and so on, as long as normalized paths are used for those (as they typically are), especially when the LDtk project is in a subdirectory.

Fixes #240