### PR TITLE
docs: add 0.8 to 0.9 migration guide

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -26,7 +26,7 @@
 - [Retrieve Loaded Level Data]()
 - [Compile to WASM]()
 - [Compile Headless]()
-- [Migration Guides]()
-  - [Migrate from 0.8 to 0.9]()
+- [Migration Guides](how-to-guides/migration-guides/README.md)
+  - [Migrate from 0.8 to 0.9](how-to-guides/migration-guides/migrate-from-0.8-to-0.9.md)
 ---
 [API Reference](api-reference.md).

--- a/book/src/how-to-guides/migration-guides/README.md
+++ b/book/src/how-to-guides/migration-guides/README.md
@@ -1,0 +1,4 @@
+# Migration Guides
+Most releases of `bevy_ecs_ldtk` introduce breaking changes.
+For these, migration guides are provided to help users migrate their existing games to the new version.
+If you're contributing a breaking change to `bevy_ecs_ldtk`, you may be asked to describe it in the appropriate migration guide.

--- a/book/src/how-to-guides/migration-guides/migrate-from-0.8-to-0.9.md
+++ b/book/src/how-to-guides/migration-guides/migrate-from-0.8-to-0.9.md
@@ -1,5 +1,9 @@
 # Migrate from 0.8 to 0.9
 
+## LDtk upgrade
+`bevy_ecs_ldtk` now supports LDtk 1.4.1, and is dropping support for previous versions.
+To update your game to LDtk 1.4.1, you should only need to install the new version of LDtk, open your project, and save it.
+
 ## `Default` behavior for `LdtkEntity` and `LdtkIntCell` derive macros
 Fields on an `LdtkEntity`- or `LdtkIntCell`-derived bundle are no longer constructed from the field's `Default` implementation, but the bundle's.
 

--- a/book/src/how-to-guides/migration-guides/migrate-from-0.8-to-0.9.md
+++ b/book/src/how-to-guides/migration-guides/migrate-from-0.8-to-0.9.md
@@ -391,7 +391,7 @@ let level_selection = LevelSelection::iid("e5eb2d73-60bb-4779-8b33-38a63da8d1db"
 
 ## `LevelSelection` index variant now stores a world index
 The `LevelSelection::Index` variant has been replaced by `LevelSelection::Indices`.
-Internally, this stores a new `LevelIndices` type, which stores an optional world index in addition to a level index.
+Internally, this contains a new `LevelIndices` type, which stores an optional world index in addition to the level index.
 However, you can still construct a `LevelSelection` from a single level index using the `index` method:
 ```rust,ignore
 // 0.8

--- a/book/src/how-to-guides/migration-guides/migrate-from-0.8-to-0.9.md
+++ b/book/src/how-to-guides/migration-guides/migrate-from-0.8-to-0.9.md
@@ -51,3 +51,27 @@ struct MyBundle {
 }
 ```
 
+## Ancestors of LDtk Entities
+Layer entities (with a `LayerMetadata` component) are now spawned for LDtk Entity layers.
+By default, LDtk Entities are now spawned as children to these layer entities instead of as children of the level.
+```rust,ignore
+fn get_level_of_entity(
+    entities: Query<Entity, With<EntityInstance>>,
+    parent_query: Query<&Parent>,
+) {
+    for entity in &entities {
+        // 0.8
+        println!(
+            "the level that {:?} belongs to is {:?}",
+            entity,
+            parent_query.iter_ancestors(entity).nth(0)
+        );
+
+        // 0.9
+        println!(
+            "the level that {:?} belongs to is {:?}",
+            entity,
+            parent_query.iter_ancestors(entity).nth(1)
+        );
+    }
+}

--- a/book/src/how-to-guides/migration-guides/migrate-from-0.8-to-0.9.md
+++ b/book/src/how-to-guides/migration-guides/migrate-from-0.8-to-0.9.md
@@ -309,6 +309,7 @@ Those that were moved have been moved into the `assets` module, and are still ex
 It has been reused throughout the API.
 
 ### In `LevelSet`
+`LevelSet` uses it, but can still be constructed from strings using `from_iids`:
 ```rust,ignore
 // 0.8
 let level_set = LevelSet {

--- a/book/src/how-to-guides/migration-guides/migrate-from-0.8-to-0.9.md
+++ b/book/src/how-to-guides/migration-guides/migrate-from-0.8-to-0.9.md
@@ -71,6 +71,8 @@ fn get_level_of_entity(
             entity,
             parent_query.iter_ancestors(entity).nth(0)
         );
+    }
+}
 ```
 ```rust,no_run
 # use bevy_ecs_ldtk::prelude::*;

