### PR TITLE
ci: publish book to versioned subdirectories

### DIFF
--- a/.github/workflows/publish-book.yml
+++ b/.github/workflows/publish-book.yml
@@ -2,6 +2,8 @@ name: publish book
 
 on:
   push:
+    branches:
+      - main
     tags:
       - 'v*.*.*'
 

--- a/.github/workflows/publish-book.yml
+++ b/.github/workflows/publish-book.yml
@@ -38,3 +38,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./book/book
+          destination_dir: ./${{ github.ref_name }}

--- a/.github/workflows/publish-book.yml
+++ b/.github/workflows/publish-book.yml
@@ -38,4 +38,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./book/book
-          destination_dir: ./${{ github.ref_name }}
+          destination_dir: ${{ github.ref_name }}

--- a/.github/workflows/publish-book.yml
+++ b/.github/workflows/publish-book.yml
@@ -39,3 +39,10 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./book/book
           destination_dir: ${{ github.ref_name }}
+      - name: Publish latest
+        uses: peaceiris/actions-gh-pages@v3
+        if: github.ref_type == 'tag'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./book/book
+          destination_dir: latest

--- a/examples/tile_based_game.rs
+++ b/examples/tile_based_game.rs
@@ -1,5 +1,5 @@
 // This example has a tutorial in the bevy_ecs_ldtk book associated with it:
-// <https://trouv.github.io/bevy_ecs_ldtk/tutorials/tile-based-game/index.html>
+// <https://trouv.github.io/bevy_ecs_ldtk/latest/tutorials/tile-based-game/index.html>
 use bevy::prelude::*;
 use bevy_ecs_ldtk::prelude::*;
 use std::collections::HashSet;


### PR DESCRIPTION
Closes #274 

This changes the publish book CI to subdirectories of the github pages branch rather than the root. The directory name is either the tag name that triggered the publishing, or the branch name (which can only be `main` due to the workflow triggers). Furthermore, if it is a tag that triggered the publishing, the `latest` directory is *also* published to. So the result will be multiple versions of the book published to github pages, one for each version of the plugin named after that version, plus two special versions: `latest` and `main`. This will help with development of the book and allow users of older versions of the plugin to reference older documentation.