### PR TITLE
Update syn to 2.0, clean up error handling, add closure support to #[with(..)] in derive.

### DIFF
--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["game-development"]
 [dependencies]
 quote = "1.0"
 proc-macro2 = "1.0"
-syn = { version = "2.0.93", features = ["parsing"] }
+syn = { version = "2.0.92", features = ["parsing"] }
 
 [lib]
 proc-macro = true

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -9,9 +9,9 @@ keywords = ["bevy", "ldtk", "game", "gamedev", "map-editor"]
 categories = ["game-development"]
 
 [dependencies]
-syn = "1.0"
 quote = "1.0"
 proc-macro2 = "1.0"
+syn = { version = "2.0.93", features = ["parsing"] }
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
Bevy uses syn 2.0 as well, so once the derive-getters dependency is updated to a version that uses syn 2.0 as well, users won't need to compile both syn 1.0 and 2.0 libraries.

I also changed a few functions to return errors instead of panicking so users get span information for some errors. (I might do another pass in the future to add error messages to _all_ derive errors)

I also added closure support for the #[with(..)] attribute. Example below:

Previously, you'd have to make a separate function for every field you want custom constructors for. This is messy and reduces readability.
```rust
#[derive(Default, Bundle, LdtkEntity)]
struct PlayerBundle {
    #[sprite_sheet]
    sprite_sheet: Sprite,
    player: Player,
    #[with(player_rigid_body)]
    rigid_body: RigidBody,
    #[with(player_collider)]
    collider: Collider,
    #[with(player_friction)]
    combine: Friction,
    #[with(player_locked)]
    locked: LockedAxes,
}

fn player_locked(_: &EntityInstance) -> LockedAxes {
    LockedAxes::ROTATION_LOCKED
}

fn player_friction(_: &EntityInstance) -> Friction {
    Friction::new(0.).with_combine_rule(CoefficientCombine::Min)
}

fn player_rigid_body(_: &EntityInstance) -> RigidBody {
    RigidBody::Dynamic
}

fn player_collider(_: &EntityInstance) -> Collider {
    Collider::rectangle(16., 16.)
}
```

With closure support, this can be shortened:

```rust
#[derive(Default, Bundle, LdtkEntity)]
struct PlayerBundle {
    #[sprite_sheet]
    sprite_sheet: Sprite,
    player: Player,
    #[with(|_| RigidBody::Dynamic)]
    rigid_body: RigidBody,
    #[with(|_| Collider::rectangle(16., 16.))]
    collider: Collider,
    #[with(|_| Friction::new(0.).with_combine_rule(CoefficientCombine::Min))]
    combine: Friction,
    #[with(|_| LockedAxes::ROTATION_LOCKED)]
    locked: LockedAxes,
}
```