--- a/book/src/how-to-guides/migration-guides/migrate-from-0.8-to-0.9.md
+++ b/book/src/how-to-guides/migration-guides/migrate-from-0.8-to-0.9.md
@@ -93,8 +93,8 @@ fn get_level_of_entity(
 ```
 
 ## Asset Type Rework
-Most breaking changes in this release are to the asset types, previously `LdtkAsset` and `LdtkLevel`.
-These types have been heavily reworked to improve code quality, correctness, and provide better APIs.
+Most breaking changes in this release are related to the asset types, previously `LdtkAsset` and `LdtkLevel`.
+These types have been heavily reworked to improve code quality, correctness, performance, and provide better APIs.
 
 ### `LdtkAsset` is now `LdtkProject`, and other changes
 `LdtkAsset` has now been renamed to `LdtkProject`.

--- a/book/src/how-to-guides/migration-guides/migrate-from-0.8-to-0.9.md
+++ b/book/src/how-to-guides/migration-guides/migrate-from-0.8-to-0.9.md
@@ -305,12 +305,79 @@ Those that were moved have been moved into the `assets` module, and are still ex
 - `LdtkExternalLevel`
 
 ## `LevelIid` everywhere
+`LevelIid` is a new component on level entities that stores the level's iid as a string.
+It has been reused throughout the API.
 
-### `LevelSelection::Iid`
+### In `LevelSet`
+```rust,ignore
+// 0.8
+let level_set = LevelSet {
+    iids: [
+        "e5eb2d73-60bb-4779-8b33-38a63da8d1db".to_string(),
+        "855fab73-2854-419f-a3c6-4ed8466592f6".to_string(),
+    ].into_iter().collect(),
+}
+```
+```rust,no_run
+# use bevy_ecs_ldtk::prelude::*;
+# fn f() {
+// 0.9
+let level_set = LevelSet::from_iids(
+    [
+        "e5eb2d73-60bb-4779-8b33-38a63da8d1db",
+        "855fab73-2854-419f-a3c6-4ed8466592f6",
+    ]
+);
+# }
+```
 
-### `LevelSet`
+### In `LevelEvent`
+```rust,ignore
+use std::any::{Any, TypeId};
+// 0.8
+fn assert_level_event_type(mut level_events: EventReader<LevelEvent>) {
+    for level_event in level_events.iter() {
+        use LevelEvent::*;
+        let level_iid = match level_event {
+            SpawnTriggered(level_iid) | Spawned(level_iid) | Transformed(level_iid) | Despawned(level_iid) => level_iid,
+        };
 
-### `LevelEvent`
+        assert_eq!(level_iid.type_id(), TypeId::of::<String>());
+    }
+}
+```
+```rust,no_run
+# use bevy_ecs_ldtk::prelude::*;
+# use bevy::prelude::*;
+use std::any::{Any, TypeId};
+// 0.9
+fn assert_level_event_type(mut level_events: EventReader<LevelEvent>) {
+    for level_event in level_events.iter() {
+        use LevelEvent::*;
+        let level_iid = match level_event {
+            SpawnTriggered(level_iid) | Spawned(level_iid) | Transformed(level_iid) | Despawned(level_iid) => level_iid,
+        };
+
+        assert_eq!(level_iid.type_id(), TypeId::of::<LevelIid>());
+    }
+}
+```
+
+### In `LevelSelection::Iid`
+`LevelSelection` uses it, but can still be constructed with a string via the `iid` method:
+```rust,ignore
+// 0.8
+let level_selection = LevelSelection::Iid("e5eb2d73-60bb-4779-8b33-38a63da8d1db".to_string());
+```
+```rust,no_run
+# use bevy_ecs_ldtk::prelude::*;
+# fn f() {
+// 0.9
+let level_selection = LevelSelection::iid("e5eb2d73-60bb-4779-8b33-38a63da8d1db");
+# }
+```
+
+## `LevelSelection` index variant now stores a world index
 
 ## `LevelSet::from_iid` replaced with `LevelSet::from_iids`
 

--- a/book/src/how-to-guides/migration-guides/migrate-from-0.8-to-0.9.md
+++ b/book/src/how-to-guides/migration-guides/migrate-from-0.8-to-0.9.md
@@ -395,5 +395,24 @@ let level_selection = LevelSelection::index(2);
 ```
 
 ## `LevelSet::from_iid` replaced with `LevelSet::from_iids`
+`LevelSet::from_iid` has been replaced by `LevelSet::from_iids`.
+This new method can accept any iterator of strings rather than just one:
+```rust,ignore
+// 0.8
+let level_set = LevelSet::from_iid("e5eb2d73-60bb-4779-8b33-38a63da8d1db");
+```
+```rust,no_run
+# use bevy_ecs_ldtk::prelude::*;
+# fn f() {
+// 0.9
+let level_set = LevelSet::from_iids(["e5eb2d73-60bb-4779-8b33-38a63da8d1db"]);
 
-## `LevelMap` and `TilesetMap` type aliases removed
+// or many..
+let level_set = LevelSet::from_iids(
+    [
+        "e5eb2d73-60bb-4779-8b33-38a63da8d1db",
+        "855fab73-2854-419f-a3c6-4ed8466592f6",
+    ]
+);
+# }
+```

--- a/book/src/how-to-guides/migration-guides/migrate-from-0.8-to-0.9.md
+++ b/book/src/how-to-guides/migration-guides/migrate-from-0.8-to-0.9.md
@@ -51,7 +51,7 @@ struct MyBundle {
 }
 ```
 
-## Ancestors of LDtk Entities
+## Hierarchy of LDtk Entities
 Layer entities (with a `LayerMetadata` component) are now spawned for LDtk Entity layers.
 By default, LDtk Entities are now spawned as children to these layer entities instead of as children of the level.
 ```rust,ignore

--- a/book/src/how-to-guides/migration-guides/migrate-from-0.8-to-0.9.md
+++ b/book/src/how-to-guides/migration-guides/migrate-from-0.8-to-0.9.md
@@ -43,7 +43,12 @@ You may also need to implement `Default` for `LdtkEntity` types that did not hav
 struct MyBundle {
     component: MyComponentThatImplementsDefault,
 }
-
+```
+```rust,no_run
+# use bevy_ecs_ldtk::prelude::*;
+# use bevy::prelude::*;
+# #[derive(Default, Component)]
+# struct MyComponentThatImplementsDefault;
 // 0.9
 #[derive(Default, Bundle, LdtkEntity)]
 struct MyBundle {
@@ -55,19 +60,27 @@ struct MyBundle {
 Layer entities (with a `LayerMetadata` component) are now spawned for LDtk Entity layers.
 By default, LDtk Entities are now spawned as children to these layer entities instead of as children of the level.
 ```rust,ignore
+// 0.8
 fn get_level_of_entity(
     entities: Query<Entity, With<EntityInstance>>,
     parent_query: Query<&Parent>,
 ) {
     for entity in &entities {
-        // 0.8
         println!(
             "the level that {:?} belongs to is {:?}",
             entity,
             parent_query.iter_ancestors(entity).nth(0)
         );
-
-        // 0.9
+```
+```rust,no_run
+# use bevy_ecs_ldtk::prelude::*;
+# use bevy::prelude::*;
+// 0.9
+fn get_level_of_entity(
+    entities: Query<Entity, With<EntityInstance>>,
+    parent_query: Query<&Parent>,
+) {
+    for entity in &entities {
         println!(
             "the level that {:?} belongs to is {:?}",
             entity,

--- a/book/src/how-to-guides/migration-guides/migrate-from-0.8-to-0.9.md
+++ b/book/src/how-to-guides/migration-guides/migrate-from-0.8-to-0.9.md
@@ -1,0 +1,49 @@
+# Migrate from 0.8 to 0.9
+
+## `Default` behavior for `LdtkEntity` and `LdtkIntCell` derive macros
+Fields on an `LdtkEntity`- or `LdtkIntCell`-derived bundle are no longer constructed from the field's `Default` implementation, but the bundle's.
+
+You may observe different behavior in `0.9` if the value for a field in your bundle's `Default` implementation differs from the field type's own `Default` implementation:
+```rust,ignore
+#[derive(Component)]
+struct MyComponent(usize);
+
+impl Default for MyComponent {
+    fn default() -> MyComponent {
+        MyComponent(1)
+    }
+}
+
+#[derive(Bundle, LdtkEntity)]
+struct MyBundle {
+    component: MyComponent,
+}
+
+impl Default for MyBundle {
+    fn default() -> MyBundle {
+        MyBundle {
+            component: MyComponent(2),
+        }
+    }
+}
+
+// In bevy_ecs_ldtk 0.8, the plugin would spawn an entity w/ MyComponent(1)
+
+// In bevy_ecs_ldtk 0.9, the plugin now spawns the entity w/ MyComponent(2)
+```
+
+You may also need to implement `Default` for `LdtkEntity` types that did not have that implementation before:
+```rust,ignore
+// 0.8
+#[derive(Bundle, LdtkEntity)]
+struct MyBundle {
+    component: MyComponentThatImplementsDefault,
+}
+
+// 0.9
+#[derive(Default, Bundle, LdtkEntity)]
+struct MyBundle {
+    component: MyComponentThatImplementsDefault,
+}
+```
+

--- a/book/src/how-to-guides/migration-guides/migrate-from-0.8-to-0.9.md
+++ b/book/src/how-to-guides/migration-guides/migrate-from-0.8-to-0.9.md
@@ -59,7 +59,7 @@ struct MyBundle {
 ```
 
 ## Hierarchy of LDtk Entities
-Layer entities (with a `LayerMetadata` component) are now spawned for LDtk Entity layers.
+Layer entities (with a `LayerMetadata` component) are now spawned for LDtk Entity layers, just like any other layer.
 By default, LDtk Entities are now spawned as children to these layer entities instead of as children of the level.
 ```rust,ignore
 // 0.8
@@ -123,7 +123,7 @@ fn do_some_processing_with_ldtk_data(
 ```
 
 Furthermore, all of its fields have been privatized, and are now only available via immutable accessor methods.
-Not all of these methods are the same name as their corresponding field in `0.8`:
+Not all of these methods share the same name as their corresponding field in `0.8`:
 ```rust,ignore
 // 0.8
 let ldtk_json = ldtk_project.project;

--- a/book/src/how-to-guides/migration-guides/migrate-from-0.8-to-0.9.md
+++ b/book/src/how-to-guides/migration-guides/migrate-from-0.8-to-0.9.md
@@ -236,9 +236,13 @@ fn print_level_uid(levels: Query<Handle<LdtkLevel>>, level_assets: Res<Assets<Ld
 # use bevy_ecs_ldtk::prelude::*;
 # use bevy::prelude::*;
 // 0.9
-fn print_level_uid(levels: Query<&LevelIid>, project_assets: Res<Assets<LdtkProject>>) {
+fn print_level_uid(
+    levels: Query<&LevelIid>,
+    projects: Query<&Handle<LdtkProject>>,
+    project_assets: Res<Assets<LdtkProject>>
+) {
     for level_iid in &levels {
-        let only_project = project_assets.iter().next().unwrap().1;
+        let only_project = project_assets.get(projects.single()).unwrap();
 
         let level_uid = only_project.get_raw_level_by_iid(level_iid.get()).unwrap().uid;
         println!("level w/ uid {level_uid}, is currently spawned");
@@ -254,9 +258,13 @@ For internal-levels (aka "standalone") projects, you can retrieve loaded level d
 # use bevy_ecs_ldtk::prelude::*;
 # use bevy::prelude::*;
 // 0.9, w/ internal_levels enabled
-fn print_layer_count_per_level(levels: Query<&LevelIid>, project_assets: Res<Assets<LdtkProject>>) {
+fn print_level_uid(
+    levels: Query<&LevelIid>,
+    projects: Query<&Handle<LdtkProject>>,
+    project_assets: Res<Assets<LdtkProject>>
+) {
     for level_iid in &levels {
-        let only_project = project_assets.iter().next().unwrap().1;
+        let only_project = project_assets.get(projects.single()).unwrap();
 
         let layer_count = only_project
             .as_standalone()
@@ -274,13 +282,14 @@ For external-levels (aka "parent") projects, you will need to additionally acces
 # use bevy_ecs_ldtk::prelude::*;
 # use bevy::prelude::*;
 // 0.9, w/ external_levels enabled
-fn print_layer_count_per_level(
+fn print_level_uid(
     levels: Query<&LevelIid>,
+    projects: Query<&Handle<LdtkProject>>,
     project_assets: Res<Assets<LdtkProject>>
-    level_assets: Res<Assets<LdtkExternalLevels>>,
+    level_assets: Res<Assets<LdtkExternalLevel>>,
 ) {
     for level_iid in &levels {
-        let only_project = project_assets.iter().next().unwrap().1;
+        let only_project = project_assets.get(projects.single()).unwrap();
 
         let layer_count = only_project
             .as_parent()

--- a/book/src/how-to-guides/migration-guides/migrate-from-0.8-to-0.9.md
+++ b/book/src/how-to-guides/migration-guides/migrate-from-0.8-to-0.9.md
@@ -75,3 +75,32 @@ fn get_level_of_entity(
         );
     }
 }
+```
+
+## Asset Type Rework
+
+### Module restructure
+
+### `LdtkAsset` is now `LdtkProject`, and other changes
+
+### internal-levels and external-levels support behind separate features
+
+### `LdtkJson` level accessor methods have been moved
+
+### `LdtkLevel` is now `LdtkExternalLevel`, and other changes
+
+### Level entities now have a `LevelIid` instead of a `Handle<LdtkLevel>`
+
+### Asset loaders are now private
+
+## `LevelIid` everywhere
+
+### `LevelSelection::Iid`
+
+### `LevelSet`
+
+### `LevelEvent`
+
+## `LevelSet::from_iid` replaced with `LevelSet::from_iids`
+
+## `LevelMap` and `TilesetMap` type aliases removed

--- a/book/src/how-to-guides/migration-guides/migrate-from-0.8-to-0.9.md
+++ b/book/src/how-to-guides/migration-guides/migrate-from-0.8-to-0.9.md
@@ -379,6 +379,20 @@ let level_selection = LevelSelection::iid("e5eb2d73-60bb-4779-8b33-38a63da8d1db"
 ```
 
 ## `LevelSelection` index variant now stores a world index
+The `LevelSelection::Index` variant has been replaced by `LevelSelection::Indices`.
+Internally, this stores a new `LevelIndices` type, which stores an optional world index in addition to a level index.
+However, you can still construct a `LevelSelection` from a single level index using the `index` method:
+```rust,ignore
+// 0.8
+let level_selection = LevelSelection::Index(2);
+```
+```rust,no_run
+# use bevy_ecs_ldtk::prelude::*;
+# fn f() {
+// 0.9
+let level_selection = LevelSelection::index(2);
+# }
+```
 
 ## `LevelSet::from_iid` replaced with `LevelSet::from_iids`
 

--- a/book/src/how-to-guides/migration-guides/migrate-from-0.8-to-0.9.md
+++ b/book/src/how-to-guides/migration-guides/migrate-from-0.8-to-0.9.md
@@ -175,19 +175,19 @@ Some APIs are unique to the two cases.
 
 If you have an LDtk project with internal levels, but have disabled default features, you will need to enable `internal_levels`:
 ```toml
-// 0.8
+# 0.8
 bevy_ecs_ldtk = { version = "0.8", default-features = false, features = ["render"] }
 
-// 0.9
+# 0.9
 bevy_ecs_ldtk = { version = "0.9", default-features = false, features = ["render", "internal_levels"] }
 ```
 
 If you have an LDtk project with external levels, you will need to enable `external_levels`:
 ```toml
-// 0.8
+# 0.8
 bevy_ecs_ldtk = "0.8"
 
-// 0.9
+# 0.9
 bevy_ecs_ldtk = { version = "0.9", features = ["external_levels"] }
 ```
 

--- a/book/src/how-to-guides/migration-guides/migrate-from-0.8-to-0.9.md
+++ b/book/src/how-to-guides/migration-guides/migrate-from-0.8-to-0.9.md
@@ -8,7 +8,9 @@ To update your game to LDtk 1.4.1, you should only need to install the new versi
 Fields on an `LdtkEntity`- or `LdtkIntCell`-derived bundle are no longer constructed from the field's `Default` implementation, but the bundle's.
 
 You may observe different behavior in `0.9` if the value for a field in your bundle's `Default` implementation differs from the field type's own `Default` implementation:
-```rust,ignore
+```rust,no_run
+# use bevy::prelude::*;
+# use bevy_ecs_ldtk::prelude::*;
 #[derive(Component)]
 struct MyComponent(usize);
 


### PR DESCRIPTION
`bevy_ecs_ldtk` 0.9 has many more breaking changes than any other release so far. I think it would be nice to provide users with a migration guide, which will document most of the changes they will need to make in their games to continue using the plugin. The changes I've chosen to describe here are basically anything that's labeled as a breaking change in the changelog. I verified that the repo examples between now and `0.8` haven't had to deal with any other breaking change, so this should be complete (especially under normal usage).

Note that this does *not* contain a section about updating to 0.12. I will add that to the 0.12 upgrade PR after this is merged.

Furthermore, the 0.9 doc-tests here are generally marked as `no_run`, not `ignore`. These should be changed back to `ignore` before releasing 0.9 so that future changes to the plugin don't break the book. It would be nice to automate this but it's a pretty easy change to do manually as part of the release process. I think it's still good to keep them as `no_run` until that time comes, especially for future releases where migration guides will be built more incrementally.