### PR TITLE
feat: add #[default] attribute to LdtkEntity and LdtkIntCell derive macros

### DIFF
--- a/macros/src/ldtk_int_cell.rs
+++ b/macros/src/ldtk_int_cell.rs
@@ -3,6 +3,7 @@ use quote::quote;
 static LDTK_INT_CELL_ATTRIBUTE_NAME: &str = "ldtk_int_cell";
 static FROM_INT_GRID_CELL_ATTRIBUTE_NAME: &str = "from_int_grid_cell";
 static WITH_ATTRIBUTE_NAME: &str = "with";
+static DEFAULT_ATTRIBUTE_NAME: &str = "default";
 
 pub fn expand_ldtk_int_cell_derive(ast: syn::DeriveInput) -> proc_macro::TokenStream {
     let struct_name = &ast.ident;
@@ -48,6 +49,15 @@ pub fn expand_ldtk_int_cell_derive(ast: syn::DeriveInput) -> proc_macro::TokenSt
             .find(|a| *a.path.get_ident().as_ref().unwrap() == WITH_ATTRIBUTE_NAME);
         if let Some(attribute) = with {
             field_constructions.push(expand_with_attribute(attribute, field_name, field_type));
+            continue;
+        }
+
+        let default = field
+            .attrs
+            .iter()
+            .find(|a| *a.path.get_ident().as_ref().unwrap() == DEFAULT_ATTRIBUTE_NAME);
+        if let Some(attribute) = default {
+            field_constructions.push(expand_default_attribute(attribute, field_name, field_type));
             continue;
         }
     }
@@ -137,5 +147,23 @@ fn expand_with_attribute(
         _ => {
             panic!("#[with...] attribute should take the form #[with(function_name)]")
         }
+    }
+}
+
+fn expand_default_attribute(
+    attribute: &syn::Attribute,
+    field_name: &syn::Ident,
+    _: &syn::Type,
+) -> proc_macro2::TokenStream {
+    match attribute
+        .parse_meta()
+        .expect("Cannot parse #[default] attribute")
+    {
+        syn::Meta::Path(_) => {
+            quote! {
+                #field_name: Default::default(),
+            }
+        }
+        _ => panic!("#[default] attribute should take the form #[default]"),
     }
 }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -12,7 +12,8 @@ mod ldtk_int_cell;
         grid_coords,
         ldtk_entity,
         from_entity_instance,
