### PR TITLE
docs: write *Respawn levels and worlds* chapter of book

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,6 +21,7 @@ jobs:
             book/src/explanation/game-logic-integration.md
             book/src/explanation/level-selection.md
             book/src/explanation/anatomy-of-the-world.md
+            book/src/how-to-guides/respawn-levels-and-worlds.md
             src/lib.rs
             src/components/mod.rs
             src/components/level_set.rs

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -18,7 +18,7 @@
 - [Process Entities Further with Blueprints]()
 - [Combine Tiles into Larger Entities]()
 - [Create Bevy Relations from LDtk Entity References](how-to-guides/create-bevy-relations-from-ldtk-entity-references.md)
-- [Respawn Levels and Worlds]()
+- [Respawn Levels and Worlds](how-to-guides/respawn-levels-and-worlds.md)
 - [Animate Tiles]()
 - [Camera Logic]()
   - [Implement Fit-Inside Camera]()

--- a/book/src/how-to-guides/respawn-levels-and-worlds.md
+++ b/book/src/how-to-guides/respawn-levels-and-worlds.md
@@ -13,6 +13,8 @@ This is especially easy if, like most users, you only have one world in your gam
 {{ #include ../../../examples/collectathon/respawn.rs:33:41 }}
 ```
 
+Note that this *will* respawn [worldly](../explanation/anatomy-of-the-world.html#worldly-entities) entities too.
+
 ## Respawn the currently-selected level
 Similarly, to respawn a level, get the level's `Entity` and insert the `Respawn` component to it.
 
@@ -70,3 +72,5 @@ There is a method on `LdtkProject` to perform this search.
     }
 }
 ```
+
+Note that, unlike respawning the world, respawning the level will not respawn any [worldly](../explanation/anatomy-of-the-world.html#worldly-entities) entities.

--- a/book/src/how-to-guides/respawn-levels-and-worlds.md
+++ b/book/src/how-to-guides/respawn-levels-and-worlds.md
@@ -5,9 +5,16 @@ This can be leveraged by users to implement a simple level restart feature, or a
 This code is from the `collectathon` cargo example.
 
 ## Respawn the world
+To respawn the world, get the world's `Entity` and insert the `Respawn` component to it.
+This is especially easy if, like most users, you only have one world in your game.
+```rust,no_run
+# use bevy::prelude::*;
+# use bevy_ecs_ldtk::prelude::*;
+{{ #include ../../../examples/collectathon/respawn.rs:33:41 }}
+```
 
 ## Respawn the currently-selected level
-Similarly, to respawn a level, all you need to do is get the level entity and insert the `Respawn` component to it.
+Similarly, to respawn a level, get the level's `Entity` and insert the `Respawn` component to it.
 
 The optimal strategy for finding the level entity can differ depending on the game.
 For example, if the game should only spawn one level at a time, then it's a simple of matter of querying for the only `LevelIid` entity.

--- a/book/src/how-to-guides/respawn-levels-and-worlds.md
+++ b/book/src/how-to-guides/respawn-levels-and-worlds.md
@@ -16,10 +16,11 @@ This is especially easy if, like most users, you only have one world in your gam
 Note that this *will* respawn [worldly](../explanation/anatomy-of-the-world.html#worldly-entities) entities too.
 
 ## Respawn the currently-selected level
-Similarly, to respawn a level, get the level's `Entity` and insert the `Respawn` component to it.
+Respawning a level works similarly to respawning the world.
+Get the level's `Entity` and insert the `Respawn` component to it.
 
 The optimal strategy for finding the level entity can differ depending on the game.
-For example, if the game should only spawn one level at a time, then it's a simple of matter of querying for the only `LevelIid` entity.
+For example, if the game should only spawn one level at a time, operate under that assumption and query for the only `LevelIid` entity.
 ```rust,no_run
 # use bevy::prelude::*;
 # use bevy_ecs_ldtk::prelude::*;
@@ -35,8 +36,9 @@ fn respawn_only_level(
 ```
 
 If the game spawns multiple levels and you want the one specified in the `LevelSelection`, you may need a more complex strategy.
+
 In the `collectathon` cargo example, the `LevelSelection` is always assumed to be of the `Iid` variety.
-With this assumption, get the `LevelIid` from the `LevelSelection` and then search for the matching level entity.
+If you share this assumption, get the `LevelIid` from the `LevelSelection` and then search for the matching level entity.
 ```rust,no_run
 # use bevy::prelude::*;
 # use bevy_ecs_ldtk::prelude::*;
@@ -73,4 +75,4 @@ There is a method on `LdtkProject` to perform this search.
 }
 ```
 
-Note that, unlike respawning the world, respawning the level will not respawn any [worldly](../explanation/anatomy-of-the-world.html#worldly-entities) entities.
+Note that, unlike respawning the world, respawning the level will *not* respawn any [worldly](../explanation/anatomy-of-the-world.html#worldly-entities) entities.

--- a/book/src/how-to-guides/respawn-levels-and-worlds.md
+++ b/book/src/how-to-guides/respawn-levels-and-worlds.md
@@ -1,0 +1,14 @@
+# Respawn Levels and Worlds
+Internally, `bevy_ecs_ldtk` uses a [`Respawn`](https://docs.rs/bevy_ecs_ldtk/0.8.0/bevy_ecs_ldtk/prelude/struct.Respawn.html) component on worlds and levels to assist in the spawning process. <!-- x-release-please-version -->
+This can be leveraged by users to implement a simple level restart feature, or an even more heavy-handed world restart feature.
+
+This code is from the `collectathon` cargo example.
+
+## Respawn the world
+
+## Respawn the currently-selected level
+Similarly, to respawn a level, all you need to do is get the level entity and insert the `Respawn` component to it.
+
+The optimal strategy for finding the level entity can differ depending on the game.
+If the game only spawns one level at a time, then it's a simple of matter of querying for the only `LevelIid` entity.
+If the game spawns multiple levels and you want the one specified in the `LevelSelection`, you may need a more complex strategy.

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -301,12 +301,9 @@ impl From<&LayerInstance> for LayerMetadata {
 
 /// [Component] that indicates that an LDtk level or world should respawn.
 ///
-/// Inserting this component on an entity with either [`Handle<LdtkProject>`] or [`LevelIid`]
-/// components will cause it to respawn.
-/// This can be used to implement a simple level-restart feature.
-/// Internally, this is used to support the entire level spawning process
-///
-/// [`Handle<LdtkProject>`]: crate::assets::LdtkProject
+/// For more details and example usage, please see the
+/// [*Respawn Levels and Worlds*](https://trouv.github.io/bevy_ecs_ldtk/v0.8.0/how-to-guides/respawn-levels-and-worlds.html) <!-- x-release-please-version -->
+/// chapter of the `bevy_ecs_ldtk` book.
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Default, Hash, Component, Reflect)]
 #[reflect(Component)]
 pub struct Respawn;


### PR DESCRIPTION
This chapter demonstrates usage of the `Respawn` component. It uses code from the new `collectathon` cargo example. This makes some docs in the api reference redundant, so those have been replaced with a link to the book.