### PR TITLE
fix: Migrate to 0.16.0-rc.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ members = ["macros"]
 
 [dependencies]
 bevy_ecs_ldtk_macros = { version = "0.11.0", optional = true, path = "macros" }
-bevy_ecs_tilemap = { version = "0.15.0", default-features = false }
-bevy = { version = "0.15", default-features = false, features = [
-    "bevy_sprite",
+bevy_ecs_tilemap = { version = "0.16.0-rc.1", default-features = false }
+bevy = { version = "0.16.0-rc.2", default-features = false, features = [
+  "bevy_sprite",
 ] }
 derive-getters = "0.3.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/ldtk/impl_definitions.rs
+++ b/src/ldtk/impl_definitions.rs
@@ -55,7 +55,7 @@ mod tests {
 
         let image = definitions.create_int_grid_image().unwrap();
 
-        for byte in image.data.iter() {
+        for byte in image.data.unwrap_or_default().iter() {
             assert_eq!(*byte, 255);
         }
     }

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -146,7 +146,7 @@ pub fn apply_level_set(
             let previous_level_maps = children
                 .into_iter()
                 .flat_map(|iterator| iterator.iter())
-                .filter_map(|child_entity| ldtk_level_query.get(*child_entity).ok())
+                .filter_map(|child_entity| ldtk_level_query.get(child_entity).ok())
                 .map(|(level_iid, entity)| (level_iid.clone(), entity))
                 .collect::<HashMap<_, _>>();
 
@@ -224,7 +224,7 @@ pub fn process_ldtk_levels(
         (
             Entity,
             &LevelIid,
-            &Parent,
+            &ChildOf,
             Option<&Respawn>,
             Option<&Children>,
         ),
@@ -356,11 +356,11 @@ pub fn clean_respawn_entities(world: &mut World) {
         for world_children in ldtk_worlds_to_clean.iter() {
             for child in world_children
                 .iter()
-                .filter(|l| other_ldtk_levels.contains(**l) || worldly_entities.contains(**l))
+                .filter(|l| other_ldtk_levels.contains(*l) || worldly_entities.contains(*l))
             {
-                entities_to_despawn_recursively.push(*child);
+                entities_to_despawn_recursively.push(child);
 
-                if let Ok(level_iid) = other_ldtk_levels.get(*child) {
+                if let Ok(level_iid) = other_ldtk_levels.get(child) {
                     level_events.send(LevelEvent::Despawned(level_iid.clone()));
                 }
             }
@@ -378,14 +378,14 @@ pub fn clean_respawn_entities(world: &mut World) {
     }
 
     for entity in entities_to_despawn_descendants {
-        world.entity_mut(entity).despawn_descendants();
+        world.entity_mut(entity).despawn_related::<Children>();
     }
 }
 
 /// Implements the functionality for `Worldly` components.
 pub fn worldly_adoption(
     mut commands: Commands,
-    ancestors: Query<&Parent>,
+    ancestors: Query<&ChildOf>,
     worldly_query: Query<Entity, Added<Worldly>>,
 ) {
     for worldly_entity in worldly_query.iter() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -254,7 +254,9 @@ pub(crate) fn set_all_tiles_with_func(
                 .map(|tile_bundle| commands.spawn(tile_bundle).insert(tilemap_id).id());
             match tile_entity {
                 Some(tile_entity) => storage.set(&tile_pos, tile_entity),
-                None => storage.remove(&tile_pos),
+                None => {
+                    storage.remove(&tile_pos);
+                }
             }
         }
     }


### PR DESCRIPTION
I followed the [0.15 -> 0.16 migration guide](https://bevyengine.org/learn/migration-guides/0-15-to-0-16/) and mechanically applied the changes.

There was one part where `rustc` complained about type mismatch on a `match`. I assume this is a new error/lint where there used to be some implicit to-unit casting. I can remove this if needed, but I think it improves clarity/correctness (and seems to be required to be compiled by my (latest stable) toolchain).

I also used `unwrap_or_default()` on an `Option<Vec<_>>`. I can replace this with an `if let` if you are worried about `clone` performance in that spot.