### PR TITLE
fix: use entity definition tile size instead of entity instance tile size as basis when calculating ldtk entity scale

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -487,6 +487,13 @@ mod tests {
             uid: 0,
             width: 32,
             height: 32,
+            tile_rect: Some(TilesetRectangle {
+                x: 0,
+                y: 0,
+                w: 16,
+                h: 32,
+                ..Default::default()
+            }),
             ..Default::default()
         }];
         let entity_definition_map = create_entity_definition_map(&entity_definitions);
@@ -500,7 +507,7 @@ mod tests {
             tile: Some(TilesetRectangle {
                 x: 0,
                 y: 0,
-                w: 16,
+                w: 32,
                 h: 32,
                 ..Default::default()
             }),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -78,7 +78,7 @@ pub fn calculate_transform_from_entity_instance(
 ) -> Transform {
     let entity_definition = entity_definition_map.get(&entity_instance.def_uid).unwrap();
 
-    let def_size = match &entity_instance.tile {
+    let def_size = match &entity_definition.tile_rect {
         Some(tile) => IVec2::new(tile.w, tile.h),
         None => IVec2::new(entity_definition.width, entity_definition.height),
     };


### PR DESCRIPTION
Closes #267 

LDtk populates an `EntityInstance`'s `__tile` field if any tile is used when visualizing that entity in-level. This is normally just the entity's editor visual, but if that entity is given a singular tile field instance and has no editor visual, it might use that instead. Currently, `bevy_ecs_ldtk` uses this field to calculate the scale when spawning `EntityInstance`s. This can lead to unexpected behavior. The scale of entity instances with no entity visual should correlate to the size of the instance in the level. This might not be the case for entities that have a tile field despite having no editor visual. The solution implemented here is to use the `tileRect` field of the entity definition instead of the `__tile` field of the entity instance.

To be honest, I'm not totally satisfied with this solution either. The entity spawning process is currently designed to match the visuals in the editor when using sprites. However, it's not perfect at doing this, and using the transform's scale to accomplish this makes the logic affect a lot more components than just the sprite. It also affects colliders, for example. However, for now, this should be a satisfactory fix that does not affect many users negatively