-        with
+        with,
+        default,
     )
 )]
 pub fn ldtk_entity_derive(input: TokenStream) -> TokenStream {
@@ -21,7 +22,10 @@ pub fn ldtk_entity_derive(input: TokenStream) -> TokenStream {
     ldtk_entity::expand_ldtk_entity_derive(ast)
 }
 
-#[proc_macro_derive(LdtkIntCell, attributes(ldtk_int_cell, from_int_grid_cell, with))]
+#[proc_macro_derive(
+    LdtkIntCell,
+    attributes(ldtk_int_cell, from_int_grid_cell, with, default)
+)]
 pub fn ldtk_int_cell_derive(input: TokenStream) -> TokenStream {
     let ast = syn::parse(input).unwrap();
 

--- a/src/app/ldtk_entity.rs
+++ b/src/app/ldtk_entity.rs
@@ -281,6 +281,37 @@ use std::{collections::HashMap, marker::PhantomData};
 ///     }
 /// }
 /// ```
+///
+/// ### `#[default]`
+///
+/// Indicates that this component or bundle should be initialized using
+/// [Default::default].
+/// This can be useful when implementing `Default` for the whole `LdtkEntity` is
+/// not easily possible, because some of the fields do not implement `Default`.
+///
+/// ```
+/// # use bevy::prelude::*;
+/// # use bevy_ecs_ldtk::prelude::*;
+/// # #[derive(Component, Default)]
+/// # struct Damage;
+/// # #[derive(Component, Default)]
+/// # struct BleedDamage;
+/// #[derive(Bundle, LdtkEntity)]
+/// pub struct Weapon {
+///     #[default]
+///     damage: Damage,
+///     #[sprite_bundle]
+///     sprite: SpriteBundle,
+/// }
+///
+/// #[derive(Bundle, LdtkEntity)]
+/// pub struct Dagger {
+///     #[ldtk_entity]
+///     weapon_bundle: Weapon,
+///     #[default]
+///     bleed_damage: BleedDamage,
+/// }
+/// ```
 pub trait LdtkEntity {
     /// The constructor used by the plugin when spawning entities from an LDtk file.
     /// Has access to resources/assets most commonly used for spawning 2d objects.

--- a/src/app/ldtk_entity.rs
+++ b/src/app/ldtk_entity.rs
@@ -285,31 +285,28 @@ use std::{collections::HashMap, marker::PhantomData};
 /// ### `#[default]`
 ///
 /// Indicates that this component or bundle should be initialized using
-/// [Default::default].
+/// [`Default::default`].
 /// This can be useful when implementing `Default` for the whole `LdtkEntity` is
 /// not easily possible, because some of the fields do not implement `Default`.
 ///
 /// ```
 /// # use bevy::prelude::*;
 /// # use bevy_ecs_ldtk::prelude::*;
+/// # mod other_crate {
+/// #     #[derive(bevy::prelude::Component)]
+/// #     pub struct ForeignComponentWithNoDefault;
+/// # }
+/// # fn custom_constructor(_: &EntityInstance) -> ForeignComponentWithNoDefault { todo!(); }
 /// # #[derive(Component, Default)]
 /// # struct Damage;
-/// # #[derive(Component, Default)]
-/// # struct BleedDamage;
-/// #[derive(Bundle, LdtkEntity)]
-/// pub struct Weapon {
-///     #[default]
-///     damage: Damage,
-///     #[sprite_bundle]
-///     sprite: SpriteBundle,
-/// }
+/// use other_crate::ForeignComponentWithNoDefault;
 ///
 /// #[derive(Bundle, LdtkEntity)]
-/// pub struct Dagger {
-///     #[ldtk_entity]
-///     weapon_bundle: Weapon,
+/// pub struct MyBundle {
 ///     #[default]
-///     bleed_damage: BleedDamage,
+///     damage: Damage,
+///     #[with(custom_constructor)]
+///     foreign: ForeignComponentWithNoDefault,
 /// }
 /// ```
 pub trait LdtkEntity {

--- a/src/app/ldtk_int_cell.rs
+++ b/src/app/ldtk_int_cell.rs
@@ -154,6 +154,35 @@ use std::{collections::HashMap, marker::PhantomData};
 ///     damage: Damage,
 /// }
 /// ```
+///
+/// ### `#[default]`
+///
+/// Indicates that this component or bundle should be initialized using
+/// [Default::default].
+/// This can be useful when implementing `Default` for the whole `IntGridCell` is
+/// not easily possible, because some of the fields do not implement `Default`.
+///
+/// ```
+/// # use bevy::prelude::*;
+/// # use bevy_ecs_ldtk::prelude::*;
+/// # #[derive(Component, Default)]
+/// # struct RigidBody;
+/// # #[derive(Component, Default)]
+/// # struct Damage;
+/// #[derive(Bundle, LdtkIntCell)]
+/// pub struct Wall {
+///     #[default]
+///     rigid_body: RigidBody,
+/// }
+///
+/// #[derive(Bundle, LdtkIntCell)]
+/// pub struct DestructibleWall {
+///     #[ldtk_int_cell]
+///     wall: Wall,
+///     #[default]
+///     damage: Damage,
+/// }
+/// ```
 pub trait LdtkIntCell {
     /// The constructor used by the plugin when spawning additional components on IntGrid tiles.
     /// If you need access to more of the [World](bevy::prelude::World), you can create a system that queries for

--- a/src/app/ldtk_int_cell.rs
+++ b/src/app/ldtk_int_cell.rs
@@ -158,7 +158,7 @@ use std::{collections::HashMap, marker::PhantomData};
 /// ### `#[default]`
 ///
 /// Indicates that this component or bundle should be initialized using
-/// [Default::default].
+/// [`Default::default`].
 /// This can be useful when implementing `Default` for the whole `IntGridCell` is
 /// not easily possible, because some of the fields do not implement `Default`.
 ///

--- a/src/app/ldtk_int_cell.rs
+++ b/src/app/ldtk_int_cell.rs
@@ -165,22 +165,21 @@ use std::{collections::HashMap, marker::PhantomData};
 /// ```
 /// # use bevy::prelude::*;
 /// # use bevy_ecs_ldtk::prelude::*;
-/// # #[derive(Component, Default)]
-/// # struct RigidBody;
+/// # mod other_crate {
+/// #     #[derive(bevy::prelude::Component)]
+/// #     pub struct ForeignComponentWithNoDefault;
+/// # }
+/// # fn custom_constructor(_: IntGridCell) -> ForeignComponentWithNoDefault { todo!(); }
 /// # #[derive(Component, Default)]
 /// # struct Damage;
-/// #[derive(Bundle, LdtkIntCell)]
-/// pub struct Wall {
-///     #[default]
-///     rigid_body: RigidBody,
-/// }
+/// use other_crate::ForeignComponentWithNoDefault;
 ///
 /// #[derive(Bundle, LdtkIntCell)]
-/// pub struct DestructibleWall {
-///     #[ldtk_int_cell]
-///     wall: Wall,
+/// pub struct MyBundle {
 ///     #[default]
 ///     damage: Damage,
+///     #[with(custom_constructor)]
+///     foreign: ForeignComponentWithNoDefault,
 /// }
 /// ```
 pub trait LdtkIntCell {


### PR DESCRIPTION
Add an attribute that initializes fields using individual field Default implementations, allowing to use the derive macros again without requiring the whole struct to implement Default (when some fields should be default-initialized and others use initialization attributes like #[from_entity_instance]).

Fixes #305