### PR TITLE
chore: add bevy_ecs_ldtk 0.12 to compatibility chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ $ cargo run --example example-name
 ## Compatibility
 | bevy | bevy_ecs_tilemap | LDtk | bevy_ecs_ldtk |
 | --- | --- | --- | --- |
+| 0.16 | 0.16 | 1.5.3 | 0.12 |
 | 0.15 | 0.15 | 1.5.3 | 0.11 |
 | 0.14 | 0.14 | 1.5.3 | 0.10 |
 | 0.12 | 0.12 | 1.5.3 | 0.9 |


### PR DESCRIPTION
In prepraration for the 0.12 release, we need to document what versions of bevy, bevy_ecs_tilemap, and LDtk are supported in the compatibility chart.
