### PR TITLE
ci: fix formatting of extra-files option for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,5 +14,5 @@ jobs:
           package-name: bevy_ecs_ldtk
           bump-minor-pre-major: true
           changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"docs","section":"Documentation Changes","hidden":false},{"type":"example","section":"Example Changes","hidden":false},{"type":"refactor","section":"Code Refactors","hidden":true},{"type":"ci","section":"CI Changes","hidden":true}]'
-          extra-files:
-            - book/src/README.md
+          extra-files: |
+            book/src/README.md


### PR DESCRIPTION
#261 added extra config to the release-please CI to format an extra file w/ the version number. However, the formatting of this config argument was wrong. This PR should fix it.