### PR TITLE
Port platformer example from bevy_rapier to avian

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ derive_more = "0.99.20"
 
 [dev-dependencies]
 bevy = "0.18"
-bevy_rapier2d = { git = "https://github.com/buncys/bevy_rapier.git", rev = "8c25504d336c8c9fc7a3c765422d56845cc36075" }
+avian2d = "0.6"
 fake = { version = "4.4", features = ["uuid"] }
 rand = "0.9"
 bevy-inspector-egui = "0.36.0"

--- a/examples/platformer/climbing.rs
+++ b/examples/platformer/climbing.rs
@@ -1,6 +1,6 @@
+use avian2d::prelude::*;
 use bevy::{platform::collections::HashSet, prelude::*};
 use bevy_ecs_ldtk::prelude::*;
-use bevy_rapier2d::prelude::*;
 
 use crate::colliders::SensorBundle;
 
@@ -23,35 +23,43 @@ pub struct LadderBundle {
 pub fn detect_climb_range(
     mut climbers: Query<&mut Climber>,
     climbables: Query<Entity, With<Climbable>>,
-    mut collisions: MessageReader<CollisionEvent>,
+    mut collision_starts: MessageReader<CollisionStart>,
+    mut collision_ends: MessageReader<CollisionEnd>,
 ) {
-    for collision in collisions.read() {
-        match collision {
-            CollisionEvent::Started(collider_a, collider_b, _) => {
-                if let (Ok(mut climber), Ok(climbable)) =
-                    (climbers.get_mut(*collider_a), climbables.get(*collider_b))
-                {
-                    climber.intersecting_climbables.insert(climbable);
-                }
-                if let (Ok(mut climber), Ok(climbable)) =
-                    (climbers.get_mut(*collider_b), climbables.get(*collider_a))
-                {
-                    climber.intersecting_climbables.insert(climbable);
-                };
-            }
-            CollisionEvent::Stopped(collider_a, collider_b, _) => {
-                if let (Ok(mut climber), Ok(climbable)) =
-                    (climbers.get_mut(*collider_a), climbables.get(*collider_b))
-                {
-                    climber.intersecting_climbables.remove(&climbable);
-                }
+    for CollisionStart {
+        collider1,
+        collider2,
+        ..
+    } in collision_starts.read()
+    {
+        if let (Ok(mut climber), Ok(climbable)) =
+            (climbers.get_mut(*collider1), climbables.get(*collider2))
+        {
+            climber.intersecting_climbables.insert(climbable);
+        }
+        if let (Ok(mut climber), Ok(climbable)) =
+            (climbers.get_mut(*collider2), climbables.get(*collider1))
+        {
+            climber.intersecting_climbables.insert(climbable);
+        };
+    }
 
-                if let (Ok(mut climber), Ok(climbable)) =
-                    (climbers.get_mut(*collider_b), climbables.get(*collider_a))
-                {
-                    climber.intersecting_climbables.remove(&climbable);
-                }
-            }
+    for CollisionEnd {
+        collider1,
+        collider2,
+        ..
+    } in collision_ends.read()
+    {
+        if let (Ok(mut climber), Ok(climbable)) =
+            (climbers.get_mut(*collider1), climbables.get(*collider2))
+        {
+            climber.intersecting_climbables.remove(&climbable);
+        }
+
+        if let (Ok(mut climber), Ok(climbable)) =
+            (climbers.get_mut(*collider2), climbables.get(*collider1))
+        {
+            climber.intersecting_climbables.remove(&climbable);
         }
     }
 }

--- a/examples/platformer/colliders.rs
+++ b/examples/platformer/colliders.rs
@@ -1,17 +1,17 @@
 use bevy::prelude::*;
 use bevy_ecs_ldtk::prelude::*;
 
-use bevy_rapier2d::prelude::*;
+use avian2d::prelude::*;
 
 #[derive(Clone, Default, Bundle, LdtkIntCell)]
 pub struct ColliderBundle {
     pub collider: Collider,
     pub rigid_body: RigidBody,
-    pub velocity: Velocity,
+    pub velocity: LinearVelocity,
     pub rotation_constraints: LockedAxes,
     pub gravity_scale: GravityScale,
     pub friction: Friction,
-    pub density: ColliderMassProperties,
+    pub density: ColliderDensity,
 }
 
 impl From<&EntityInstance> for ColliderBundle {
@@ -20,28 +20,29 @@ impl From<&EntityInstance> for ColliderBundle {
 
         match entity_instance.identifier.as_ref() {
             "Player" => ColliderBundle {
-                collider: Collider::cuboid(6., 14.),
+                collider: Collider::rectangle(12., 28.),
                 rigid_body: RigidBody::Dynamic,
                 friction: Friction {
-                    coefficient: 0.0,
-                    combine_rule: CoefficientCombineRule::Min,
+                    dynamic_coefficient: 0.0,
+                    static_coefficient: 0.0,
+                    combine_rule: CoefficientCombine::Min,
                 },
                 rotation_constraints,
                 ..Default::default()
             },
             "Mob" => ColliderBundle {
-                collider: Collider::cuboid(5., 5.),
-                rigid_body: RigidBody::KinematicVelocityBased,
+                collider: Collider::rectangle(10., 10.),
+                rigid_body: RigidBody::Kinematic,
                 rotation_constraints,
                 ..Default::default()
             },
             "Chest" => ColliderBundle {
-                collider: Collider::cuboid(8., 8.),
+                collider: Collider::rectangle(16., 16.),
                 rigid_body: RigidBody::Dynamic,
                 rotation_constraints,
                 gravity_scale: GravityScale(1.0),
                 friction: Friction::new(0.5),
-                density: ColliderMassProperties::Density(15.0),
+                density: ColliderDensity(15.0),
                 ..Default::default()
             },
             _ => ColliderBundle::default(),
@@ -53,7 +54,7 @@ impl From<&EntityInstance> for ColliderBundle {
 pub struct SensorBundle {
     pub collider: Collider,
     pub sensor: Sensor,
-    pub active_events: ActiveEvents,
+    pub collision_events: CollisionEventsEnabled,
     pub rotation_constraints: LockedAxes,
 }
 
@@ -64,10 +65,10 @@ impl From<IntGridCell> for SensorBundle {
         // ladder
         if int_grid_cell.value == 2 {
             SensorBundle {
-                collider: Collider::cuboid(8., 8.),
+                collider: Collider::rectangle(16., 16.),
                 sensor: Sensor,
                 rotation_constraints,
-                active_events: ActiveEvents::COLLISION_EVENTS,
+                collision_events: CollisionEventsEnabled,
             }
         } else {
             SensorBundle::default()

--- a/examples/platformer/enemy.rs
+++ b/examples/platformer/enemy.rs
@@ -1,6 +1,6 @@
+use avian2d::prelude::*;
 use bevy::prelude::*;
 use bevy_ecs_ldtk::{prelude::*, utils::ldtk_pixel_coords_to_translation_pivoted};
-use bevy_rapier2d::dynamics::Velocity;
 
 use crate::colliders::ColliderBundle;
 
@@ -71,7 +71,7 @@ impl LdtkEntity for Patrol {
     }
 }
 
-pub fn patrol(mut query: Query<(&mut Transform, &mut Velocity, &mut Patrol)>) {
+pub fn patrol(mut query: Query<(&mut Transform, &mut LinearVelocity, &mut Patrol)>) {
     for (mut transform, mut velocity, mut patrol) in &mut query {
         if patrol.points.len() <= 1 {
             continue;
@@ -80,7 +80,7 @@ pub fn patrol(mut query: Query<(&mut Transform, &mut Velocity, &mut Patrol)>) {
         let mut new_velocity =
             (patrol.points[patrol.index] - transform.translation.truncate()).normalize() * 75.;
 
-        if new_velocity.dot(velocity.linvel) < 0. {
+        if new_velocity.dot(**velocity) < 0. {
             if patrol.index == 0 {
                 patrol.forward = true;
             } else if patrol.index == patrol.points.len() - 1 {
@@ -100,7 +100,7 @@ pub fn patrol(mut query: Query<(&mut Transform, &mut Velocity, &mut Patrol)>) {
                 (patrol.points[patrol.index] - transform.translation.truncate()).normalize() * 75.;
         }
 
-        velocity.linvel = new_velocity;
+        **velocity = new_velocity;
     }
 }
 

--- a/examples/platformer/game_flow.rs
+++ b/examples/platformer/game_flow.rs
@@ -1,16 +1,19 @@
 use crate::player::Player;
+use avian2d::prelude::*;
 use bevy::prelude::*;
 use bevy_ecs_ldtk::prelude::*;
-use bevy_rapier2d::prelude::*;
 
 pub fn setup(
     mut commands: Commands,
     asset_server: Res<AssetServer>,
-    mut rapier_config: Query<&mut RapierConfiguration>,
-) -> Result {
+    mut physics_time: ResMut<Time<Physics>>,
+) {
     commands.spawn(Camera2d);
 
-    rapier_config.single_mut()?.gravity = Vec2::new(0.0, -2000.0);
+    // The wall colliders spawn one frame later than the player and other
+    // entities. Only start the physics simulation after that (in
+    // [start_physics]), so they don't end up in the ground.
+    physics_time.pause();
 
     let ldtk_handle = asset_server
         .load("Typical_2D_platformer_example.ldtk")
@@ -19,7 +22,17 @@ pub fn setup(
         ldtk_handle,
         ..Default::default()
     });
-    Ok(())
+}
+
+fn start_physics(
+    mut level_events: MessageReader<LevelEvent>,
+    mut physics_time: ResMut<Time<Physics>>,
+) {
+    for event in level_events.read() {
+        if let LevelEvent::Transformed(_) = event {
+            physics_time.unpause();
+        }
+    }
 }
 
 pub fn update_level_selection(
@@ -77,6 +90,7 @@ pub struct GameFlowPlugin;
 impl Plugin for GameFlowPlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(Startup, setup)
+            .add_systems(Update, start_physics)
             .add_systems(Update, update_level_selection)
             .add_systems(Update, restart_level);
     }

--- a/examples/platformer/ground_detection.rs
+++ b/examples/platformer/ground_detection.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use bevy::prelude::*;
 
-use bevy_rapier2d::prelude::*;
+use avian2d::prelude::*;
 
 #[derive(Component)]
 pub struct GroundSensor {
@@ -20,20 +20,20 @@ pub fn spawn_ground_sensor(
     detect_ground_for: Query<(Entity, &Collider), Added<GroundDetection>>,
 ) {
     for (entity, shape) in &detect_ground_for {
-        if let Some(cuboid) = shape.as_cuboid() {
+        if let Some(cuboid) = shape.shape().as_cuboid() {
             let Vec2 {
                 x: half_extents_x,
                 y: half_extents_y,
-            } = cuboid.half_extents();
+            } = cuboid.half_extents;
 
-            let detector_shape = Collider::cuboid(half_extents_x / 2.0, 2.);
+            let detector_shape = Collider::rectangle(half_extents_x, 4.);
 
             let sensor_translation = Vec3::new(0., -half_extents_y, 0.);
 
             commands.entity(entity).with_children(|builder| {
                 builder
                     .spawn_empty()
-                    .insert(ActiveEvents::COLLISION_EVENTS)
+                    .insert(CollisionEventsEnabled)
                     .insert(detector_shape)
                     .insert(Sensor)
                     .insert(Transform::from_translation(sensor_translation))
@@ -49,32 +49,40 @@ pub fn spawn_ground_sensor(
 
 pub fn ground_detection(
     mut ground_sensors: Query<&mut GroundSensor>,
-    mut collisions: MessageReader<CollisionEvent>,
+    mut collision_starts: MessageReader<CollisionStart>,
+    mut collision_ends: MessageReader<CollisionEnd>,
     collidables: Query<Entity, (With<Collider>, Without<Sensor>)>,
 ) {
-    for collision_event in collisions.read() {
-        match collision_event {
-            CollisionEvent::Started(e1, e2, _) => {
-                if collidables.contains(*e1) {
-                    if let Ok(mut sensor) = ground_sensors.get_mut(*e2) {
-                        sensor.intersecting_ground_entities.insert(*e1);
-                    }
-                } else if collidables.contains(*e2) {
-                    if let Ok(mut sensor) = ground_sensors.get_mut(*e1) {
-                        sensor.intersecting_ground_entities.insert(*e2);
-                    }
-                }
+    for CollisionStart {
+        collider1,
+        collider2,
+        ..
+    } in collision_starts.read()
+    {
+        if collidables.contains(*collider1) {
+            if let Ok(mut sensor) = ground_sensors.get_mut(*collider2) {
+                sensor.intersecting_ground_entities.insert(*collider1);
             }
-            CollisionEvent::Stopped(e1, e2, _) => {
-                if collidables.contains(*e1) {
-                    if let Ok(mut sensor) = ground_sensors.get_mut(*e2) {
-                        sensor.intersecting_ground_entities.remove(e1);
-                    }
-                } else if collidables.contains(*e2) {
-                    if let Ok(mut sensor) = ground_sensors.get_mut(*e1) {
-                        sensor.intersecting_ground_entities.remove(e2);
-                    }
-                }
+        } else if collidables.contains(*collider2) {
+            if let Ok(mut sensor) = ground_sensors.get_mut(*collider1) {
+                sensor.intersecting_ground_entities.insert(*collider2);
+            }
+        }
+    }
+
+    for CollisionEnd {
+        collider1,
+        collider2,
+        ..
+    } in collision_ends.read()
+    {
+        if collidables.contains(*collider1) {
+            if let Ok(mut sensor) = ground_sensors.get_mut(*collider2) {
+                sensor.intersecting_ground_entities.remove(collider1);
+            }
+        } else if collidables.contains(*collider2) {
+            if let Ok(mut sensor) = ground_sensors.get_mut(*collider1) {
+                sensor.intersecting_ground_entities.remove(collider2);
             }
         }
     }

--- a/examples/platformer/main.rs
+++ b/examples/platformer/main.rs
@@ -4,7 +4,7 @@
 use bevy::prelude::*;
 use bevy_ecs_ldtk::prelude::*;
 
-use bevy_rapier2d::prelude::*;
+use avian2d::prelude::*;
 
 mod camera;
 mod climbing;
@@ -22,10 +22,8 @@ mod walls;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(ImagePlugin::default_nearest()))
-        .add_plugins((
-            LdtkPlugin,
-            RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(100.0),
-        ))
+        .add_plugins((LdtkPlugin, PhysicsPlugins::default()))
+        .insert_resource(Gravity(Vec2::new(0.0, -2000.0)))
         .insert_resource(LevelSelection::Uid(0))
         .insert_resource(LdtkSettings {
             level_spawn_behavior: LevelSpawnBehavior::UseWorldTranslation {

--- a/examples/platformer/player.rs
+++ b/examples/platformer/player.rs
@@ -1,6 +1,6 @@
+use avian2d::prelude::*;
 use bevy::prelude::*;
 use bevy_ecs_ldtk::prelude::*;
-use bevy_rapier2d::dynamics::Velocity;
 
 use crate::{climbing::Climber, inventory::Inventory};
 use crate::{colliders::ColliderBundle, ground_detection::GroundDetection};
@@ -31,13 +31,13 @@ pub struct PlayerBundle {
 
 pub fn player_movement(
     input: Res<ButtonInput<KeyCode>>,
-    mut query: Query<(&mut Velocity, &mut Climber, &GroundDetection), With<Player>>,
+    mut query: Query<(&mut LinearVelocity, &mut Climber, &GroundDetection), With<Player>>,
 ) {
     for (mut velocity, mut climber, ground_detection) in &mut query {
         let right = if input.pressed(KeyCode::KeyD) { 1. } else { 0. };
         let left = if input.pressed(KeyCode::KeyA) { 1. } else { 0. };
 
-        velocity.linvel.x = (right - left) * 200.;
+        velocity.x = (right - left) * 200.;
 
         if climber.intersecting_climbables.is_empty() {
             climber.climbing = false;
@@ -49,11 +49,11 @@ pub fn player_movement(
             let up = if input.pressed(KeyCode::KeyW) { 1. } else { 0. };
             let down = if input.pressed(KeyCode::KeyS) { 1. } else { 0. };
 
-            velocity.linvel.y = (up - down) * 200.;
+            velocity.y = (up - down) * 200.;
         }
 
         if input.just_pressed(KeyCode::Space) && (ground_detection.on_ground || climber.climbing) {
-            velocity.linvel.y = 500.;
+            velocity.y = 500.;
             climber.climbing = false;
         }
     }

--- a/examples/platformer/walls.rs
+++ b/examples/platformer/walls.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use bevy::{platform::collections::HashMap, prelude::*};
 use bevy_ecs_ldtk::prelude::*;
 
-use bevy_rapier2d::prelude::*;
+use avian2d::prelude::*;
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Default, Component)]
 pub struct Wall;
@@ -157,15 +157,13 @@ pub fn spawn_wall_collision(
                     for wall_rect in wall_rects {
                         level
                             .spawn_empty()
-                            .insert(Collider::cuboid(
+                            .insert(Collider::rectangle(
                                 (wall_rect.right as f32 - wall_rect.left as f32 + 1.)
-                                    * grid_size as f32
-                                    / 2.,
+                                    * grid_size as f32,
                                 (wall_rect.top as f32 - wall_rect.bottom as f32 + 1.)
-                                    * grid_size as f32
-                                    / 2.,
+                                    * grid_size as f32,
                             ))
-                            .insert(RigidBody::Fixed)
+                            .insert(RigidBody::Static)
                             .insert(Friction::new(1.0))
                             .insert(Transform::from_xyz(
                                 (wall_rect.left + wall_rect.right + 1) as f32 * grid_size as f32


### PR DESCRIPTION
Being a native bevy plugin, avian provides support for new bevy versions quickly and is not plagued by dependency incompatibilities (like requiring rapier and bevy to use the same version of glam).

Prepares for the Bevy 0.19 update in https://github.com/Trouv/bevy_ecs_ldtk/pull/404. As noted in https://github.com/dimforge/bevy_rapier/pull/694, rapier skipped the glam version used by Bevy 0.19, so making them work together is cumbersome (and not even using a git version of bevy_rapier would work). Using avian instead of bevy_rapier allows us to update bevy without waiting for a solution and avoids similar problems in the future.

As far as I can tell, nothing about the game feels significantly different with this change applied. One ugly hack was necessary to make it work correctly, marked by a comment.