### PR TITLE
docs: write *Make level selection follow player* chapter of book

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -19,6 +19,7 @@
 - [Combine Tiles into Larger Entities]()
 - [Create Bevy Relations from LDtk Entity References](how-to-guides/create-bevy-relations-from-ldtk-entity-references.md)
 - [Respawn Levels and Worlds](how-to-guides/respawn-levels-and-worlds.md)
+- [Make LevelSelection Follow Player](how-to-guides/make-level-selection-follow-player.md)
 - [Animate Tiles]()
 - [Camera Logic]()
   - [Implement Fit-Inside Camera]()

--- a/book/src/how-to-guides/make-level-selection-follow-player.md
+++ b/book/src/how-to-guides/make-level-selection-follow-player.md
@@ -20,15 +20,38 @@ fn main() {
 ```
 
 ## Determine bounds of spawned levels and update level selection
-One benefit of loading level neighbors is that, presumably, all levels that it is possible for the player to traverse to are already spawned.
-Use their transforms to determine the lower-left bound of levels in bevy's coordinate space.
-To get their upper-right bounds, get the width and height values of the level from the project asset.
+With `load_level_neighbors` enabled, any level that the player can traverse to will already be spawned, barring teleportation.
+Use the transforms of the spawned levels and width/height info from the level's asset data to create a `Rect` of the level's bounds.
 
+
+To access the level asset data, you first need to access the project asset data.
 Assuming you only have one project, query for the only `Handle<LdtkProject>` entity and look up its asset data in the `LdtkProject` asset store.
 Then, get the raw level data for every spawned level using the level entity's `LevelIid` component (there is a provided method for this).
-The raw level's `px_wid` and `pix_hei` values are what we need.
+
+```rust,no_run
+# use bevy::prelude::*;
+# use bevy_ecs_ldtk::prelude::*;
+# #[derive(Component)]
+# struct Player;
+{{ #include ../../../examples/collectathon/player.rs:59:74 }}
+        }
+    }
+}
+```
+
+The level's `GlobalTransform`'s x/y value should be used as the lower-left bound of the `Rect`.
+Add the raw level's `px_wid` and `pix_hei` values to the lower-left bound to calculate the upper-right bound.
+
+```rust,no_run
+# use bevy::prelude::*;
+# use bevy_ecs_ldtk::ldtk::Level;
+# fn foo(level_transform: &GlobalTransform, level: &Level) {
+{{ #include ../../../examples/collectathon/player.rs:76:85 }}
+# }
+```
 
 After creating a `Rect` of the level bounds, check if the player is inside those bounds and update the `LevelSelection` resource accordingly.
+The full system should look something like this:
 ```rust,no_run
 # use bevy::prelude::*;
 # use bevy_ecs_ldtk::prelude::*;

--- a/book/src/how-to-guides/make-level-selection-follow-player.md
+++ b/book/src/how-to-guides/make-level-selection-follow-player.md
@@ -1,1 +1,6 @@
 # Make LevelSelection Follow Player
+In games with GridVania/Free world layouts, it is common to make the player ["worldly"](../explanation/anatomy-of-the-world.html#worldly-entities) and have them traverse levels freely.
+This level traversal requires levels to be spawned as/before the Player traverses to them, and for levels to be despawned as the player traverses away from them.
+
+This guide demonstrates one strategy for managing levels like this: having the `LevelSelection` follow the player entity.
+This code comes from the `collectathon` cargo example.

--- a/book/src/how-to-guides/make-level-selection-follow-player.md
+++ b/book/src/how-to-guides/make-level-selection-follow-player.md
@@ -18,3 +18,21 @@ fn main() {
         .run();
 }
 ```
+
+## Determine bounds of spawned levels and update level selection
+One benefit of loading level neighbors is that, presumably, all levels that it is possible for the player to traverse to are already spawned.
+Use their transforms to determine the lower-left bound of levels in bevy's coordinate space.
+To get their upper-right bounds, get the width and height values of the level from the project asset.
+
+Assuming you only have one project, query for the only `Handle<LdtkProject>` entity and look up its asset data in the `LdtkProject` asset store.
+Then, get the raw level data for every spawned level using the level entity's `LevelIid` component (there is a provided method for this).
+The raw level's `px_wid` and `pix_hei` values are what we need.
+
+After creating a `Rect` of the level bounds, check if the player is inside those bounds and update the `LevelSelection` resource accordingly.
+```rust,no_run
+# use bevy::prelude::*;
+# use bevy_ecs_ldtk::prelude::*;
+# #[derive(Component)]
+# struct Player;
+{{ #include ../../../examples/collectathon/player.rs:59:92 }}
+```

--- a/book/src/how-to-guides/make-level-selection-follow-player.md
+++ b/book/src/how-to-guides/make-level-selection-follow-player.md
@@ -4,3 +4,17 @@ This level traversal requires levels to be spawned as/before the Player traverse
 
 This guide demonstrates one strategy for managing levels like this: having the `LevelSelection` follow the player entity.
 This code comes from the `collectathon` cargo example.
+
+## Use world translation for levels and load level neighbors
+Rather than spawning a level the moment the player travels to them, this guide instead loads levels *before* they reach them.
+This is accomplished using the ["load level neighbors"](../explanation/level-selection.html#levelselection-resource) feature, spawning not just the currently selected level, but its neighbors too.
+```rust,no_run
+# use bevy::prelude::*;
+# use bevy_ecs_ldtk::prelude::*;
+fn main() {
+    App::new()
+        // Other App builders
+{{ #include ../../../examples/collectathon/main.rs:13:18 }}
+        .run();
+}
+```

--- a/book/src/how-to-guides/make-level-selection-follow-player.md
+++ b/book/src/how-to-guides/make-level-selection-follow-player.md
@@ -1,0 +1,1 @@
+# Make LevelSelection Follow Player

--- a/book/src/how-to-guides/make-level-selection-follow-player.md
+++ b/book/src/how-to-guides/make-level-selection-follow-player.md
@@ -7,7 +7,7 @@ This code comes from the `collectathon` cargo example.
 
 ## Use world translation for levels and load level neighbors
 Rather than spawning a level the moment the player travels to them, this guide instead loads levels *before* they reach them.
-This is accomplished using the ["load level neighbors"](../explanation/level-selection.html#levelselection-resource) feature, spawning not just the currently selected level, but its neighbors too.
+Use the ["load level neighbors"](../explanation/level-selection.html#levelselection-resource) feature, so the plugin spawns not just the currently selected level, but its neighbors too.
 ```rust,no_run
 # use bevy::prelude::*;
 # use bevy_ecs_ldtk::prelude::*;

--- a/examples/collectathon/player.rs
+++ b/examples/collectathon/player.rs
@@ -63,27 +63,29 @@ fn level_selection_follow_player(
     ldtk_project_assets: Res<Assets<LdtkProject>>,
     mut level_selection: ResMut<LevelSelection>,
 ) {
-    for player_transform in players.iter() {
-        if let Some(ldtk_project) = ldtk_project_assets.get(ldtk_projects.single()) {
-            for (level_iid, level_transform) in levels.iter() {
-                let level = ldtk_project
-                    .get_raw_level_by_iid(level_iid.get())
-                    .expect("level should exist in only project");
+    if let Ok(player_transform) = players.get_single() {
+        let ldtk_project = ldtk_project_assets
+            .get(ldtk_projects.single())
+            .expect("ldtk project should be loaded before player is spawned");
 
-                let level_bounds = Rect {
-                    min: Vec2::new(
-                        level_transform.translation().x,
-                        level_transform.translation().y,
-                    ),
-                    max: Vec2::new(
-                        level_transform.translation().x + level.px_wid as f32,
-                        level_transform.translation().y + level.px_hei as f32,
-                    ),
-                };
+        for (level_iid, level_transform) in levels.iter() {
+            let level = ldtk_project
+                .get_raw_level_by_iid(level_iid.get())
+                .expect("level should exist in only project");
 
-                if level_bounds.contains(player_transform.translation().truncate()) {
-                    *level_selection = LevelSelection::Iid(level_iid.clone());
-                }
+            let level_bounds = Rect {
+                min: Vec2::new(
+                    level_transform.translation().x,
+                    level_transform.translation().y,
+                ),
+                max: Vec2::new(
+                    level_transform.translation().x + level.px_wid as f32,
+                    level_transform.translation().y + level.px_hei as f32,
+                ),
+            };
+
+            if level_bounds.contains(player_transform.translation().truncate()) {
+                *level_selection = LevelSelection::Iid(level_iid.clone());
             }
         }
     }


### PR DESCRIPTION
This demonstrates how to update the `LevelSelection` based on the level the player is currently in, for games that use `LevelSpawnBehavior::UseWorldTranslation` and a `Worldly` player. It uses code from the new `collectathon` example (and improves that code a little bit).