### PR TITLE
docs: update compatibility chart for bevy_ecs_ldtk 0.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ $ cargo run --example example-name
 ## Compatibility
 | bevy | bevy_ecs_tilemap | LDtk | bevy_ecs_ldtk |
 | --- | --- | --- | --- |
-| 0.17 | 0.17 | 1.5.3 | main |
+| 0.17 | 0.17 | 1.5.3 | 0.13 |
 | 0.16 | 0.16 | 1.5.3 | 0.12 |
 | 0.15 | 0.15 | 1.5.3 | 0.11 |
 | 0.14 | 0.14 | 1.5.3 | 0.10 |


### PR DESCRIPTION
bevy_ecs_ldtk 0.13 will be released shortly, but first the compatibility chart needs to be updated accordingly. This change replaces the current "main" line with 0.13.
