### PR TITLE
fix: map Array<FilePath> field to correct FieldValue variant

### DIFF
--- a/src/ldtk/field_instance.rs
+++ b/src/ldtk/field_instance.rs
@@ -132,7 +132,7 @@ impl<'de> Deserialize<'de> for FieldInstance {
 
                 FieldValue::Colors(helpers.iter().map(|h| h.0).collect())
             }
-            "Array<FilePath>" => FieldValue::Strings(
+            "Array<FilePath>" => FieldValue::FilePaths(
                 Vec::<Option<String>>::deserialize(helper.value).map_err(de::Error::custom)?,
             ),
             "Array<Tile>" => FieldValue::Tiles(


### PR DESCRIPTION
Closes #402

Currently, an `Array<FilePath>` field gets mapped into a `FieldValue::Strings` in this library on deserialization. It should instead be mapped to a `FieldValue::FilePaths`.
