### PR TITLE
ci: publish book to github pages on new releases

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -128,6 +128,6 @@ jobs:
         with:
           mdbook-version: '0.4.35'
       - name: Install mdbook-keeper
-        run: cargo install mdbook-keeper --git https://github.com/tfpk/mdbook-keeper/ --rev 12f116d0840c69a6786dba3865768af3fde634f3
+        run: cargo install mdbook-keeper --git https://github.com/tfpk/mdbook-keeper/ --rev 12f116d0840c69a6786dba3865768af3fde634f3 --force
       - name: Run mdbook build (tests all code snippets)
         run: CARGO_MANIFEST_DIR=. mdbook build book

--- a/.github/workflows/publish-book.yml
+++ b/.github/workflows/publish-book.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           mdbook-version: '0.4.35'
       - name: Install mdbook-keeper
-        run: cargo install mdbook-keeper --git https://github.com/tfpk/mdbook-keeper/ --rev 12f116d0840c69a6786dba3865768af3fde634f3
+        run: cargo install mdbook-keeper --git https://github.com/tfpk/mdbook-keeper/ --rev 12f116d0840c69a6786dba3865768af3fde634f3 --force
       - name: build book
         run: CARGO_MANIFEST_DIR=. mdbook build book
       - name: Publish

--- a/.github/workflows/publish-book.yml
+++ b/.github/workflows/publish-book.yml
@@ -1,0 +1,38 @@
+name: publish book
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  publish-book:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-mdbook-publish-${{ hashFiles('**/Cargo.toml') }}
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install mdbook
+        uses: peaceiris/actions-mdbook@v1
+        with:
+          mdbook-version: '0.4.35'
+      - name: Install mdbook-keeper
+        run: cargo install mdbook-keeper --git https://github.com/tfpk/mdbook-keeper/ --rev 12f116d0840c69a6786dba3865768af3fde634f3
+      - name: build book
+        run: CARGO_MANIFEST_DIR=. mdbook build book
+      - name: Publish
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./book/book

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,6 +10,7 @@ jobs:
     steps:
       - uses: google-github-actions/release-please-action@v3
         with:
+          token: ${{ secrets.PAT }}
           release-type: rust
           package-name: bevy_ecs_ldtk
           bump-minor-pre-major: true


### PR DESCRIPTION
Now that we have a book as part of our documentation, new builds of this book should be published for new versions of the plugin, similar to docs.rs. This PR accomplishes this by adding a workflow to the CI that publishes the book to github pages on new releases. Furthermore, the token used by release-please has been updated so that it can trigger workflows itself (something the default `secrets.GH_TOKEN` is not capable of).

The workflow has been tested, and a preview of the book is now available: https://trouv.github.io/bevy_ecs_ldtk