### PR TITLE
docs: write *Create bevy relations from ldtk entity references* chapter of book

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -17,7 +17,7 @@
 - [Register Bundles for Intgrid Tiles and LDtk Entities]()
 - [Process Entities Further with Blueprints]()
 - [Combine Tiles into Larger Entities]()
-- [Create Bevy Relations from LDtk Entity References]()
+- [Create Bevy Relations from LDtk Entity References](how-to-guides/create-bevy-relations-from-ldtk-entity-references.md)
 - [Respawn Levels and Worlds]()
 - [Animate Tiles]()
 - [Camera Logic]()

--- a/book/src/how-to-guides/create-bevy-relations-from-ldtk-entity-references.md
+++ b/book/src/how-to-guides/create-bevy-relations-from-ldtk-entity-references.md
@@ -8,14 +8,14 @@ This code is used in the `field_instances` cargo example, and facilitates "enemy
 ## Register unresolved reference
 First, create a component representing an "unresolved" entity reference, storing the target entity's LDtk iid rather than a bevy `Entity`:
 ```rust,no_run
-use bevy::prelude::*;
-use bevy_ecs_ldtk::prelude::*;
-
+# use bevy::prelude::*;
+# use bevy_ecs_ldtk::prelude::*;
 {{ #include ../../../examples/field_instances/mother.rs:10:11 }}
 ```
 
 Create a method for constructing this component from an `&EntityInstance`.
-This should get the entity reference field instance value on the LDtk entity, most likely using a hard-coded field identifier to find it:
+This should retrieve the value of the entity reference field instance on the LDtk entity.
+Most likely, you'll use a hard-coded field identifier ("mother" in this example) to find it:
 ```rust,no_run
 # use bevy::prelude::*;
 # use bevy_ecs_ldtk::prelude::*;

--- a/book/src/how-to-guides/create-bevy-relations-from-ldtk-entity-references.md
+++ b/book/src/how-to-guides/create-bevy-relations-from-ldtk-entity-references.md
@@ -36,3 +36,20 @@ This guide assumes that you've already registered this bundle to the app.
 ```
 
 ## Resolve reference in post-processing
+Create a second relational component that stores the actual bevy `Entity` that this `Unresolved` reference should "resolve" to.
+```rust,no_run
+# use bevy::prelude::*;
+# use bevy_ecs_ldtk::prelude::*;
+{{ #include ../../../examples/field_instances/mother.rs:26:27 }}
+```
+
+Finally, create a ["post-processing"](../explanation/game-logic-integration.html#post-processing-plugin-spawned-entities) system that takes entities with the `Unresolved` component, and replaces it with the relational component.
+```rust,no_run
+# use bevy::prelude::*;
+# use bevy_ecs_ldtk::prelude::*;
+# {{ #include ../../../examples/field_instances/mother.rs:10 }}
+# {{ #include ../../../examples/field_instances/mother.rs:11 }}
+# {{ #include ../../../examples/field_instances/mother.rs:26 }}
+# {{ #include ../../../examples/field_instances/mother.rs:27 }}
+{{ #include ../../../examples/field_instances/mother.rs:29:51 }}
+```

--- a/book/src/how-to-guides/create-bevy-relations-from-ldtk-entity-references.md
+++ b/book/src/how-to-guides/create-bevy-relations-from-ldtk-entity-references.md
@@ -1,5 +1,5 @@
 # Create Bevy Relations from LDtk Entity References
-LDtk allows entities to point to other entities within a field instance.
+LDtk allows entities to point to other entities using a field.
 This is analogous to a bevy "relation" - a component on one entity that stores the `Entity` identifier of another entity.
 
 This chapter goes through one possible method for resolving LDtk entity references as such.

--- a/book/src/how-to-guides/create-bevy-relations-from-ldtk-entity-references.md
+++ b/book/src/how-to-guides/create-bevy-relations-from-ldtk-entity-references.md
@@ -1,0 +1,38 @@
+# Create Bevy Relations from LDtk Entity References
+LDtk allows entities to point to other entities within a field instance.
+This is analogous to a bevy "relation" - a component on one entity that stores the `Entity` identifier of another entity.
+
+This chapter goes through one possible method for resolving LDtk entity references as such.
+This code is used in the `field_instances` cargo example, and facilitates "enemy" entities pointing to another "enemy" entity as their "mother".
+
+## Register unresolved reference
+First, create a component representing an "unresolved" entity reference, storing the target entity's LDtk iid rather than a bevy `Entity`:
+```rust,no_run
+use bevy::prelude::*;
+use bevy_ecs_ldtk::prelude::*;
+
+{{ #include ../../../examples/field_instances/mother.rs:10:11 }}
+```
+
+Create a method for constructing this component from an `&EntityInstance`.
+This should get the entity reference field instance value on the LDtk entity, most likely using a hard-coded field identifier to find it:
+```rust,no_run
+# use bevy::prelude::*;
+# use bevy_ecs_ldtk::prelude::*;
+# {{ #include ../../../examples/field_instances/mother.rs:11 }}
+{{ #include ../../../examples/field_instances/mother.rs:13:23 }}
+```
+
+Add this component to the `LdtkEntity` and configure it to be constructed using this method.
+This guide assumes that you've already registered this bundle to the app.
+```rust,no_run
+# use bevy::prelude::*;
+# use bevy_ecs_ldtk::prelude::*;
+# {{ #include ../../../examples/field_instances/mother.rs:10 }}
+# {{ #include ../../../examples/field_instances/mother.rs:11 }}
+# impl UnresolvedMotherRef { fn from_mother_field(_: &EntityInstance) -> UnresolvedMotherRef { todo!() } }
+{{ #include ../../../examples/field_instances/enemy.rs:7:8}}
+{{ #include ../../../examples/field_instances/enemy.rs:15:19}}
+```
+
+## Resolve reference in post-processing

--- a/book/src/how-to-guides/create-bevy-relations-from-ldtk-entity-references.md
+++ b/book/src/how-to-guides/create-bevy-relations-from-ldtk-entity-references.md
@@ -43,7 +43,7 @@ Create a second relational component that stores the actual bevy `Entity` that t
 {{ #include ../../../examples/field_instances/mother.rs:26:27 }}
 ```
 
-Finally, create a ["post-processing"](../explanation/game-logic-integration.html#post-processing-plugin-spawned-entities) system that takes entities with the `Unresolved` component, and replaces it with the relational component.
+Finally, create a ["post-processing"](../explanation/game-logic-integration.html#post-processing-plugin-spawned-entities) system that takes entities with the `Unresolved` component, finds the entity with the matching `EntityIid`, and replaces the `Unresolved` component with the relational component.
 ```rust,no_run
 # use bevy::prelude::*;
 # use bevy_ecs_ldtk::prelude::*;


### PR DESCRIPTION
This adds a simple how-to-guide for creating bevy relations from LDtk entity references. This has already been kind-of documented by the field_instances example, which this chapter uses code from heavily.