### PR TITLE
ci: address new clippy lints in 1.80

### DIFF
--- a/examples/field_instances/main.rs
+++ b/examples/field_instances/main.rs
@@ -8,6 +8,7 @@
 //! - health, a non-nullable int.
 //! - equipment_drops, an array of Equipment values, which is a custom enum.
 //! - mother, a nullable entity reference.
+//!
 //! This example accesses all of these and stores them on the enemy entity via components.
 //! With the mother field - it also demonstrates one possible pattern for resolving an LDtk entity
 //! reference to an actual bevy "relational" component.

--- a/src/app/ldtk_entity.rs
+++ b/src/app/ldtk_entity.rs
@@ -69,8 +69,9 @@ use std::{collections::HashMap, marker::PhantomData};
 /// Indicates that a [SpriteBundle] field should be created with an actual material/image.
 /// There are two forms for this attribute:
 /// - `#[sprite_bundle("path/to/asset.png")]` will create the field using the image at the provided
-/// path in the assets folder.
+///   path in the assets folder.
 /// - `#[sprite_bundle]` will create the field using its Editor Visual image in LDtk, if it has one.
+///
 /// Note that if your editor visual is part of a tilemap, you should use `#[sprite_sheet_bundle]` instead.
 /// ```
 /// # use bevy::prelude::*;
@@ -102,14 +103,14 @@ use std::{collections::HashMap, marker::PhantomData};
 /// with an actual material/image.
 /// There are two forms for this attribute:
 /// - `#[sprite_sheet_bundle("path/to/asset.png", tile_width, tile_height, columns, rows, padding,
-/// offset, index)]` will create the field using all of the information provided.
-/// Similar to using [TextureAtlasLayout::from_grid()].
+///   offset, index)]` will create the field using all of the information provided.
+///   Similar to using [TextureAtlasLayout::from_grid()].
 /// - `#[sprite_sheet_bundle]` will create the field using information from the LDtk Editor visual,
-/// if it has one.
+///   if it has one.
 /// - `#[sprite_sheet_bundle(no_grid)]` will create the field using information from the LDtk
-/// Editor visual, if it has one, but without using a grid. Instead a single texture will be used.
-/// This may be useful if the LDtk entity's visual uses a rectangle of tiles from its tileset,
-/// but will prevent using the generated [TextureAtlasLayout] for animation purposes.
+///   Editor visual, if it has one, but without using a grid. Instead a single texture will be used.
+///   This may be useful if the LDtk entity's visual uses a rectangle of tiles from its tileset,
+///   but will prevent using the generated [TextureAtlasLayout] for animation purposes.
 /// ```
 /// # use bevy::prelude::*;
 /// # use bevy_ecs_ldtk::prelude::*;

--- a/src/ldtk/mod.rs
+++ b/src/ldtk/mod.rs
@@ -24,6 +24,7 @@
 //! 10. All urls in docs have been changed to hyperlinks with `<>`
 //! 11. `From<&EntityInstance>` implemented for [`EntityInstance`]
 //! 12. [`LayerInstance::layer_instance_type`] changed from [`String`] to [`Type`].
+#![allow(clippy::doc_lazy_continuation)]
 
 use bevy::{
     prelude::{Color, Component, IVec2, Vec2},


### PR DESCRIPTION
Rust 1.80 has been released, and new clippy lints are now being checked in our CI. This PR addresses these lints to uphold the code quality of this repository and get the clippy CI job passing again.

The new lint that was failing is `doc_lazy_continuation`, so this PR only really affects docs. This lint was simply `#[allow(...)]`'d in the `ldtk` module since most of the code in this module is auto-generated and any manual changes to it need to be repeated whenever it is regenerated.