### PR TITLE
docs: write *Level Selection* chapter of book

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,3 +22,4 @@ jobs:
             book/src/explanation/level-selection.md
             src/lib.rs
             src/components/level_set.rs
+            src/resources/level_selection.rs

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,8 +16,9 @@ jobs:
           bump-minor-pre-major: true
           changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"docs","section":"Documentation Changes","hidden":false},{"type":"example","section":"Example Changes","hidden":false},{"type":"refactor","section":"Code Refactors","hidden":true},{"type":"ci","section":"CI Changes","hidden":true}]'
           extra-files: |
-            book/src/README.md
             README.md
-            src/lib.rs
+            book/src/README.md
             book/src/explanation/game-logic-integration.md
             book/src/explanation/level-selection.md
+            src/lib.rs
+            src/components/level_set.rs

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,3 +20,4 @@ jobs:
             README.md
             src/lib.rs
             book/src/explanation/game-logic-integration.md
+            book/src/explanation/level-selection.md

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Documentation for this plugin is available in two main places.
 
 In the book, the following chapters are good jumping-off points for beginners:
 - [*Tile-based Game* tutorial](https://trouv.github.io/bevy_ecs_ldtk/main/tutorials/tile-based-game/index.html) <!-- x-release-please-version -->
+- [*Level Selection* explanation](https://trouv.github.io/bevy_ecs_ldtk/main/explanation/level-selection.html) <!-- x-release-please-version -->
 - [*Game Logic Integration* explanation](https://trouv.github.io/bevy_ecs_ldtk/main/explanation/game-logic-integration.html) <!-- x-release-please-version -->
 
 Cargo examples are also available in this repository:

--- a/book/src/README.md
+++ b/book/src/README.md
@@ -23,6 +23,7 @@ Splitting the documentation up this way means that this book is not necessarily 
 Some chapters are intended to be read while working on your own project, while others are meant to be more like studying material.
 The following chapters are good jumping-off points for beginners:
 - [*Tile-based Game* tutorial](tutorials/tile-based-game/index.html)
+- [*Level Selection* explanation](explanation/level-selection.md)
 - [*Game Logic Integration* explanation](explanation/game-logic-integration.md)
 
 ## Other resources

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -9,8 +9,8 @@
 - [Platformer]()
 # Explanation
 - [Game Logic Integration](explanation/game-logic-integration.md)
-- [Hierarchy of the World]()
 - [Level Selection](explanation/level-selection.md)
+- [Hierarchy of the World]()
 - [Plugin Schedule]()
 - [Asset Model]()
 # How-To Guides

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -8,8 +8,8 @@
   - [Add gameplay to your project](tutorials/tile-based-game/add-gameplay-to-your-project.md)
 - [Platformer]()
 # Explanation
-- [Game Logic Integration](explanation/game-logic-integration.md)
 - [Level Selection](explanation/level-selection.md)
+- [Game Logic Integration](explanation/game-logic-integration.md)
 - [Hierarchy of the World]()
 - [Plugin Schedule]()
 - [Asset Model]()

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -10,7 +10,7 @@
 # Explanation
 - [Game Logic Integration](explanation/game-logic-integration.md)
 - [Hierarchy of the World]()
-- [Level Selection]()
+- [Level Selection](explanation/level-selection.md)
 - [Plugin Schedule]()
 - [Asset Model]()
 # How-To Guides

--- a/book/src/explanation/level-selection.md
+++ b/book/src/explanation/level-selection.md
@@ -36,6 +36,13 @@ Note: this *only* works if you are using the `LevelSelection` resource.
 One component in the `LdtkWorldBundle` is [`LevelSet`](https://docs.rs/bevy_ecs_ldtk/0.8.0/bevy_ecs_ldtk/prelude/struct.LevelSet.html). <!-- x-release-please-version -->
 This component can be used for lower-level level selection.
 Instead of selecting one level globally with a `LevelSelection` resource, you can select a specific set of levels by their iids.
+From the `level_set` cargo example:
+```rust,no_run
+# use bevy::prelude::*;
+# use bevy_ecs_ldtk::prelude::*;
+{{#include ../../../examples/level_set.rs:28:50}}
+# fn main() {}
+```
 
 This component is actually used by `LevelSelection` under the hood.
 So, in order for this workflow to work properly, no `LevelSelection` resource can exist in the world.

--- a/book/src/explanation/level-selection.md
+++ b/book/src/explanation/level-selection.md
@@ -1,0 +1,48 @@
+# Level Selection
+Once you have spawned an [`LdtkWorldBundle`](https://docs.rs/bevy_ecs_ldtk/0.8.0/bevy_ecs_ldtk/prelude/struct.LdtkWorldBundle.html), the levels you have requested to spawn will spawn as children of the world bundle.
+You have a couple options for selecting levels - and it may be useful to understand how these work to use them effectively.
+
+## `LevelSelection` resource
+The highest-level option for selecting a level to spawn is using the [`LevelSelection`](https://docs.rs/bevy_ecs_ldtk/0.8.0/bevy_ecs_ldtk/prelude/enum.LevelSelection.html) resource.
+This resource allows you to specify a particular level either by its indices in the project/world, its identifier, its iid, or its uid.
+Once this resource is added or changed, levels will be spawned/despawned in order to match your selection.
+
+One additional feature worth pointing out is loading level neighbors.
+You can enable this with the settings resource [`LdtkSettings`](https://docs.rs/bevy_ecs_ldtk/0.8.0/bevy_ecs_ldtk/prelude/struct.LdtkSettings.html):
+```rust,no_run
+use bevy::prelude::*;
+use bevy_ecs_ldtk::prelude::*;
+
+fn main() {
+    App::new()
+        // other App builders
+        .insert_resource(LevelSelection::index(0))
+        .insert_resource(LdtkSettings {
+            level_spawn_behavior: LevelSpawnBehavior::UseWorldTranslation {
+                load_level_neighbors: true
+            },
+            ..default()
+        })
+        .run();
+}
+```
+
+With this set, the plugin will spawn the currently-selected level's neighbors in addition to the currently-selected level.
+This can be especially useful for GridVania/Free-style worlds where it's important to have a level spawned before the player traverses to it.
+Note: this *only* works if you are using the `LevelSelection` resource.
+
+## `LevelSet` component
+One component in the `LdtkWorldBundle` is [`LevelSet`](https://docs.rs/bevy_ecs_ldtk/0.8.0/bevy_ecs_ldtk/prelude/struct.LevelSet.html).
+This component can be used for lower-level level selection.
+Instead of selecting one level globally with a `LevelSelection` resource, you can select a specific set of levels by iid by updating the set contained in the `LevelSet` component.
+
+This component is actually used by `LevelSelection` under the hood.
+So, in order for this workflow to work properly, no `LevelSelection` resource can exist in the world.
+
+`LevelSet` is ideal for more complex level-spawning needs.
+It is an option if you need any level-spawning behavior that `LevelSelection`/`load_level_neighbors` are not capable of.
+Furthermore, if you have more than one `LdtkWorldBundle` spawned, it can be used to select different levels per-world rather than global level selection.
+
+When the set of levels in the `LevelSet` is updated, an extra layer of change-detection is employed to make these changes idempotent/declarative.
+In other words, the plugin will observe what levels are already spawned before trying to respond to the changes in `LevelSet`.
+Only levels in the level set that weren't previously spawned will be spawned - and only levels not in the level set that are currently spawned will be despawned.

--- a/book/src/explanation/level-selection.md
+++ b/book/src/explanation/level-selection.md
@@ -47,4 +47,4 @@ Furthermore, if you have more than one `LdtkWorldBundle` spawned, it can be used
 
 When the set of levels in the `LevelSet` is updated, an extra layer of change-detection is employed to make these changes idempotent/declarative.
 In other words, the plugin will observe what levels are already spawned before trying to respond to the changes in `LevelSet`.
-Only levels in the level set that weren't previously spawned will be spawned - and only levels not in the level set that are currently spawned will be despawned.
+Only levels *in* the level set that *aren't* currently spawned will be spawned - and only levels *not in* the level set that *are* currently spawned will be despawned.

--- a/book/src/explanation/level-selection.md
+++ b/book/src/explanation/level-selection.md
@@ -1,14 +1,15 @@
 # Level Selection
-Once you have spawned an [`LdtkWorldBundle`](https://docs.rs/bevy_ecs_ldtk/0.8.0/bevy_ecs_ldtk/prelude/struct.LdtkWorldBundle.html), the levels you have requested to spawn will spawn as children of the world bundle.
+Once you have spawned an [`LdtkWorldBundle`](https://docs.rs/bevy_ecs_ldtk/0.8.0/bevy_ecs_ldtk/prelude/struct.LdtkWorldBundle.html), the levels you have requested to spawn will spawn as children of the world bundle. <!-- x-release-please-version -->
 You have a couple options for selecting levels - and it may be useful to understand how these work to use them effectively.
 
 ## `LevelSelection` resource
-The highest-level option for selecting a level to spawn is using the [`LevelSelection`](https://docs.rs/bevy_ecs_ldtk/0.8.0/bevy_ecs_ldtk/prelude/enum.LevelSelection.html) resource.
+The highest-level option for selecting a level to spawn is using the [`LevelSelection`](https://docs.rs/bevy_ecs_ldtk/0.8.0/bevy_ecs_ldtk/prelude/enum.LevelSelection.html) resource. <!-- x-release-please-version -->
 This resource allows you to specify a particular level either by its indices in the project/world, its identifier, its iid, or its uid.
 Once this resource is added or changed, levels will be spawned/despawned in order to match your selection.
 
 One additional feature worth pointing out is loading level neighbors.
-You can enable this with the settings resource [`LdtkSettings`](https://docs.rs/bevy_ecs_ldtk/0.8.0/bevy_ecs_ldtk/prelude/struct.LdtkSettings.html):
+You can enable this with the settings resource [`LdtkSettings`](https://docs.rs/bevy_ecs_ldtk/0.8.0/bevy_ecs_ldtk/prelude/struct.LdtkSettings.html): <!-- x-release-please-version -->
+
 ```rust,no_run
 use bevy::prelude::*;
 use bevy_ecs_ldtk::prelude::*;
@@ -32,7 +33,7 @@ This can be especially useful for GridVania/Free-style worlds where it's importa
 Note: this *only* works if you are using the `LevelSelection` resource.
 
 ## `LevelSet` component
-One component in the `LdtkWorldBundle` is [`LevelSet`](https://docs.rs/bevy_ecs_ldtk/0.8.0/bevy_ecs_ldtk/prelude/struct.LevelSet.html).
+One component in the `LdtkWorldBundle` is [`LevelSet`](https://docs.rs/bevy_ecs_ldtk/0.8.0/bevy_ecs_ldtk/prelude/struct.LevelSet.html). <!-- x-release-please-version -->
 This component can be used for lower-level level selection.
 Instead of selecting one level globally with a `LevelSelection` resource, you can select a specific set of levels by iid by updating the set contained in the `LevelSet` component.
 

--- a/book/src/explanation/level-selection.md
+++ b/book/src/explanation/level-selection.md
@@ -39,6 +39,7 @@ Instead of selecting one level globally with a `LevelSelection` resource, you ca
 
 This component is actually used by `LevelSelection` under the hood.
 So, in order for this workflow to work properly, no `LevelSelection` resource can exist in the world.
+This also implies, as mentioned in the previous section, that `load_level_neighbors` cannot be used with the `LevelSet` workflow.
 
 `LevelSet` is ideal for more complex level-spawning needs.
 It is an option if you need any level-spawning behavior that `LevelSelection`/`load_level_neighbors` are not capable of.

--- a/book/src/explanation/level-selection.md
+++ b/book/src/explanation/level-selection.md
@@ -1,6 +1,6 @@
 # Level Selection
-Once you have spawned an [`LdtkWorldBundle`](https://docs.rs/bevy_ecs_ldtk/0.8.0/bevy_ecs_ldtk/prelude/struct.LdtkWorldBundle.html), the levels you have requested to spawn will spawn as children of the world bundle. <!-- x-release-please-version -->
-You have a couple options for selecting levels - and it may be useful to understand how these work to use them effectively.
+Once you have spawned an [`LdtkWorldBundle`](https://docs.rs/bevy_ecs_ldtk/0.8.0/bevy_ecs_ldtk/prelude/struct.LdtkWorldBundle.html) with a handle pointing to your LDtk project file, the levels you have selected will spawn as children of the world bundle. <!-- x-release-please-version -->
+You have a couple options for selecting levels, which will be explained and discussed in this chapter.
 
 ## `LevelSelection` resource
 The highest-level option for selecting a level to spawn is using the [`LevelSelection`](https://docs.rs/bevy_ecs_ldtk/0.8.0/bevy_ecs_ldtk/prelude/enum.LevelSelection.html) resource. <!-- x-release-please-version -->

--- a/book/src/explanation/level-selection.md
+++ b/book/src/explanation/level-selection.md
@@ -1,6 +1,6 @@
 # Level Selection
 Once you have spawned an [`LdtkWorldBundle`](https://docs.rs/bevy_ecs_ldtk/0.8.0/bevy_ecs_ldtk/prelude/struct.LdtkWorldBundle.html) with a handle pointing to your LDtk project file, the levels you have selected will spawn as children of the world bundle. <!-- x-release-please-version -->
-You have a couple options for selecting levels, which will be explained and discussed in this chapter.
+You have a couple options for selecting levels, which will be discussed in this chapter.
 
 ## `LevelSelection` resource
 The highest-level option for selecting a level to spawn is using the [`LevelSelection`](https://docs.rs/bevy_ecs_ldtk/0.8.0/bevy_ecs_ldtk/prelude/enum.LevelSelection.html) resource. <!-- x-release-please-version -->

--- a/book/src/explanation/level-selection.md
+++ b/book/src/explanation/level-selection.md
@@ -35,16 +35,18 @@ Note: this *only* works if you are using the `LevelSelection` resource.
 ## `LevelSet` component
 One component in the `LdtkWorldBundle` is [`LevelSet`](https://docs.rs/bevy_ecs_ldtk/0.8.0/bevy_ecs_ldtk/prelude/struct.LevelSet.html). <!-- x-release-please-version -->
 This component can be used for lower-level level selection.
-Instead of selecting one level globally with a `LevelSelection` resource, you can select a specific set of levels by iid by updating the set contained in the `LevelSet` component.
+Instead of selecting one level globally with a `LevelSelection` resource, you can select a specific set of levels by their iids.
 
 This component is actually used by `LevelSelection` under the hood.
 So, in order for this workflow to work properly, no `LevelSelection` resource can exist in the world.
 This also implies, as mentioned in the previous section, that `load_level_neighbors` cannot be used with the `LevelSet` workflow.
+However, the `LevelSpawnBehavior::UseWorldTranslation` option in general *does* work, and should be used if you plan to spawn multiple levels anyway.
 
 `LevelSet` is ideal for more complex level-spawning needs.
 It is an option if you need any level-spawning behavior that `LevelSelection`/`load_level_neighbors` are not capable of.
-Furthermore, if you have more than one `LdtkWorldBundle` spawned, it can be used to select different levels per-world rather than global level selection.
+Furthermore, if you have more than one `LdtkWorldBundle` spawned, it can be used to select different levels per-world, which is impossible with global level selection.
 
 When the set of levels in the `LevelSet` is updated, an extra layer of change-detection is employed to make these changes idempotent/declarative.
 In other words, the plugin will observe what levels are already spawned before trying to respond to the changes in `LevelSet`.
 Only levels *in* the level set that *aren't* currently spawned will be spawned - and only levels *not in* the level set that *are* currently spawned will be despawned.
+Everything else will be left alone, remaining spawned or despawned appropriately.

--- a/examples/level_set.rs
+++ b/examples/level_set.rs
@@ -1,7 +1,7 @@
 // This example uses the LevelSet component instead of the LevelSelection resource.
 // The setup system puts several level iids in the LevelSet, so an entire LDtk world layer is
 // spawned.
-
+// See <https://trouv.github.io/bevy_ecs_ldtk/latest/explanation/level-selection.html>.
 use bevy::prelude::*;
 use bevy_ecs_ldtk::prelude::*;
 

--- a/src/components/level_set.rs
+++ b/src/components/level_set.rs
@@ -3,21 +3,11 @@ use std::collections::HashSet;
 
 use crate::LevelIid;
 
-/// [`Component`] that determines the desired levels to be loaded for an [`LdtkWorldBundle`].
+/// [`Component`] that determines the desired levels to be spawned in an [`LdtkWorldBundle`].
 ///
-/// There is an abstraction for this in the form of the [`LevelSelection`] resource.
-/// This component does not respond to the [`load_level_neighbors`] option at all, while the
-/// [`LevelSelection`] does.
-/// If a [`LevelSelection`] is inserted, the plugin will update this component based off its value.
-/// If not, [`LevelSet`] allows you to have more direct control over the levels you spawn.
-///
-/// Changes to this component are idempotent, so levels won't be respawned greedily.
-///
-/// [`LevelSelection`]: crate::prelude::LevelSelection
-/// [`load_level_neighbors`]:
-/// crate::prelude::LevelSpawnBehavior::UseWorldTranslation::load_level_neighbors
-/// [`LdtkWorldBundle`]: crate::prelude::LdtkWorldBundle
-/// [`Component`]: https://docs.rs/bevy/latest/bevy/ecs/component/trait.Component.html
+/// For more explanation and comparison of options for selecting levels to spawn, see the
+/// [*Level Selection*](https://trouv.github.io/bevy_ecs_ldtk/v0.8.0/explanation/level-selection.html) <!-- x-release-please-version -->
+/// chapter of the `bevy_ecs_ldtk` book.
 #[derive(Clone, Eq, PartialEq, Debug, Default, Component)]
 pub struct LevelSet {
     pub iids: HashSet<LevelIid>,

--- a/src/components/level_set.rs
+++ b/src/components/level_set.rs
@@ -8,6 +8,9 @@ use crate::LevelIid;
 /// For more explanation and comparison of options for selecting levels to spawn, see the
 /// [*Level Selection*](https://trouv.github.io/bevy_ecs_ldtk/v0.8.0/explanation/level-selection.html) <!-- x-release-please-version -->
 /// chapter of the `bevy_ecs_ldtk` book.
+///
+/// [`Component`]: https://docs.rs/bevy/latest/bevy/ecs/prelude/trait.Component.html
+/// [`LdtkWorldBundle`]: crate::prelude::LdtkWorldBundle
 #[derive(Clone, Eq, PartialEq, Debug, Default, Component)]
 pub struct LevelSet {
     pub iids: HashSet<LevelIid>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,30 +13,6 @@
 //! Cargo examples are also available in this plugin's
 //! [github repository](https://github.com/Trouv/bevy_ecs_ldtk/tree/v0.8.0/examples). <!-- x-release-please-version -->
 //!
-//! ## Worlds and Levels
-//!
-//! When you spawn an [LdtkWorldBundle], level entities are automatically spawned as children to
-//! the world based off your level selection.
-//! The documentation for [LdtkWorldBundle] goes into a little more detail about the spawning
-//! process.
-//!
-//! You can select what levels to spawn via the [LevelSelection] resource, or via the [LevelSet]
-//! component in the [LdtkWorldBundle].
-//! The [LevelSelection] resource is a convenient abstraction over the [LevelSet] component, and
-//! updates the [LevelSet] component automatically when used.
-//! It also responds to [LevelSpawnBehavior::UseWorldTranslation::load_level_neighbors], while
-//! [LevelSet] does not.
-//!
-//! To spawn a new level, you can just update the [LevelSelection] resource.
-//! The current level will be automatically despawned, unless it's still selected due to loading
-//! level neighbors.
-//! Updating the [LevelSet] component will have similar results.
-//!
-//! By default, the levels will be spawned so their bottom left corner is at the origin of the
-//! world.
-//! You can make them spawn according to their world location in LDtk by setting
-//! [LevelSpawnBehavior::UseWorldTranslation].
-//!
 //! ## Feature flags
 //!
 //! This crate uses the following set of [feature flags]:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 //!
 //! The following chapters are good jumping-off points for beginners:
 //! - [*Tile-based Game* tutorial](https://trouv.github.io/bevy_ecs_ldtk/v0.8.0/tutorials/tile-based-game/index.html) <!-- x-release-please-version -->
+//! - [*Level Selection* explanation](https://trouv.github.io/bevy_ecs_ldtk/v0.8.0/explanation/level-selection.html) <!-- x-release-please-version -->
 //! - [*Game Logic Integration* explanation](https://trouv.github.io/bevy_ecs_ldtk/v0.8.0/explanation/game-logic-integration.html) <!-- x-release-please-version -->
 //!
 //! Cargo examples are also available in this plugin's

--- a/src/resources/level_selection.rs
+++ b/src/resources/level_selection.rs
@@ -3,16 +3,10 @@ use bevy::prelude::*;
 
 /// [`Resource`] for choosing which level(s) to spawn.
 ///
-/// Updating this will despawn the current level and spawn the new one (unless they are the same).
-/// You can also load the selected level's neighbors using the [`LevelSpawnBehavior`] option.
+/// For more explanation and comparison of options for selecting levels to spawn, see the
+/// [*Level Selection*](https://trouv.github.io/bevy_ecs_ldtk/v0.8.0/explanation/level-selection.html) <!-- x-release-please-version -->
+/// chapter of the `bevy_ecs_ldtk` book.
 ///
-/// This resource works by updating the [`LdtkWorldBundle`]'s [`LevelSet`] component.
-/// If you need more control over the spawned levels than this resource provides,
-/// you can choose not to insert this resource and interface with [`LevelSet`] directly instead.
-///
-/// [`LevelSpawnBehavior`]: crate::prelude::LevelSpawnBehavior
-/// [`LdtkWorldBundle`]: crate::prelude::LdtkWorldBundle
-/// [`LevelSet`]: crate::prelude::LevelSet
 /// [`Resource`]: https://docs.rs/bevy/latest/bevy/ecs/prelude/trait.Resource.html
 #[derive(Clone, Eq, PartialEq, Debug, Resource)]
 pub enum LevelSelection {

--- a/src/resources/mod.rs
+++ b/src/resources/mod.rs
@@ -18,7 +18,7 @@ pub enum SetClearColor {
     /// Don't update the clear color at all
     No,
     /// Update the clear color to use the background color of the current level
-    /// (determined by [LevelSelection])
+    /// (determined by [`LevelSelection`])
     FromLevelBackground,
     /// Update the clear color to use the entire editor's background color
     FromEditorBackground,
@@ -42,8 +42,8 @@ pub enum LevelSpawnBehavior {
     ///
     /// Useful for "2d free map" and "GridVania" layouts.
     UseWorldTranslation {
-        /// When used with the [LevelSelection] resource, levels in the `__level_neighbors` list of
-        /// the selected level will be spawned in addition to the selected level.
+        /// When used with the [`LevelSelection`] resource, levels in the `__level_neighbors` list
+        /// of the selected level will be spawned in addition to the selected level.
         load_level_neighbors: bool,
     },
 }


### PR DESCRIPTION
This new chapter explains and compares the strategies for spawning levels:
- `LevelSelection`
- `LevelSet`
- `load_level_neighbors`...

In writing this, I realized this was actually a better first explanation chapter for the book than *Game Logic Integration*, so I've placed it first and also referenced it directly in `README.md`, `src/lib.rs`, and the book introduction.

Any explanations in the API reference made redundant by this chapter have been updated to reference the chapter instead.