### PR TITLE
build: use a git revision dependency for bevy_ecs_tilemap instead of a git branch patch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = ["macros"]
 
 [dependencies]
 bevy_ecs_ldtk_macros = { version = "0.9.0", optional = true, path = "macros" }
-bevy_ecs_tilemap = { version = "0.12", default-features = false }
+bevy_ecs_tilemap = { git = "https://github.com/StarArawn/bevy_ecs_tilemap", rev = "e4f3cc668110d9a46f6fe407db4f6d4daeabc3d2", default-features = false }
 bevy = { version = "0.13", default-features = false, features = ["bevy_sprite"] }
 derive-getters = "0.3.0"
 serde = { version = "1.0", features = ["derive"] }
@@ -56,6 +56,3 @@ path = "examples/field_instances/main.rs"
 [[example]]
 name = "collectathon"
 path = "examples/collectathon/main.rs"
-
-[patch.crates-io]
-bevy_ecs_tilemap = { git = "https://github.com/StarArawn/bevy_ecs_tilemap/", branch = "main" }

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ $ cargo run --example example-name
 ## Compatibility
 | bevy | bevy_ecs_tilemap | LDtk | bevy_ecs_ldtk |
 | --- | --- | --- | --- |
-| 0.13 | main | 1.5.3 | main |
+| 0.13 | `e4f3cc668110d9a46f6fe407db4f6d4daeabc3d2` | 1.5.3 | `main` |
 | 0.12 | 0.12 | 1.5.3 | 0.9 |
 | 0.11 | 0.11 | 1.3.3 | 0.8 |
 | 0.10 | 0.10 | 1.1 | 0.7 |

--- a/examples/field_instances/level_title.rs
+++ b/examples/field_instances/level_title.rs
@@ -32,7 +32,7 @@ pub fn set_level_title_to_current_level(
                 .get_string_field("title")
                 .expect("level should have non-nullable title string field");
 
-            **current_level_title = title.clone();
+            (*current_level_title).clone_from(title);
         }
     }
 }


### PR DESCRIPTION
Closes #321

Currently, we're using a patch to depend on `bevy_ecs_tilemap`.  This places a burden on the user to use a similar patch in their own `Cargo.toml`. We're also using the `main` branch of `bevy_ecs_tilemap` in this patch. This can lead to issues when updates occur to that branch of the `bevy_ecs_tilemap` repository, as new users and `cargo update`rs will pull in any new changes to that repo, even breaking ones. This is currently affecting our CI.

This PR's changes will ultimately be overwritten soon by an update to bevy 0.14 (#325), but merging this sooner will help set the standard for development of this project inbetween `bevy_ecs_tilemap` releases in the future, and also unblock other PRs whose CI checks are affected (#306).