### PR TITLE
Remove unused asset server param

### DIFF
--- a/book/src/explanation/game-logic-integration.md
+++ b/book/src/explanation/game-logic-integration.md
@@ -128,7 +128,6 @@ struct PlayerBundle {
 fn process_player(
     mut commands: Commands,
     new_players: Query<Entity, Added<Player>>,
-    assets: Res<AssetServer>,
 )
 {
     for player_entity in new_players.iter() {


### PR DESCRIPTION
This param wasn't being "used" in this example code.