### PR TITLE
docs: document spacing and padding effect on the rendered tilemap #94

### DIFF
--- a/book/src/tutorials/tile-based-game/spawn-your-ldtk-project-in-bevy.md
+++ b/book/src/tutorials/tile-based-game/spawn-your-ldtk-project-in-bevy.md
@@ -52,7 +52,9 @@ fn main() {
 }
 ```
 
-Now, run the game with `$ cargo run --release` to see your first level spawning in Bevy!
+Now, run the game with `$ cargo run --release` to see your first level spawning in Bevy! Is the rendered level different than shown in LDtk? [^1])
+
+[^1]: Due to a difference in the handling of spacing and padding between `bevy_ecs_tilemap` and LDtk spacing is not perfectly supported. This can be resolved by having the value of padding and spacing be equal, for example both 0, or both 1 and so on. Previous versions of `bevy_ecs_tilemap` require the `atlas` feature flag enabled for WASM support and also for tile spacing to work with Tile and AutoTile layers.
 
 ![bevy-setup](images/bevy-setup.png)
 


### PR DESCRIPTION
Adding the behaviour of `bevy_ecs_tilemap` and spacing / padding to the book.

Feel free to change the wording as you will