### PR TITLE
Bevy 0.19

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ members = ["macros"]
 
 [dependencies]
 bevy_ecs_ldtk_macros = { version = "0.14.0", optional = true, path = "macros" }
-bevy_ecs_tilemap = { version = "0.18.0", default-features = false }
-bevy = { version = "0.18", default-features = false, features = [
+bevy_ecs_tilemap = { version = "0.19.0", default-features = false }
+bevy = { version = "0.19", default-features = false, features = [
     "bevy_sprite",
 ] }
 derive-getters = "0.5.0"
@@ -28,11 +28,11 @@ paste = "1.0"
 derive_more = "0.99.20"
 
 [dev-dependencies]
-bevy = "0.18"
-avian2d = "0.6"
+bevy = "0.19"
+avian2d = "0.7"
 fake = { version = "4.4", features = ["uuid"] }
 rand = "0.9"
-bevy-inspector-egui = "0.36.0"
+bevy-inspector-egui = "0.37.0"
 
 [features]
 default = ["derive", "render", "internal_levels"]

--- a/src/app/entity_app_ext.rs
+++ b/src/app/entity_app_ext.rs
@@ -108,10 +108,7 @@ impl LdtkEntityAppExt for App {
         entity_identifier: Option<String>,
     ) -> &mut Self {
         let new_entry = Box::new(PhantomLdtkEntity::<B>::new());
-        match self
-            .world_mut()
-            .get_non_send_resource_mut::<LdtkEntityMap>()
-        {
+        match self.world_mut().get_non_send_mut::<LdtkEntityMap>() {
             Some(mut entries) => {
                 entries.insert((layer_identifier, entity_identifier), new_entry);
             }
@@ -119,7 +116,7 @@ impl LdtkEntityAppExt for App {
                 let mut bundle_map = LdtkEntityMap::new();
                 bundle_map.insert((layer_identifier, entity_identifier), new_entry);
                 self.world_mut()
-                    .insert_non_send_resource::<LdtkEntityMap>(bundle_map);
+                    .insert_non_send::<LdtkEntityMap>(bundle_map);
             }
         }
         self
@@ -167,10 +164,7 @@ mod tests {
             .register_default_ldtk_entity_for_layer::<LdtkEntityBundle>("default_entity_for_layer")
             .register_default_ldtk_entity::<LdtkEntityBundle>();
 
-        let ldtk_entity_map = app
-            .world_mut()
-            .get_non_send_resource::<LdtkEntityMap>()
-            .unwrap();
+        let ldtk_entity_map = app.world_mut().get_non_send::<LdtkEntityMap>().unwrap();
 
         assert!(ldtk_entity_map.contains_key(&(
             Some("layer".to_string()),

--- a/src/app/int_cell_app_ext.rs
+++ b/src/app/int_cell_app_ext.rs
@@ -108,10 +108,7 @@ impl LdtkIntCellAppExt for App {
         value: Option<i32>,
     ) -> &mut Self {
         let new_entry = Box::new(PhantomLdtkIntCell::<B>::new());
-        match self
-            .world_mut()
-            .get_non_send_resource_mut::<LdtkIntCellMap>()
-        {
+        match self.world_mut().get_non_send_mut::<LdtkIntCellMap>() {
             Some(mut entries) => {
                 entries.insert((layer_identifier, value), new_entry);
             }
@@ -119,7 +116,7 @@ impl LdtkIntCellAppExt for App {
                 let mut bundle_map = LdtkIntCellMap::new();
                 bundle_map.insert((layer_identifier, value), new_entry);
                 self.world_mut()
-                    .insert_non_send_resource::<LdtkIntCellMap>(bundle_map);
+                    .insert_non_send::<LdtkIntCellMap>(bundle_map);
             }
         }
         self
@@ -159,10 +156,7 @@ mod tests {
             )
             .register_default_ldtk_int_cell::<LdtkIntCellBundle>();
 
-        let ldtk_int_cell_map = app
-            .world_mut()
-            .get_non_send_resource::<LdtkIntCellMap>()
-            .unwrap();
+        let ldtk_int_cell_map = app.world_mut().get_non_send::<LdtkIntCellMap>().unwrap();
 
         assert!(ldtk_int_cell_map.contains_key(&(Some("layer".to_string()), Some(1))));
 

--- a/src/assets/ldtk_project.rs
+++ b/src/assets/ldtk_project.rs
@@ -26,7 +26,7 @@ fn ldtk_path_to_asset_path<'b>(
     ldtk_path: &AssetPath<'b>,
     rel_path: &str,
 ) -> Result<AssetPath<'b>, ParseAssetPathError> {
-    ldtk_path.resolve_embed(rel_path)
+    ldtk_path.resolve_embed_str(rel_path)
 }
 
 /// Main asset for loading LDtk project data.

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -44,8 +44,8 @@ impl Plugin for LdtkPlugin {
                 ProcessLdtkApi,
                 (ProcessApiSet::PreClean, ProcessApiSet::Clean).chain(),
             )
-            .init_non_send_resource::<app::LdtkEntityMap>()
-            .init_non_send_resource::<app::LdtkIntCellMap>()
+            .init_non_send::<app::LdtkEntityMap>()
+            .init_non_send::<app::LdtkIntCellMap>()
             .init_resource::<resources::LdtkSettings>()
             .add_message::<resources::LevelEvent>()
             .add_systems(

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -340,7 +340,7 @@ pub fn clean_respawn_entities(world: &mut World) {
             other_ldtk_levels,
             worldly_entities,
             mut level_events,
-        ) = system_state.get_mut(world);
+        ) = system_state.get_mut(world).unwrap();
 
         for world_children in ldtk_worlds_to_clean.iter() {
             for child in world_children


### PR DESCRIPTION
- [x] Waiting for https://github.com/StarArawn/bevy_ecs_tilemap/pull/634
- [x] Depends on https://github.com/Trouv/bevy_ecs_ldtk/pull/405, as there is not even a git version of bevy_rapier with support for 0.19, and there may not be for some time due to the dependency incompatibilities noted in https://github.com/dimforge/bevy_rapier/pull/694
- [x] Decide how to deal with inconsistent sprite ordering (caused by the avian migration, not Bevy 0.19)

~With the platformer example I'm seeing inconsistent sprite ordering between the player and the chests after the update to 0.19. See https://github.com/Trouv/bevy_ecs_ldtk/pull/404#issuecomment-4805200384.~

I've also given this a superficial test with a simple personal project. I didn't notice any obvious issues here.