### PR TITLE
Allow custom deserialization of ldtk files

### DIFF
--- a/book/src/tutorials/tile-based-game/spawn-your-ldtk-project-in-bevy.md
+++ b/book/src/tutorials/tile-based-game/spawn-your-ldtk-project-in-bevy.md
@@ -8,7 +8,7 @@ You are welcome to bring your own tile-based LDtk project to this tutorial, but 
 For details about the tutorial in general, including prerequisites, please see the parent page.
 
 ## Set up minimal Bevy App
-In the `main` function of your game, create a Bevy `App` with `DefaultPlugins` and `LdtkPlugin`.
+In the `main` function of your game, create a Bevy `App` with `DefaultPlugins` and `LdtkPlugin::default()`.
 This code snippet also sets bevy's texture filtering to "nearest", which is good for pixelated games.
 ```rust,no_run
 use bevy::prelude::*;
@@ -17,7 +17,7 @@ use bevy_ecs_ldtk::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(ImagePlugin::default_nearest()))
-        .add_plugins(LdtkPlugin)
+        .add_plugins(LdtkPlugin::default())
         .run();
 }
 ```

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -6,7 +6,7 @@ fn main() {
         .add_plugins(
             DefaultPlugins.set(ImagePlugin::default_nearest()), // prevents blurry sprites
         )
-        .add_plugins(LdtkPlugin)
+        .add_plugins(LdtkPlugin::default())
         .add_systems(Startup, setup)
         .insert_resource(LevelSelection::index(0))
         .register_ldtk_entity::<MyBundle>("MyEntityIdentifier")

--- a/examples/collectathon/main.rs
+++ b/examples/collectathon/main.rs
@@ -8,7 +8,7 @@ mod respawn;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(ImagePlugin::default_nearest()))
-        .add_plugins(LdtkPlugin)
+        .add_plugins(LdtkPlugin::default())
         .insert_resource(LevelSelection::iid("34f51d20-8990-11ee-b0d1-cfeb0e9e30f6"))
         .insert_resource(LdtkSettings {
             level_spawn_behavior: LevelSpawnBehavior::UseWorldTranslation {

--- a/examples/field_instances/main.rs
+++ b/examples/field_instances/main.rs
@@ -34,7 +34,7 @@ fn main() {
         .add_plugins(
             DefaultPlugins.set(ImagePlugin::default_nearest()), // prevents blurry sprites
         )
-        .add_plugins(LdtkPlugin)
+        .add_plugins(LdtkPlugin::default())
         .insert_resource(LevelSelection::default())
         .add_systems(Startup, setup)
         .add_systems(Update, mother::resolve_mother_references)

--- a/examples/level_set.rs
+++ b/examples/level_set.rs
@@ -10,7 +10,7 @@ use rand::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugins(LdtkPlugin)
+        .add_plugins(LdtkPlugin::default())
         .add_systems(Startup, setup)
         .add_systems(Update, toggle_levels)
         // No LevelSelection resource!

--- a/examples/platformer/main.rs
+++ b/examples/platformer/main.rs
@@ -13,7 +13,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(ImagePlugin::default_nearest()))
         .add_plugins((
-            LdtkPlugin,
+            LdtkPlugin::default(),
             RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(100.0),
         ))
         .insert_resource(RapierConfiguration {

--- a/examples/tile_based_game.rs
+++ b/examples/tile_based_game.rs
@@ -7,7 +7,7 @@ use std::collections::HashSet;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(ImagePlugin::default_nearest()))
-        .add_plugins(LdtkPlugin)
+        .add_plugins(LdtkPlugin::default())
         .add_systems(Startup, setup)
         .insert_resource(LevelSelection::index(0))
         .register_ldtk_entity::<PlayerBundle>("Player")

--- a/examples/traitless.rs
+++ b/examples/traitless.rs
@@ -7,7 +7,7 @@ use bevy_ecs_ldtk::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(ImagePlugin::default_nearest()))
-        .add_plugins(LdtkPlugin)
+        .add_plugins(LdtkPlugin::default())
         .add_systems(Startup, setup)
         .add_systems(Update, process_my_entity)
         .insert_resource(LevelSelection::index(0))

--- a/src/app/entity_app_ext.rs
+++ b/src/app/entity_app_ext.rs
@@ -44,7 +44,7 @@ pub trait LdtkEntityAppExt {
     ///
     /// fn main() {
     ///     App::empty()
-    ///         .add_plugins(LdtkPlugin)
+    ///         .add_plugins(LdtkPlugin::default())
     ///         .register_ldtk_entity_for_layer::<MyBundle>("MyLayerIdentifier", "my_entity_identifier")
     ///         // add other systems, plugins, resources...
     ///         .run();

--- a/src/app/int_cell_app_ext.rs
+++ b/src/app/int_cell_app_ext.rs
@@ -44,7 +44,7 @@ pub trait LdtkIntCellAppExt {
     ///
     /// fn main() {
     ///     App::empty()
-    ///         .add_plugins(LdtkPlugin)
+    ///         .add_plugins(LdtkPlugin::default())
     ///         .register_ldtk_int_cell_for_layer::<MyBundle>("MyLayerIdentifier", 1)
     ///         // add other systems, plugins, resources...
     ///         .run();

--- a/src/app/ldtk_entity.rs
+++ b/src/app/ldtk_entity.rs
@@ -38,7 +38,7 @@ use std::{collections::HashMap, marker::PhantomData};
 ///
 /// fn main() {
 ///     App::empty()
-///         .add_plugins(LdtkPlugin)
+///         .add_plugins(LdtkPlugin::default())
 ///         .register_ldtk_entity::<MyBundle>("my_entity_identifier")
 ///         // add other systems, plugins, resources...
 ///         .run();

--- a/src/app/ldtk_int_cell.rs
+++ b/src/app/ldtk_int_cell.rs
@@ -34,7 +34,7 @@ use std::{collections::HashMap, marker::PhantomData};
 ///
 /// fn main() {
 ///     App::empty()
-///         .add_plugins(LdtkPlugin)
+///         .add_plugins(LdtkPlugin::default())
 ///         .register_ldtk_int_cell::<MyBundle>(1)
 ///         // add other systems, plugins, resources...
 ///         .run();

--- a/src/assets/ldtk_asset_plugin.rs
+++ b/src/assets/ldtk_asset_plugin.rs
@@ -1,16 +1,21 @@
 #[cfg(feature = "external_levels")]
 use crate::assets::{ldtk_external_level::LdtkExternalLevelLoader, LdtkExternalLevel};
-use crate::assets::{ldtk_project::LdtkProjectLoader, LdtkProject};
+use crate::{
+    assets::{ldtk_project::LdtkProjectLoader, LdtkProject},
+    ldtk::LdtkJson,
+};
 use bevy::prelude::*;
 
+use super::ldtk_project::LdtkProjectLoaderError;
+
 /// Plugin that registers LDtk-related assets.
-#[derive(Copy, Clone, Debug, Default)]
-pub struct LdtkAssetPlugin;
+#[derive(Copy, Clone, Debug)]
+pub struct LdtkAssetPlugin(pub fn(Vec<u8>) -> Result<LdtkJson, LdtkProjectLoaderError>);
 
 impl Plugin for LdtkAssetPlugin {
     fn build(&self, app: &mut App) {
         app.init_asset::<LdtkProject>()
-            .init_asset_loader::<LdtkProjectLoader>();
+            .register_asset_loader(LdtkProjectLoader { de_call: self.0 });
 
         #[cfg(feature = "external_levels")]
         {

--- a/src/assets/ldtk_project.rs
+++ b/src/assets/ldtk_project.rs
@@ -175,8 +175,9 @@ pub enum LdtkProjectLoaderError {
 }
 
 /// AssetLoader for [`LdtkProject`].
-#[derive(Default)]
-pub struct LdtkProjectLoader;
+pub struct LdtkProjectLoader {
+    pub de_call: fn(Vec<u8>) -> Result<LdtkJson, LdtkProjectLoaderError>,
+}
 
 fn load_level_metadata(
     load_context: &mut LoadContext,
@@ -234,7 +235,7 @@ impl AssetLoader for LdtkProjectLoader {
         Box::pin(async move {
             let mut bytes = Vec::new();
             reader.read_to_end(&mut bytes).await?;
-            let data: LdtkJson = serde_json::from_slice(&bytes)?;
+            let data = (self.de_call)(bytes)?;
 
             let mut tileset_map: HashMap<i32, Handle<Image>> = HashMap::new();
             for tileset in &data.defs.tilesets {

--- a/src/assets/mod.rs
+++ b/src/assets/mod.rs
@@ -34,6 +34,7 @@ pub use ldtk_project_data::LdtkProjectData;
 
 mod ldtk_project;
 pub use ldtk_project::LdtkProject;
+pub use ldtk_project::LdtkProjectLoaderError;
 
 mod level_indices;
 pub use level_indices::LevelIndices;


### PR DESCRIPTION
This PR makes it possible to load Ldtk files that you have preprocessed, for example by re-serializing the file using `bincode` and compressing it. 