### PR TITLE
docs: write *Game Logic Integration* chapter of the book

### DIFF
--- a/book/src/README.md
+++ b/book/src/README.md
@@ -27,7 +27,7 @@ Splitting the documentation up this way means that this book is not necessarily 
 Some chapters are intended to be read while working on your own project, while others are meant to be more like studying material.
 The following chapters are good jumping-off points for beginners:
 - [*Tile-based Game* tutorial](tutorials/tile-based-game/index.html)
-- [*Game Logic Integration* explanation]()
+- [*Game Logic Integration* explanation](explanation/game-logic-integration.md)
 
 ## Other resources
 This book is not suitable documentation for bevy or LDtk.

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -8,7 +8,7 @@
   - [Add gameplay to your project](tutorials/tile-based-game/add-gameplay-to-your-project.md)
 - [Platformer]()
 # Explanation
-- [Game Logic Integration]()
+- [Game Logic Integration](explanation/game-logic-integration.md)
 - [Hierarchy of the World]()
 - [Level Selection]()
 - [Plugin Schedule]()

--- a/book/src/explanation/game-logic-integration.md
+++ b/book/src/explanation/game-logic-integration.md
@@ -42,7 +42,7 @@ For documentation about all the available attributes, check out the API referenc
 
 This approach is suitable for many common, simple use cases.
 There's also room for more granular, component-level customization within some of the attributes, like `#[with(...)]` or `#[from_entity_instance]`.
-Of course, the traits can also be manually implemented for the even-more custom cases.
+Of course, the traits can also be manually implemented for the even-more-custom cases.
 
 ## Post-processing plugin-spawned entities
 There are still many cases where `LdtkEntity`/`LdtkIntCell` registration is insufficient.
@@ -92,12 +92,13 @@ This approach makes spawning entities from LDtk just as powerful and customizabl
 However, there are some pretty obvious ergonomics issues to this strategy compared to using registration:
 - You need to manually filter `EntityInstance`s for the desired LDtk entity identifier.
 - You need to manually perform the iteration of the query.
-- If you need the associated layer data, or tileset image, or tileset definition, you need to manually access these assets.
+- You may need to manually find the associated layer data, or tileset image, or tileset definition (if necessary).
 - You need to be careful not to overwrite the plugin-provided `Transform` component.
 
 ## A combined approach - the blueprint pattern
 At least one of these ergonomics issues can be alleviated with a combined approach.
-If you register an `LdtkEntity`/`LdtkIntCell` with a unique component, even a marker component, querying for it later won't require filtering for a particular entity instance identifier.
+If you register an `LdtkEntity`/`LdtkIntCell` with a marker component, querying for it later won't require filtering for a particular entity instance identifier.
+The plugin does that for you when giving the entity your bundle, then you can write queries that filter for the marker component instead of `EntityInstance` or `IntGridCell`.
 Furthermore, if you can add the transform-overwriting bundles within the `LdtkEntity` bundle, you won't need to tiptoe around the `Transform` in your post-processing system.
 
 ```rust,no_run
@@ -138,6 +139,6 @@ fn process_player(
 }
 ```
 
-Using a simple component or a marker component for the initial spawn of an entity, and processing it further in another system is called the "blueprint pattern".
+Using a simple component or a marker component for the initial spawn of an entity and processing it further in another system is called the "blueprint pattern".
 You may find it desirable to use the `LdtkEntity`/`LdtkIntCell` derives to construct most of the components, but need post-processing for the more demanding ones.
 This approach is recommended over filtering for `Added<EntityInstance>` or `Added<IntGridCell>`.

--- a/book/src/explanation/game-logic-integration.md
+++ b/book/src/explanation/game-logic-integration.md
@@ -7,7 +7,7 @@ It is fundamental to associate the LDtk entities and IntGrid tiles with Bevy ent
 `bevy_ecs_ldtk` is designed around a couple core strategies for doing so, which will be discussed here.
 
 ## `LdtkEntity` and `LdtkIntCell` registration
-The `LdtkEntity`/`LdtkIntCell` registration API allows you to hook custom bevy Bundles into the level spawning process.
+The `LdtkEntity`/`LdtkIntCell` registration API allows you to hook custom bevy `Bundle`s into the level spawning process.
 You define what components you want on the entity with a bundle, define how they should be constructed with the `LdtkEntity` or `LdtkIntCell` derive, and register the bundle to the `App` for a given LDtk entity identifier, or IntGrid value.
 
 ```rust,no_run

--- a/book/src/explanation/game-logic-integration.md
+++ b/book/src/explanation/game-logic-integration.md
@@ -32,13 +32,19 @@ struct MyBundle {
 }
 ```
 
