### PR TITLE
feat: set per-tile opacity in tile maker

### DIFF
--- a/src/tile_makers.rs
+++ b/src/tile_makers.rs
@@ -313,7 +313,7 @@ mod tests {
     #[test]
     fn test_tile_pos_to_tile_maker_with_alpha() {
         const GRID_SIZE: i32 = 32;
-        let test_data = vec![0.0, 0.5, 1.0];
+        let test_data = [0.0, 0.5, 1.0];
 
         let grid_tiles = test_data
             .iter()

--- a/src/tile_makers.rs
+++ b/src/tile_makers.rs
@@ -123,6 +123,7 @@ pub(crate) fn tile_pos_to_tile_maker(
                         y: flip_y,
                         ..default()
                     },
+                    color: TileColor(Color::WHITE.with_alpha(tile_instance.a)),
                     ..default()
                 })
             }
@@ -307,6 +308,45 @@ mod tests {
             tile_maker(TilePos { x: 1, y: 1 }).unwrap().texture_index.0,
             4
         );
+    }
+
+    #[test]
+    fn test_tile_pos_to_tile_maker_with_alpha() {
+        const GRID_SIZE: i32 = 32;
+        let test_data = vec![0.0, 0.5, 1.0];
+
+        let grid_tiles = test_data
+            .iter()
+            .cloned()
+            .enumerate()
+            .map(|(i, alpha)| TileInstance {
+                px: IVec2::new(i as i32 * GRID_SIZE, 0),
+                a: alpha,
+                ..Default::default()
+            })
+            .collect::<Vec<_>>();
+
+        let mut tile_maker = tile_pos_to_tile_maker(&grid_tiles, 1, GRID_SIZE);
+
+        test_data
+            .iter()
+            .cloned()
+            .enumerate()
+            .for_each(|(i, alpha)| {
+                let tile = tile_maker(TilePos { x: i as u32, y: 0 }); // TilePos use grid coordinates, so we use i as x
+                if let Some(tile_bundle) = tile {
+                    let expect = Color::WHITE.with_alpha(alpha);
+                    let color = tile_bundle.color.0;
+                    assert!(
+                        expect == color,
+                        "test {i} failed, expect color {:?}, got {:?}",
+                        expect,
+                        color
+                    );
+                } else {
+                    panic!("test {i} failed, no tile found at ({i},0)");
+                }
+            });
     }
 
     #[test]

--- a/src/tile_makers.rs
+++ b/src/tile_makers.rs
@@ -228,7 +228,7 @@ pub(crate) fn tile_pos_to_transparent_tile_maker(
     move |tile_pos: TilePos| -> Option<TileBundle> {
         if alpha < 1. {
             tile_maker(tile_pos).map(|mut tile| {
-                tile.color.0.set_alpha(alpha);
+                tile.color.0.set_alpha(alpha * tile.color.0.alpha());
                 tile
             })
         } else {
@@ -509,5 +509,42 @@ mod tests {
             tile_maker(TilePos { x: 1, y: 1 }).unwrap().color.0,
             css::RED.into()
         );
+    }
+
+    #[test]
+    fn test_tile_pos_to_transparent_tile_maker() {
+        let tile_alpha = [0.0, 0.5, 1.0];
+        let layer_alpha = [0.0, 0.5, 1.0];
+        // let mut expect_alpha_iter = tile_alpha
+        //     .iter()
+        //     .flat_map(|&ta| layer_alpha.iter().map(move |&la| ta * la));
+        let mut expect_alpha_iter = [
+            0.0, 0.0, 0.0, // tile alpha is 0.0
+            0.0, 0.25, 0.5, // tile alpha is 0.5
+            0.0, 0.5, 1.0, // tile alpha is 1.0
+        ]
+        .into_iter();
+
+        tile_alpha.iter().for_each(|&ta| {
+            layer_alpha.iter().for_each(|&la| {
+                let dummy_maker = |_: TilePos| -> Option<TileBundle> {
+                    Some(TileBundle {
+                        color: TileColor(Color::WHITE.with_alpha(ta)),
+                        ..Default::default()
+                    })
+                };
+
+                let mut tile_maker = tile_pos_to_transparent_tile_maker(dummy_maker, la);
+                let tile = tile_maker(TilePos::default()).unwrap();
+                let expect_alpha = expect_alpha_iter.next().unwrap();
+                let actual_alpha = tile.color.0.alpha();
+
+                assert_eq!(
+                    expect_alpha,
+                    actual_alpha,
+                    "tile's alpha is {ta:.01} and layer's alpha is {la:.01}, the expectation is {expect_alpha:.01}, not {actual_alpha:.01}"
+                );
+            });
+        });
     }
 }


### PR DESCRIPTION
Hello, while researching this [ldtk file](https://github.com/deepnight/gamefeel/blob/master/res/levels/gameFeel.ldtk), I noticed that some tiles looked a bit unusual. After a brief investigation, I found that the tile opacity was not being applied. So, in this PR, I attempted to implement this functionality.

<img width="518" height="271" alt="截屏2026-03-01 10 08 37" src="https://github.com/user-attachments/assets/1de3b0f3-7372-45e6-8e8b-53bd87382081" />
