### PR TITLE
Bevy 0.13 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,4 +58,4 @@ name = "collectathon"
 path = "examples/collectathon/main.rs"
 
 [patch.crates-io]
-bevy_ecs_tilemap = { git = "https://github.com/rparrett/bevy_ecs_tilemap/", branch = "bevy13" }
+bevy_ecs_tilemap = { git = "https://github.com/StarArawn/bevy_ecs_tilemap/", branch = "main" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = ["macros"]
 [dependencies]
 bevy_ecs_ldtk_macros = { version = "0.9.0", optional = true, path = "macros" }
 bevy_ecs_tilemap = { version = "0.12", default-features = false }
-bevy = { version = "0.12", default-features = false, features = ["bevy_sprite"] }
+bevy = { version = "0.13", default-features = false, features = ["bevy_sprite"] }
 derive-getters = "0.3.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -28,11 +28,11 @@ derive_more = "0.99.17"
 path-clean = "1.0.1"
 
 [dev-dependencies]
-bevy = "0.12"
-bevy_rapier2d = "0.23.0"
+bevy = "0.13"
+bevy_rapier2d = "0.25.0"
 fake = { version = "2.8.0", features = ["uuid"] }
 rand = "0.8"
-bevy-inspector-egui = "0.21.0"
+bevy-inspector-egui = "0.23.0"
 
 [features]
 default = ["derive", "render", "internal_levels"]
@@ -56,3 +56,6 @@ path = "examples/field_instances/main.rs"
 [[example]]
 name = "collectathon"
 path = "examples/collectathon/main.rs"
+
+[patch.crates-io]
+bevy_ecs_tilemap = { git = "https://github.com/rparrett/bevy_ecs_tilemap/", branch = "bevy13" }

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ $ cargo run --example example-name
 ## Compatibility
 | bevy | bevy_ecs_tilemap | LDtk | bevy_ecs_ldtk |
 | --- | --- | --- | --- |
+| 0.13 | main | 1.5.3 | main |
 | 0.12 | 0.12 | 1.5.3 | 0.9 |
 | 0.11 | 0.11 | 1.3.3 | 0.8 |
 | 0.10 | 0.10 | 1.1 | 0.7 |

--- a/book/src/how-to-guides/respawn-levels-and-worlds.md
+++ b/book/src/how-to-guides/respawn-levels-and-worlds.md
@@ -27,9 +27,9 @@ For example, if the game should only spawn one level at a time, operate under th
 fn respawn_only_level(
     mut commands: Commands,
     levels: Query<Entity, With<LevelIid>>,
-    input: Res<Input<KeyCode>>
+    input: Res<ButtonInput<KeyCode>>
 ) {
-    if input.just_pressed(KeyCode::L) {
+    if input.just_pressed(KeyCode::KeyL) {
         commands.entity(levels.single()).insert(Respawn);
     }
 }
@@ -54,7 +54,7 @@ There is a method on `LdtkProject` to perform this search.
     ldtk_projects: Query<&Handle<LdtkProject>>,
     ldtk_project_assets: Res<Assets<LdtkProject>>,
 ) {
-    if input.just_pressed(KeyCode::L) {
+    if input.just_pressed(KeyCode::KeyL) {
         if let Some(only_project) = ldtk_project_assets.get(ldtk_projects.single()) {
             let level_selection_iid = LevelIid::new(
                 only_project

--- a/examples/collectathon/player.rs
+++ b/examples/collectathon/player.rs
@@ -30,22 +30,22 @@ const MOVEMENT_SPEED: f32 = 96.;
 
 fn move_player(
     mut players: Query<&mut Transform, With<Player>>,
-    input: Res<Input<KeyCode>>,
+    input: Res<ButtonInput<KeyCode>>,
     time: Res<Time>,
 ) {
     for mut player_transform in players.iter_mut() {
         let mut movement = Vec2::ZERO;
 
-        if input.pressed(KeyCode::W) || input.pressed(KeyCode::Up) {
+        if input.pressed(KeyCode::KeyW) || input.pressed(KeyCode::ArrowUp) {
             movement += Vec2::Y;
         }
-        if input.pressed(KeyCode::A) || input.pressed(KeyCode::Left) {
+        if input.pressed(KeyCode::KeyA) || input.pressed(KeyCode::ArrowLeft) {
             movement -= Vec2::X;
         }
-        if input.pressed(KeyCode::S) || input.pressed(KeyCode::Down) {
+        if input.pressed(KeyCode::KeyS) || input.pressed(KeyCode::ArrowDown) {
             movement -= Vec2::Y;
         }
-        if input.pressed(KeyCode::D) || input.pressed(KeyCode::Right) {
+        if input.pressed(KeyCode::KeyD) || input.pressed(KeyCode::ArrowRight) {
             movement += Vec2::X;
         }
 

--- a/examples/collectathon/respawn.rs
+++ b/examples/collectathon/respawn.rs
@@ -14,9 +14,9 @@ fn respawn_level(
     mut commands: Commands,
     level_selection: Res<LevelSelection>,
     levels: Query<(Entity, &LevelIid)>,
-    input: Res<Input<KeyCode>>,
+    input: Res<ButtonInput<KeyCode>>,
 ) {
-    if input.just_pressed(KeyCode::L) {
+    if input.just_pressed(KeyCode::KeyL) {
         let level_selection_iid = match level_selection.as_ref() {
             LevelSelection::Iid(iid) => iid,
             _ => panic!("level should always be selected by iid in this example"),
@@ -33,9 +33,9 @@ fn respawn_level(
 fn respawn_world(
     mut commands: Commands,
     ldtk_projects: Query<Entity, With<Handle<LdtkProject>>>,
-    input: Res<Input<KeyCode>>,
+    input: Res<ButtonInput<KeyCode>>,
 ) {
-    if input.just_pressed(KeyCode::R) {
+    if input.just_pressed(KeyCode::KeyR) {
         commands.entity(ldtk_projects.single()).insert(Respawn);
     }
 }

--- a/examples/level_set.rs
+++ b/examples/level_set.rs
@@ -51,7 +51,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
 // This function is a demonstation that changes to the LevelSet have the expected results.
 // Hit spacebar and watch what happens!
-fn toggle_levels(input: Res<Input<KeyCode>>, mut level_sets: Query<&mut LevelSet>) {
+fn toggle_levels(input: Res<ButtonInput<KeyCode>>, mut level_sets: Query<&mut LevelSet>) {
     if input.just_pressed(KeyCode::Space) {
         let mut rng = rand::thread_rng();
         let level_to_toggle = LevelIid::new(*LEVEL_IIDS.choose(&mut rng).unwrap());

--- a/examples/platformer/components.rs
+++ b/examples/platformer/components.rs
@@ -157,7 +157,7 @@ impl LdtkEntity for Patrol {
         _: Option<&Handle<Image>>,
         _: Option<&TilesetDefinition>,
         _: &AssetServer,
-        _: &mut Assets<TextureAtlas>,
+        _: &mut Assets<TextureAtlasLayout>,
     ) -> Patrol {
         let mut points = Vec::new();
         points.push(ldtk_pixel_coords_to_translation_pivoted(

--- a/examples/platformer/systems.rs
+++ b/examples/platformer/systems.rs
@@ -18,11 +18,11 @@ pub fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 }
 
 pub fn dbg_player_items(
-    input: Res<Input<KeyCode>>,
+    input: Res<ButtonInput<KeyCode>>,
     mut query: Query<(&Items, &EntityInstance), With<Player>>,
 ) {
     for (items, entity_instance) in &mut query {
-        if input.just_pressed(KeyCode::P) {
+        if input.just_pressed(KeyCode::KeyP) {
             dbg!(&items);
             dbg!(&entity_instance);
         }
@@ -30,24 +30,24 @@ pub fn dbg_player_items(
 }
 
 pub fn movement(
-    input: Res<Input<KeyCode>>,
+    input: Res<ButtonInput<KeyCode>>,
     mut query: Query<(&mut Velocity, &mut Climber, &GroundDetection), With<Player>>,
 ) {
     for (mut velocity, mut climber, ground_detection) in &mut query {
-        let right = if input.pressed(KeyCode::D) { 1. } else { 0. };
-        let left = if input.pressed(KeyCode::A) { 1. } else { 0. };
+        let right = if input.pressed(KeyCode::KeyD) { 1. } else { 0. };
+        let left = if input.pressed(KeyCode::KeyA) { 1. } else { 0. };
 
         velocity.linvel.x = (right - left) * 200.;
 
         if climber.intersecting_climbables.is_empty() {
             climber.climbing = false;
-        } else if input.just_pressed(KeyCode::W) || input.just_pressed(KeyCode::S) {
+        } else if input.just_pressed(KeyCode::KeyW) || input.just_pressed(KeyCode::KeyS) {
             climber.climbing = true;
         }
 
         if climber.climbing {
-            let up = if input.pressed(KeyCode::W) { 1. } else { 0. };
-            let down = if input.pressed(KeyCode::S) { 1. } else { 0. };
+            let up = if input.pressed(KeyCode::KeyW) { 1. } else { 0. };
+            let down = if input.pressed(KeyCode::KeyS) { 1. } else { 0. };
 
             velocity.linvel.y = (up - down) * 200.;
         }
@@ -108,7 +108,7 @@ pub fn spawn_wall_collision(
     // 2. it lets us easily add the collision entities as children of the appropriate level entity
     let mut level_to_wall_locations: HashMap<Entity, HashSet<GridCoords>> = HashMap::new();
 
-    wall_query.for_each(|(&grid_coords, parent)| {
+    wall_query.iter().for_each(|(&grid_coords, parent)| {
         // An intgrid tile's direct parent will be a layer entity, not the level entity
         // To get the level entity, you need the tile's grandparent.
         // This is where parent_query comes in.
@@ -121,7 +121,7 @@ pub fn spawn_wall_collision(
     });
 
     if !wall_query.is_empty() {
-        level_query.for_each(|(level_entity, level_iid)| {
+        level_query.iter().for_each(|(level_entity, level_iid)| {
             if let Some(level_walls) = level_to_wall_locations.get(&level_entity) {
                 let ldtk_project = ldtk_project_assets
                     .get(ldtk_projects.single())
@@ -448,7 +448,7 @@ pub fn spawn_ground_sensor(
 pub fn ground_detection(
     mut ground_sensors: Query<&mut GroundSensor>,
     mut collisions: EventReader<CollisionEvent>,
-    collidables: Query<With<Collider>, Without<Sensor>>,
+    collidables: Query<Entity, (With<Collider>, Without<Sensor>)>,
 ) {
     for collision_event in collisions.read() {
         match collision_event {
@@ -492,9 +492,9 @@ pub fn update_on_ground(
 pub fn restart_level(
     mut commands: Commands,
     level_query: Query<Entity, With<LevelIid>>,
-    input: Res<Input<KeyCode>>,
+    input: Res<ButtonInput<KeyCode>>,
 ) {
-    if input.just_pressed(KeyCode::R) {
+    if input.just_pressed(KeyCode::KeyR) {
         for level_entity in &level_query {
             commands.entity(level_entity).insert(Respawn);
         }

--- a/examples/tile_based_game.rs
+++ b/examples/tile_based_game.rs
@@ -90,16 +90,16 @@ impl LevelWalls {
 
 fn move_player_from_input(
     mut players: Query<&mut GridCoords, With<Player>>,
-    input: Res<Input<KeyCode>>,
+    input: Res<ButtonInput<KeyCode>>,
     level_walls: Res<LevelWalls>,
 ) {
-    let movement_direction = if input.just_pressed(KeyCode::W) {
+    let movement_direction = if input.just_pressed(KeyCode::KeyW) {
         GridCoords::new(0, 1)
-    } else if input.just_pressed(KeyCode::A) {
+    } else if input.just_pressed(KeyCode::KeyA) {
         GridCoords::new(-1, 0)
-    } else if input.just_pressed(KeyCode::S) {
+    } else if input.just_pressed(KeyCode::KeyS) {
         GridCoords::new(0, -1)
-    } else if input.just_pressed(KeyCode::D) {
+    } else if input.just_pressed(KeyCode::KeyD) {
         GridCoords::new(1, 0)
     } else {
         return;

--- a/examples/traitless.rs
+++ b/examples/traitless.rs
@@ -32,16 +32,15 @@ struct ComponentB;
 fn process_my_entity(
     mut commands: Commands,
     entity_query: Query<(Entity, &Transform, &EntityInstance), Added<EntityInstance>>,
-    mut texture_atlases: ResMut<Assets<TextureAtlas>>,
+    mut texture_atlases: ResMut<Assets<TextureAtlasLayout>>,
     asset_server: Res<AssetServer>,
 ) {
     for (entity, transform, entity_instance) in entity_query.iter() {
         if entity_instance.identifier == *"MyEntityIdentifier" {
-            let tileset = asset_server.load("atlas/MV Icons Complete Sheet Free - ALL.png");
+            let texture = asset_server.load("atlas/MV Icons Complete Sheet Free - ALL.png");
 
             if let Some(tile) = &entity_instance.tile {
-                let texture_atlas = texture_atlases.add(TextureAtlas::from_grid(
-                    tileset.clone(),
+                let layout = texture_atlases.add(TextureAtlasLayout::from_grid(
                     Vec2::new(tile.w as f32, tile.h as f32),
                     16,
                     95,
@@ -49,14 +48,14 @@ fn process_my_entity(
                     None,
                 ));
 
-                let sprite = TextureAtlasSprite {
+                let atlas = TextureAtlas {
                     index: (tile.y / tile.h) as usize * 16 + (tile.x / tile.w) as usize,
-                    ..Default::default()
+                    layout,
                 };
 
                 commands.entity(entity).insert(SpriteSheetBundle {
-                    texture_atlas,
-                    sprite,
+                    atlas,
+                    texture,
                     transform: *transform,
                     ..Default::default()
                 });

--- a/macros/src/ldtk_entity.rs
+++ b/macros/src/ldtk_entity.rs
@@ -115,7 +115,7 @@ pub fn expand_ldtk_entity_derive(ast: syn::DeriveInput) -> proc_macro::TokenStre
                 tileset: Option<&bevy::prelude::Handle<bevy::prelude::Image>>,
                 tileset_definition: Option<&bevy_ecs_ldtk::prelude::TilesetDefinition>,
                 asset_server: &bevy::prelude::AssetServer,
-                texture_atlases: &mut bevy::prelude::Assets<bevy::prelude::TextureAtlas>,
+                texture_atlases: &mut bevy::prelude::Assets<bevy::prelude::TextureAtlasLayout>,
             ) -> Self {
                 Self {
                     #(#field_constructions)*
@@ -231,18 +231,16 @@ fn expand_sprite_sheet_bundle_attribute(
 
             quote! {
                 #field_name: bevy::prelude::SpriteSheetBundle {
-                    texture_atlas: texture_atlases.add(
-                        bevy::prelude::TextureAtlas::from_grid(
-                            asset_server.load(#asset_path).into(),
-                            bevy::prelude::Vec2::new(#tile_width, #tile_height),
-                            #columns, #rows, Some(bevy::prelude::Vec2::splat(#padding)),
-                            Some(bevy::prelude::Vec2::splat(#offset)),
-                        )
-                    ),
-                    sprite: bevy::prelude::TextureAtlasSprite {
-                        index: #index,
-                        ..Default::default()
+                    atlas: bevy::prelude::TextureAtlas {
+                        layout: texture_atlases.add(
+                            bevy::prelude::TextureAtlasLayout::from_grid(
+                                bevy::prelude::Vec2::new(#tile_width, #tile_height),
+                                #columns, #rows, Some(bevy::prelude::Vec2::splat(#padding)),
+                                Some(bevy::prelude::Vec2::splat(#offset)),
+                            )),
+                        index: #index
                     },
+                    texture: asset_server.load(#asset_path).into(),
                     ..Default::default()
                 },
             }

--- a/src/app/entity_app_ext.rs
+++ b/src/app/entity_app_ext.rs
@@ -150,7 +150,7 @@ mod tests {
             _: Option<&Handle<Image>>,
             _: Option<&TilesetDefinition>,
             _: &AssetServer,
-            _: &mut Assets<TextureAtlas>,
+            _: &mut Assets<TextureAtlasLayout>,
         ) -> LdtkEntityBundle {
             LdtkEntityBundle::default()
         }

--- a/src/app/ldtk_entity.rs
+++ b/src/app/ldtk_entity.rs
@@ -12,7 +12,7 @@ use std::{collections::HashMap, marker::PhantomData};
 /// [Component]: bevy::prelude::Component
 /// [SpriteBundle]: bevy::prelude::SpriteBundle
 /// [SpriteSheetBundle]: bevy::prelude::SpriteSheetBundle
-/// [TextureAtlas]: bevy::prelude::TextureAtlas
+/// [TextureAtlasLayout]: bevy::prelude::TextureAtlasLayout
 ///
 /// Provides a constructor which can be used for spawning entities from an LDtk file.
 ///
@@ -103,13 +103,13 @@ use std::{collections::HashMap, marker::PhantomData};
 /// There are two forms for this attribute:
 /// - `#[sprite_sheet_bundle("path/to/asset.png", tile_width, tile_height, columns, rows, padding,
 /// offset, index)]` will create the field using all of the information provided.
-/// Similar to using [TextureAtlas::from_grid()].
+/// Similar to using [TextureAtlasLayout::from_grid()].
 /// - `#[sprite_sheet_bundle]` will create the field using information from the LDtk Editor visual,
 /// if it has one.
 /// - `#[sprite_sheet_bundle(no_grid)]` will create the field using information from the LDtk
 /// Editor visual, if it has one, but without using a grid. Instead a single texture will be used.
 /// This may be useful if the LDtk entity's visual uses a rectangle of tiles from its tileset,
-/// but will prevent using the generated [TextureAtlas] for animation purposes.
+/// but will prevent using the generated [TextureAtlasLayout] for animation purposes.
 /// ```
 /// # use bevy::prelude::*;
 /// # use bevy_ecs_ldtk::prelude::*;
@@ -300,7 +300,7 @@ pub trait LdtkEntity {
         tileset: Option<&Handle<Image>>,
         tileset_definition: Option<&TilesetDefinition>,
         asset_server: &AssetServer,
-        texture_atlases: &mut Assets<TextureAtlas>,
+        texture_atlases: &mut Assets<TextureAtlasLayout>,
     ) -> Self;
 }
 
@@ -311,7 +311,7 @@ impl LdtkEntity for EntityInstanceBundle {
         _: Option<&Handle<Image>>,
         _: Option<&TilesetDefinition>,
         _: &AssetServer,
-        _: &mut Assets<TextureAtlas>,
+        _: &mut Assets<TextureAtlasLayout>,
     ) -> Self {
         EntityInstanceBundle {
             entity_instance: entity_instance.clone(),
@@ -326,7 +326,7 @@ impl LdtkEntity for SpriteBundle {
         tileset: Option<&Handle<Image>>,
         _: Option<&TilesetDefinition>,
         _: &AssetServer,
-        _: &mut Assets<TextureAtlas>,
+        _: &mut Assets<TextureAtlasLayout>,
     ) -> Self {
         utils::sprite_bundle_from_entity_info(tileset)
     }
@@ -339,7 +339,7 @@ impl LdtkEntity for SpriteSheetBundle {
         tileset: Option<&Handle<Image>>,
         tileset_definition: Option<&TilesetDefinition>,
         _: &AssetServer,
-        texture_atlases: &mut Assets<TextureAtlas>,
+        texture_atlases: &mut Assets<TextureAtlasLayout>,
     ) -> Self {
         utils::sprite_sheet_bundle_from_entity_info(
             entity_instance,
@@ -358,7 +358,7 @@ impl LdtkEntity for Worldly {
         _: Option<&Handle<Image>>,
         _: Option<&TilesetDefinition>,
         _: &AssetServer,
-        _: &mut Assets<TextureAtlas>,
+        _: &mut Assets<TextureAtlasLayout>,
     ) -> Worldly {
         Worldly::from_entity_info(entity_instance)
     }
@@ -371,7 +371,7 @@ impl LdtkEntity for GridCoords {
         _: Option<&Handle<Image>>,
         _: Option<&TilesetDefinition>,
         _: &AssetServer,
-        _: &mut Assets<TextureAtlas>,
+        _: &mut Assets<TextureAtlasLayout>,
     ) -> Self {
         GridCoords::from_entity_info(entity_instance, layer_instance)
     }
@@ -392,29 +392,29 @@ impl<B: LdtkEntity + Bundle> PhantomLdtkEntity<B> {
 
 pub trait PhantomLdtkEntityTrait {
     #[allow(clippy::too_many_arguments)]
-    fn evaluate<'w, 's, 'a, 'b>(
+    fn evaluate<'a, 'b>(
         &self,
-        commands: &'b mut EntityCommands<'w, 's, 'a>,
+        commands: &'b mut EntityCommands<'a>,
         entity_instance: &EntityInstance,
         layer_instance: &LayerInstance,
         tileset: Option<&Handle<Image>>,
         tileset_definition: Option<&TilesetDefinition>,
         asset_server: &AssetServer,
-        texture_atlases: &mut Assets<TextureAtlas>,
-    ) -> &'b mut EntityCommands<'w, 's, 'a>;
+        texture_atlases: &mut Assets<TextureAtlasLayout>,
+    ) -> &'b mut EntityCommands<'a>;
 }
 
 impl<B: LdtkEntity + Bundle> PhantomLdtkEntityTrait for PhantomLdtkEntity<B> {
-    fn evaluate<'w, 's, 'a, 'b>(
+    fn evaluate<'a, 'b>(
         &self,
-        entity_commands: &'b mut EntityCommands<'w, 's, 'a>,
+        entity_commands: &'b mut EntityCommands<'a>,
         entity_instance: &EntityInstance,
         layer_instance: &LayerInstance,
         tileset: Option<&Handle<Image>>,
         tileset_definition: Option<&TilesetDefinition>,
         asset_server: &AssetServer,
-        texture_atlases: &mut Assets<TextureAtlas>,
-    ) -> &'b mut EntityCommands<'w, 's, 'a> {
+        texture_atlases: &mut Assets<TextureAtlasLayout>,
+    ) -> &'b mut EntityCommands<'a> {
         entity_commands.insert(B::bundle_entity(
             entity_instance,
             layer_instance,

--- a/src/app/ldtk_int_cell.rs
+++ b/src/app/ldtk_int_cell.rs
@@ -191,21 +191,21 @@ impl<B: LdtkIntCell + Bundle> PhantomLdtkIntCell<B> {
 }
 
 pub trait PhantomLdtkIntCellTrait {
-    fn evaluate<'w, 's, 'a, 'b>(
+    fn evaluate<'a, 'b>(
         &self,
-        entity_commands: &'b mut EntityCommands<'w, 's, 'a>,
+        entity_commands: &'b mut EntityCommands<'a>,
         int_grid_cell: IntGridCell,
         layer_instance: &LayerInstance,
-    ) -> &'b mut EntityCommands<'w, 's, 'a>;
+    ) -> &'b mut EntityCommands<'a>;
 }
 
 impl<B: LdtkIntCell + Bundle> PhantomLdtkIntCellTrait for PhantomLdtkIntCell<B> {
-    fn evaluate<'w, 's, 'a, 'b>(
+    fn evaluate<'a, 'b>(
         &self,
-        entity_commands: &'b mut EntityCommands<'w, 's, 'a>,
+        entity_commands: &'b mut EntityCommands<'a>,
         int_grid_cell: IntGridCell,
         layer_instance: &LayerInstance,
-    ) -> &'b mut EntityCommands<'w, 's, 'a> {
+    ) -> &'b mut EntityCommands<'a> {
         entity_commands.insert(B::bundle_int_cell(int_grid_cell, layer_instance))
     }
 }

--- a/src/ldtk/impl_definitions.rs
+++ b/src/ldtk/impl_definitions.rs
@@ -1,7 +1,10 @@
 use crate::ldtk::{Definitions, Type};
 use bevy::{
     prelude::*,
-    render::render_resource::{Extent3d, TextureDimension, TextureFormat},
+    render::{
+        render_asset::RenderAssetUsages,
+        render_resource::{Extent3d, TextureDimension, TextureFormat},
+    },
 };
 
 impl Definitions {
@@ -27,6 +30,7 @@ impl Definitions {
                     TextureDimension::D2,
                     &[255, 255, 255, 255],
                     TextureFormat::Rgba8UnormSrgb,
+                    RenderAssetUsages::default(),
                 )
             })
     }

--- a/src/level.rs
+++ b/src/level.rs
@@ -40,7 +40,7 @@ enum BackgroundImageError {
 
 fn background_image_sprite_sheet_bundle(
     images: &Assets<Image>,
-    texture_atlases: &mut Assets<TextureAtlas>,
+    texture_atlases: &mut Assets<TextureAtlasLayout>,
     background_image_handle: &Handle<Image>,
     background_position: &LevelBackgroundPosition,
     level_height: i32,
@@ -52,7 +52,7 @@ fn background_image_sprite_sheet_bundle(
             background_image.texture_descriptor.size.width as f32,
             background_image.texture_descriptor.size.height as f32,
         );
-        let mut texture_atlas = TextureAtlas::new_empty(background_image_handle.clone(), tile_size);
+        let mut texture_atlas_layout = TextureAtlasLayout::new_empty(tile_size);
 
         let min = Vec2::new(
             background_position.crop_rect[0],
@@ -68,9 +68,7 @@ fn background_image_sprite_sheet_bundle(
 
         let crop_rect = Rect { min, max };
 
-        texture_atlas.textures.push(crop_rect);
-
-        let texture_atlas_handle = texture_atlases.add(texture_atlas);
+        let index = texture_atlas_layout.add_texture(crop_rect);
 
         let scale = background_position.scale;
 
@@ -83,7 +81,11 @@ fn background_image_sprite_sheet_bundle(
             top_left_translation + (Vec2::new(scaled_size.x, -scaled_size.y) / 2.);
 
         Ok(SpriteSheetBundle {
-            texture_atlas: texture_atlas_handle,
+            atlas: TextureAtlas {
+                index,
+                layout: texture_atlases.add(texture_atlas_layout),
+            },
+            texture: background_image_handle.clone(),
             transform: Transform::from_translation(center_translation.extend(transform_z))
                 .with_scale(scale.extend(1.)),
             ..Default::default()
@@ -210,7 +212,7 @@ pub fn spawn_level(
     commands: &mut Commands,
     asset_server: &AssetServer,
     images: &Assets<Image>,
-    texture_atlases: &mut Assets<TextureAtlas>,
+    texture_atlases: &mut Assets<TextureAtlasLayout>,
     ldtk_entity_map: &LdtkEntityMap,
     ldtk_int_cell_map: &LdtkIntCellMap,
     entity_definition_map: &HashMap<i32, &EntityDefinition>,

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -216,7 +216,7 @@ pub fn process_ldtk_levels(
     mut commands: Commands,
     asset_server: Res<AssetServer>,
     images: ResMut<Assets<Image>>,
-    mut texture_atlases: ResMut<Assets<TextureAtlas>>,
+    mut texture_atlases: ResMut<Assets<TextureAtlasLayout>>,
     ldtk_project_assets: Res<Assets<LdtkProject>>,
     #[cfg(feature = "external_levels")] level_assets: Res<Assets<LdtkExternalLevel>>,
     ldtk_entity_map: NonSend<LdtkEntityMap>,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -314,49 +314,44 @@ pub fn sprite_sheet_bundle_from_entity_info(
     entity_instance: &EntityInstance,
     tileset: Option<&Handle<Image>>,
     tileset_definition: Option<&TilesetDefinition>,
-    texture_atlases: &mut Assets<TextureAtlas>,
+    texture_atlases: &mut Assets<TextureAtlasLayout>,
     grid: bool,
 ) -> SpriteSheetBundle {
     match (tileset, &entity_instance.tile, tileset_definition) {
         (Some(tileset), Some(tile), Some(tileset_definition)) => SpriteSheetBundle {
-            texture_atlas: if grid {
-                texture_atlases.add(TextureAtlas::from_grid(
-                    tileset.clone(),
+            atlas: if grid {
+                let layout = TextureAtlasLayout::from_grid(
                     Vec2::new(tile.w as f32, tile.h as f32),
                     tileset_definition.c_wid as usize,
                     tileset_definition.c_hei as usize,
                     Some(Vec2::splat(tileset_definition.spacing as f32)),
                     Some(Vec2::splat(tileset_definition.padding as f32)),
-                ))
-            } else {
-                let mut texture_atlas = TextureAtlas::new_empty(
-                    tileset.clone(),
-                    Vec2::new(
-                        tileset_definition.px_wid as f32,
-                        tileset_definition.px_hei as f32,
-                    ),
                 );
-                texture_atlas.add_texture(Rect::new(
+                let texture_atlas: Handle<TextureAtlasLayout> = texture_atlases.add(layout);
+                TextureAtlas {
+                    layout: texture_atlas,
+                    index: (tile.y / (tile.h + tileset_definition.spacing)) as usize
+                        * tileset_definition.c_wid as usize
+                        + (tile.x / (tile.w + tileset_definition.spacing)) as usize,
+                }
+            } else {
+                let mut layout = TextureAtlasLayout::new_empty(Vec2::new(
+                    tileset_definition.px_wid as f32,
+                    tileset_definition.px_hei as f32,
+                ));
+                layout.add_texture(Rect::new(
                     tile.x as f32,
                     tile.y as f32,
                     (tile.x + tile.w) as f32,
                     (tile.y + tile.h) as f32,
                 ));
-                texture_atlases.add(texture_atlas)
-            },
-            sprite: if grid {
-                TextureAtlasSprite {
-                    index: (tile.y / (tile.h + tileset_definition.spacing)) as usize
-                        * tileset_definition.c_wid as usize
-                        + (tile.x / (tile.w + tileset_definition.spacing)) as usize,
-                    ..Default::default()
-                }
-            } else {
-                TextureAtlasSprite {
+                let texture_atlas: Handle<TextureAtlasLayout> = texture_atlases.add(layout);
+                TextureAtlas {
+                    layout: texture_atlas,
                     index: 0,
-                    ..Default::default()
                 }
             },
+            texture: tileset.clone(),
             ..Default::default()
         },
         _ => {


### PR DESCRIPTION
~~Leaving this in draft until https://github.com/StarArawn/bevy_ecs_tilemap/pull/508 merges.~~

Upstream `bevy_ecs_tilemap` PR has merged, but a new release hasn't been cut. PR updated to note that `main` here tracks to `main` for ECS Tilemap which both allow for Bevy 0.13 support and PR should be mergeable.

Most of the changes here are related to the new `TextureAtlasLayout` and the examples in the repo look correct to me still at least.

Fixes #301 