-How does `LdtkEntity`/`LdtkIntCell` construct the bundle?
+How does `LdtkEntity`/`LdtkIntCell` construct the bundle when derived?
+Without any intervention, the bundle's fields are constructed using the bundle's `Default` implementation.
+However, various attributes are available to override this behavior, like `#[sprite_sheet_bundle]` in the above example.
+This attribute gives the entity a sprite sheet based on its LDtk editor visual.
+For documentation about all the available attributes, check out the API reference for these traits:
+- [`LdtkEntity`](https://docs.rs/bevy_ecs_ldtk/0.8.0/bevy_ecs_ldtk/app/trait.LdtkEntity.html) <!-- x-release-please-version -->
+- [`LdtkIntCell`](https://docs.rs/bevy_ecs_ldtk/0.8.0/bevy_ecs_ldtk/app/trait.LdtkIntCell.html) <!-- x-release-please-version -->
 
+This approach is suitable for many common, simple use cases.
+There's also room for more granular, component-level customization within some of the attributes, like `#[with(...)]` or `#[from_entity_instance]`.
+Of course, the traits can also be manually implemented for the even-more custom cases.
 
 ## Post-processing plugin-added entities
 
 ## A combined approach - the blueprint pattern
-
-[`LdtkEntity`](https://docs.rs/bevy_ecs_ldtk/0.8.0/bevy_ecs_ldtk/app/trait.LdtkEntity.html) <!-- x-release-please-version -->
-[`LdtkIntCell`](https://docs.rs/bevy_ecs_ldtk/0.8.0/bevy_ecs_ldtk/app/trait.LdtkIntCell.html) <!-- x-release-please-version -->
 

--- a/book/src/explanation/game-logic-integration.md
+++ b/book/src/explanation/game-logic-integration.md
@@ -1,0 +1,1 @@
+# Game Logic Integration

--- a/book/src/explanation/game-logic-integration.md
+++ b/book/src/explanation/game-logic-integration.md
@@ -7,8 +7,38 @@ It is fundamental to associate the LDtk entities and IntGrid tiles with Bevy ent
 `bevy_ecs_ldtk` is designed around a couple core strategies for doing so, which will be discussed here.
 
 ## `LdtkEntity` and `LdtkIntCell` registration
+The `LdtkEntity`/`LdtkIntCell` registration API allows you to hook custom bevy Bundles into the level spawning process.
+You define what components you want on the entity with a bundle, define how they should be constructed with the `LdtkEntity` or `LdtkIntCell` derive, and register the bundle to the `App` for a given LDtk entity identifier, or IntGrid value.
+
+```rust,no_run
+use bevy::prelude::*;
+use bevy_ecs_ldtk::prelude::*;
+
+fn main() {
+    App::new()
+        // other App builders
+        .register_ldtk_entity::<MyBundle>("My Entity Identifier")
+        .run();
+}
+
+#[derive(Default, Component)]
+struct MyComponent;
+
+#[derive(Default, Bundle, LdtkEntity)]
+struct MyBundle {
+    my_component: MyComponent,
+    #[sprite_sheet_bundle]
+    sprite_sheet_bundle: SpriteSheetBundle,
+}
+```
+
+How does `LdtkEntity`/`LdtkIntCell` construct the bundle?
+
 
 ## Post-processing plugin-added entities
 
 ## A combined approach - the blueprint pattern
+
+[`LdtkEntity`](https://docs.rs/bevy_ecs_ldtk/0.8.0/bevy_ecs_ldtk/app/trait.LdtkEntity.html) <!-- x-release-please-version -->
+[`LdtkIntCell`](https://docs.rs/bevy_ecs_ldtk/0.8.0/bevy_ecs_ldtk/app/trait.LdtkIntCell.html) <!-- x-release-please-version -->
 

--- a/book/src/explanation/game-logic-integration.md
+++ b/book/src/explanation/game-logic-integration.md
@@ -1,1 +1,14 @@
 # Game Logic Integration
+Loading LDtk levels into Bevy doesn't get you very far if you cannot play them.
+
+Aside from rendering tilemaps, LDtk has features for placing gameplay objects on Entity layers.
+Even within tilemaps, IntGrid layers imply a categorization of tiles, and perhaps a game designerly meaning.
+It is fundamental to associate the LDtk entities and IntGrid tiles with Bevy entities/components.
+`bevy_ecs_ldtk` is designed around a couple core strategies for doing so, which will be discussed here.
+
+## `LdtkEntity` and `LdtkIntCell` registration
+
+## Post-processing plugin-added entities
+
+## A combined approach - the blueprint pattern
+

--- a/book/src/explanation/game-logic-integration.md
+++ b/book/src/explanation/game-logic-integration.md
@@ -17,25 +17,25 @@ use bevy_ecs_ldtk::prelude::*;
 fn main() {
     App::new()
         // other App builders
-        .register_ldtk_entity::<MyBundle>("My Entity Identifier")
+        .register_ldtk_entity::<PlayerBundle>("Player")
         .run();
 }
 
 #[derive(Default, Component)]
-struct MyComponent;
+struct Player;
 
 #[derive(Default, Bundle, LdtkEntity)]
-struct MyBundle {
-    my_component: MyComponent,
-    #[sprite_sheet_bundle]
-    sprite_sheet_bundle: SpriteSheetBundle,
+struct PlayerBundle {
+    player: Player,
+    #[sprite_bundle]
+    sprite_bundle: SpriteBundle,
 }
 ```
 
 How does `LdtkEntity`/`LdtkIntCell` construct the bundle when derived?
 Without any intervention, the bundle's fields are constructed using the bundle's `Default` implementation.
-However, various attributes are available to override this behavior, like `#[sprite_sheet_bundle]` in the above example.
-This attribute gives the entity a sprite sheet based on its LDtk editor visual.
+However, various attributes are available to override this behavior, like `#[sprite_bundle]` in the above example.
+This attribute gives the entity a sprite using the tileset in its LDtk editor visual.
 For documentation about all the available attributes, check out the API reference for these traits:
 - [`LdtkEntity`](https://docs.rs/bevy_ecs_ldtk/0.8.0/bevy_ecs_ldtk/app/trait.LdtkEntity.html) <!-- x-release-please-version -->
 - [`LdtkIntCell`](https://docs.rs/bevy_ecs_ldtk/0.8.0/bevy_ecs_ldtk/app/trait.LdtkIntCell.html) <!-- x-release-please-version -->


### PR DESCRIPTION
This chapter covers the main strategies for integrating game logic with LDtk projects, and also compares them. These main strategies being `LdtkEntity`/`LdtkIntCell` registration and the blueprint pattern. In a future PR, explanations of these concepts in the API reference and project readme will be removed in favor of linking to this chapter.